### PR TITLE
Add official website (static landing page)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,44 @@
+name: Deploy website
+
+# Publishes the static landing page in `website/` to GitHub Pages.
+# Runs on every push to main that touches the site, and can be triggered manually.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - ".github/workflows/deploy-website.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,89 @@
+# Parley website
+
+The official landing page for Parley. It's a **zero-build static site** — plain
+HTML, CSS, and a little vanilla JS — so it has no dependencies and deploys
+anywhere that can serve files.
+
+```
+website/
+  index.html      # the page
+  styles.css      # all styling (brand gradient, dark theme, responsive)
+  script.js       # nav, scroll-reveal, copy button, media auto-loading
+  assets/         # logo + your showcase GIFs/screenshots go here
+```
+
+## Run it locally
+
+Any static server works:
+
+```bash
+cd website
+python3 -m http.server 4178
+# open http://localhost:4178
+```
+
+## Adding showcase GIFs / screenshots
+
+The page has marked media slots (the hero window and the three "Showcase"
+rows). **You don't need to edit any HTML** — just drop a file into `assets/`
+with the matching name and it appears automatically:
+
+| Slot                        | Drop a file named                                  |
+| --------------------------- | -------------------------------------------------- |
+| Hero window                 | `assets/showcase-hero.{gif,png,jpg,webp,mp4}`      |
+| "Every word, attributed"    | `assets/showcase-transcript.{gif,png,jpg,webp,mp4}`|
+| "Ask mid-conversation"      | `assets/showcase-qa.{gif,png,jpg,webp,mp4}`        |
+| "Insight that keeps up"     | `assets/showcase-eval.{gif,png,jpg,webp,mp4}`      |
+
+Notes:
+- `.mp4` is detected too and mounts as a muted, looping, autoplaying clip — often
+  smaller and crisper than a GIF for screen recordings.
+- Slots are `16:9` (hero) / `16:10` (rows); media is `object-fit: cover`. Record
+  at roughly those ratios for the cleanest fit.
+- Until you add a file, each slot shows a styled placeholder telling you the
+  exact filename to use.
+
+To add a brand-new slot, copy a `data-media="..."` figure block in `index.html`
+and pick a new name.
+
+## Deploying to GitHub Pages
+
+A workflow at [`.github/workflows/deploy-website.yml`](../.github/workflows/deploy-website.yml)
+publishes this folder automatically.
+
+1. In the repo: **Settings → Pages → Build and deployment → Source: GitHub Actions**.
+2. Push to `main` (any change under `website/`) — the workflow builds and deploys.
+   You can also run it manually from the **Actions** tab (`Deploy website`).
+3. The default URL will be `https://pathorsai.github.io/parley/`.
+
+## Custom domain with Cloudflare
+
+To serve the site at your own domain (e.g. `parley.pathors.com`) using GitHub
+Pages + Cloudflare DNS:
+
+1. **Tell GitHub the domain.** Create `website/CNAME` containing just the
+   hostname, e.g.:
+   ```
+   parley.pathors.com
+   ```
+   (Or set it under Settings → Pages → Custom domain, which creates the same
+   file. Keeping it in `website/` means the Actions deploy preserves it.)
+
+2. **Add the DNS record in Cloudflare** (DNS → Records):
+   - **Subdomain** (recommended, e.g. `parley`): add a `CNAME` record
+     `parley` → `pathorsai.github.io`.
+   - **Apex/root** (`pathors.com`): add `CNAME` `@` → `pathorsai.github.io`
+     (Cloudflare flattens this automatically), or use GitHub's four A records:
+     `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`.
+
+3. **Proxy + SSL.** You can leave the record **Proxied** (orange cloud). Set
+   Cloudflare **SSL/TLS → Overview → Full** (not Flexible — Flexible causes
+   redirect loops with Pages). Then in GitHub **Settings → Pages**, wait for the
+   domain check to pass and tick **Enforce HTTPS**.
+
+4. Give DNS a few minutes to propagate, then load your domain.
+
+> Tip: if you use a subdomain and proxy through Cloudflare, GitHub's HTTPS
+> certificate provisioning can take up to ~24h the first time. If "Enforce
+> HTTPS" is greyed out, set the Cloudflare record to **DNS only** (grey cloud)
+> until GitHub issues the cert, then flip it back to Proxied.

--- a/website/assets/logo.svg
+++ b/website/assets/logo.svg
@@ -1,0 +1,14 @@
+<svg width="32" height="32" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="mark" x1="320" y1="240" x2="760" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5eead4"/>
+      <stop offset="0.55" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#818cf8"/>
+    </linearGradient>
+  </defs>
+  <g stroke="url(#mark)" stroke-width="74" stroke-linecap="round" fill="none">
+    <path d="M360 300 V724"/>
+    <path d="M360 300 H560 A150 150 0 0 1 560 600 H360"/>
+  </g>
+  <circle cx="648" cy="724" r="40" fill="url(#mark)"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parley — Your realtime meeting copilot for interviews & negotiations</title>
+    <meta
+      name="description"
+      content="Parley is a native macOS meeting copilot. It listens to both sides of the conversation, transcribes live with speaker diarization, and runs AI evaluations and a live Q&A sidebar — so you see what matters in the moment."
+    />
+    <meta property="og:title" content="Parley — Realtime meeting copilot" />
+    <meta
+      property="og:description"
+      content="Live transcription, AI evaluations, and a Q&A sidebar for interviews and negotiations. Native macOS. Open source."
+    />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300..700&family=Geist+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Ambient background -->
+    <div class="bg-aura" aria-hidden="true">
+      <div class="aura aura--1"></div>
+      <div class="aura aura--2"></div>
+      <div class="aura aura--3"></div>
+      <div class="grid-overlay"></div>
+    </div>
+
+    <!-- Nav -->
+    <header class="nav" id="nav">
+      <a class="nav__brand" href="#top" aria-label="Parley home">
+        <img src="assets/logo.svg" alt="" width="28" height="28" />
+        <span>Parley</span>
+      </a>
+      <nav class="nav__links" aria-label="Primary">
+        <a href="#features">Features</a>
+        <a href="#how">How it works</a>
+        <a href="#showcase">Showcase</a>
+        <a href="#stack">Tech</a>
+      </nav>
+      <div class="nav__actions">
+        <a class="btn btn--ghost" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5Z"/></svg>
+          <span>GitHub</span>
+        </a>
+        <a class="btn btn--primary" href="#download">
+          <span>Get Parley</span>
+        </a>
+      </div>
+      <button class="nav__burger" id="burger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span>
+      </button>
+    </header>
+
+    <main id="top">
+      <!-- Hero -->
+      <section class="hero">
+        <div class="hero__inner reveal">
+          <a class="pill" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">
+            <span class="pill__dot"></span>
+            Open source · Native macOS
+            <span class="pill__arrow">→</span>
+          </a>
+          <h1 class="hero__title">
+            Hear <span class="grad">both sides</span>.<br />
+            Know what matters <span class="grad">in the moment</span>.
+          </h1>
+          <p class="hero__sub">
+            Parley is a realtime meeting copilot for interviews and negotiations. It listens to you and
+            the other party, transcribes live with speaker diarization, and runs AI evaluations and a
+            live Q&amp;A sidebar — so you stay focused on the conversation, not your notes.
+          </p>
+          <div class="hero__cta">
+            <a class="btn btn--primary btn--lg" href="#download">Get Parley for macOS</a>
+            <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">Star on GitHub</a>
+          </div>
+          <ul class="hero__meta">
+            <li><span class="dot dot--me"></span> Tags every line <strong>me</strong> / <strong>them</strong></li>
+            <li><span class="dot dot--live"></span> Low-latency streaming</li>
+            <li><span class="dot dot--ai"></span> Claude &amp; OpenRouter</li>
+          </ul>
+        </div>
+
+        <!-- Hero showcase: drop a hero GIF/screenshot at assets/showcase-hero.* -->
+        <figure class="window reveal" data-media="showcase-hero">
+          <div class="window__bar">
+            <span class="traffic"><i></i><i></i><i></i></span>
+            <span class="window__title">Parley — Meeting in progress</span>
+          </div>
+          <div class="media-slot media-slot--hero">
+            <div class="media-slot__hint">
+              <svg viewBox="0 0 24 24" width="34" height="34" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 5v14l11-7L8 5Z" stroke-linejoin="round"/></svg>
+              <p><strong>Add your hero showcase</strong></p>
+              <code>website/assets/showcase-hero.png</code>
+              <span>(or .gif / .mp4 — see website/README.md)</span>
+            </div>
+          </div>
+        </figure>
+      </section>
+
+      <!-- Logos / positioning strip -->
+      <section class="strip reveal">
+        <p>Built for the conversations that count</p>
+        <ul>
+          <li>Job interviews</li>
+          <li>Salary negotiations</li>
+          <li>Sales calls</li>
+          <li>Deal-making</li>
+          <li>Diligence calls</li>
+        </ul>
+      </section>
+
+      <!-- Features -->
+      <section class="section" id="features">
+        <div class="section__head reveal">
+          <span class="eyebrow">Features</span>
+          <h2>Everything you need, on a single live canvas</h2>
+          <p>No tab-switching, no recording-then-reviewing. Parley surfaces insight while the conversation is still happening.</p>
+        </div>
+
+        <div class="grid">
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 3v18M5 8v8M19 8v8M9 5v14M15 5v14" stroke-linecap="round"/></svg>
+            </div>
+            <h3>Dual-source capture</h3>
+            <p>Captures your microphone and system audio at the same time, so every line is tagged as <em>me</em> or <em>them</em>.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 12h3l2 5 4-13 2 8h5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <h3>Realtime transcription</h3>
+            <p>Soniox streaming transcription with low latency, speaker diarization, and editable speaker names.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 3a9 9 0 1 0 9 9M21 3l-9 9" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="2.5"/></svg>
+            </div>
+            <h3>Switchable AI provider</h3>
+            <p>Run analysis through Anthropic Claude or OpenRouter — pick whichever you prefer in Settings.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M21 12a8 8 0 0 1-8 8H5l-2 2V8a8 8 0 0 1 8-8h2a8 8 0 0 1 8 8Z" stroke-linejoin="round"/><path d="M11 9h.01M11 12v3" stroke-linecap="round"/></svg>
+            </div>
+            <h3>Live Q&amp;A sidebar</h3>
+            <p>Ask anything about the ongoing conversation and get streamed answers grounded in the live transcript.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="3" width="18" height="18" rx="4"/><path d="M8 12h8M8 8h8M8 16h5" stroke-linecap="round"/></svg>
+            </div>
+            <h3>Configurable evaluations</h3>
+            <p>Preset and custom evaluation cards surface insights as the conversation unfolds — automatic or manual rerun.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="3" width="18" height="18" rx="4"/><path d="m8 12 3 3 5-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <h3>TODO with AI auto-check</h3>
+            <p>Track what you want to cover; items check off automatically as the AI detects they've been addressed.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" /></svg>
+            </div>
+            <h3>Traditional Chinese</h3>
+            <p>On-the-fly conversion of transcribed text to Traditional Chinese, right in the transcript.</p>
+          </article>
+
+          <article class="card reveal">
+            <div class="card__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="4" width="18" height="16" rx="3"/><path d="M3 9h18" /><circle cx="6.5" cy="6.5" r=".6" fill="currentColor"/></svg>
+            </div>
+            <h3>Native, focused chrome</h3>
+            <p>A clean custom titlebar and native-feeling window — designed to sit quietly beside your call.</p>
+          </article>
+        </div>
+      </section>
+
+      <!-- How it works -->
+      <section class="section section--alt" id="how">
+        <div class="section__head reveal">
+          <span class="eyebrow">How it works</span>
+          <h2>From audio to insight in three steps</h2>
+        </div>
+        <ol class="steps">
+          <li class="step reveal">
+            <span class="step__n">01</span>
+            <h3>Capture both sides</h3>
+            <p>Parley taps your system audio via Core Audio and your mic via cpal — no virtual cables, no setup.</p>
+          </li>
+          <li class="step reveal">
+            <span class="step__n">02</span>
+            <h3>Transcribe live</h3>
+            <p>Two Soniox sessions stream transcription with diarization, labeling each line by speaker.</p>
+          </li>
+          <li class="step reveal">
+            <span class="step__n">03</span>
+            <h3>Evaluate &amp; answer</h3>
+            <p>AI evaluations and the Q&amp;A sidebar run continuously, surfacing what's missing and what matters.</p>
+          </li>
+        </ol>
+      </section>
+
+      <!-- Showcase: alternating media slots -->
+      <section class="section" id="showcase">
+        <div class="section__head reveal">
+          <span class="eyebrow">Showcase</span>
+          <h2>See it in motion</h2>
+          <p>Drop a short GIF or screenshot into each slot to bring these moments to life.</p>
+        </div>
+
+        <div class="feature-rows">
+          <div class="feature-row reveal">
+            <div class="feature-row__copy">
+              <span class="eyebrow eyebrow--sm">Live transcript</span>
+              <h3>Every word, attributed</h3>
+              <p>Watch the conversation stream in with <em>me</em> / <em>them</em> tags and editable speaker names. Convert to Traditional Chinese inline whenever you need it.</p>
+              <ul class="checklist">
+                <li>Low-latency streaming</li>
+                <li>Speaker diarization</li>
+                <li>Editable names</li>
+              </ul>
+            </div>
+            <figure class="media-slot media-slot--wide" data-media="showcase-transcript">
+              <div class="media-slot__hint">
+                <p><strong>showcase-transcript</strong></p>
+                <code>website/assets/showcase-transcript.gif</code>
+              </div>
+            </figure>
+          </div>
+
+          <div class="feature-row feature-row--rev reveal">
+            <div class="feature-row__copy">
+              <span class="eyebrow eyebrow--sm">Q&amp;A sidebar</span>
+              <h3>Ask mid-conversation</h3>
+              <p>Type a question and get a streamed answer grounded in everything said so far — without breaking eye contact.</p>
+              <ul class="checklist">
+                <li>Grounded in live transcript</li>
+                <li>Streamed responses</li>
+                <li>Claude or OpenRouter</li>
+              </ul>
+            </div>
+            <figure class="media-slot media-slot--wide" data-media="showcase-qa">
+              <div class="media-slot__hint">
+                <p><strong>showcase-qa</strong></p>
+                <code>website/assets/showcase-qa.gif</code>
+              </div>
+            </figure>
+          </div>
+
+          <div class="feature-row reveal">
+            <div class="feature-row__copy">
+              <span class="eyebrow eyebrow--sm">Evaluations &amp; TODOs</span>
+              <h3>Insight that keeps up</h3>
+              <p>Evaluation cards rerun as the conversation evolves, and your checklist ticks itself off as topics get covered.</p>
+              <ul class="checklist">
+                <li>Preset &amp; custom cards</li>
+                <li>Auto or manual rerun</li>
+                <li>AI auto-check TODOs</li>
+              </ul>
+            </div>
+            <figure class="media-slot media-slot--wide" data-media="showcase-eval">
+              <div class="media-slot__hint">
+                <p><strong>showcase-eval</strong></p>
+                <code>website/assets/showcase-eval.gif</code>
+              </div>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <!-- Tech stack -->
+      <section class="section section--alt" id="stack">
+        <div class="section__head reveal">
+          <span class="eyebrow">Under the hood</span>
+          <h2>Built on a fast, native foundation</h2>
+          <p>A Rust + Tauri shell with a modern React frontend — small, quick, and genuinely native on macOS.</p>
+        </div>
+        <div class="stack-grid">
+          <div class="stack-card reveal"><span class="stack-card__k">Shell</span><span class="stack-card__v">Tauri v2 · Rust · React 19 · Vite · TS · Tailwind v4</span></div>
+          <div class="stack-card reveal"><span class="stack-card__k">Transcription</span><span class="stack-card__v">Soniox realtime websocket (mic + system audio)</span></div>
+          <div class="stack-card reveal"><span class="stack-card__k">Audio (macOS)</span><span class="stack-card__v">Core Audio process tap · cpal · AudioSource trait</span></div>
+          <div class="stack-card reveal"><span class="stack-card__k">AI</span><span class="stack-card__v">Vercel AI SDK · Anthropic Claude / OpenRouter</span></div>
+          <div class="stack-card reveal"><span class="stack-card__k">State</span><span class="stack-card__v">Zustand</span></div>
+          <div class="stack-card reveal"><span class="stack-card__k">License</span><span class="stack-card__v">Apache 2.0 · © Pathors AI</span></div>
+        </div>
+      </section>
+
+      <!-- Download / CTA -->
+      <section class="section cta-section" id="download">
+        <div class="cta reveal">
+          <div class="cta__glow" aria-hidden="true"></div>
+          <span class="eyebrow">Get started</span>
+          <h2>Run Parley in two commands</h2>
+          <p>Clone the repo, add your API keys in Settings, and you're listening. macOS only for now — the audio layer sits behind a trait, so other platforms are possible.</p>
+          <div class="codeblock">
+            <button class="copy" data-copy="bun install&#10;bun run tauri dev" aria-label="Copy commands">Copy</button>
+            <pre><code><span class="c-cmt"># from the repo root</span>
+bun install
+bun run tauri dev</code></pre>
+          </div>
+          <div class="cta__actions">
+            <a class="btn btn--primary btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">View on GitHub</a>
+            <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley#setup--run" target="_blank" rel="noopener">Read the setup guide</a>
+          </div>
+          <p class="cta__note">Requires a Soniox key and an Anthropic or OpenRouter key — entered in-app, no env setup needed.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer__top">
+        <a class="nav__brand" href="#top">
+          <img src="assets/logo.svg" alt="" width="26" height="26" />
+          <span>Parley</span>
+        </a>
+        <nav class="footer__links" aria-label="Footer">
+          <a href="#features">Features</a>
+          <a href="#how">How it works</a>
+          <a href="#stack">Tech</a>
+          <a href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://github.com/pathorsAI/parley/blob/main/LICENSE" target="_blank" rel="noopener">License</a>
+        </nav>
+      </div>
+      <div class="footer__bottom">
+        <p>© 2026 Pathors AI · Apache 2.0</p>
+        <p>Built with <a href="https://claude.com/claude-code" target="_blank" rel="noopener">Claude Code</a></p>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,118 @@
+// Parley website — light progressive enhancement, no dependencies.
+
+// Sticky nav state on scroll
+const nav = document.getElementById("nav");
+const onScroll = () => nav.classList.toggle("is-scrolled", window.scrollY > 8);
+onScroll();
+window.addEventListener("scroll", onScroll, { passive: true });
+
+// Mobile menu
+const burger = document.getElementById("burger");
+burger?.addEventListener("click", () => {
+  const open = nav.classList.toggle("is-open");
+  burger.setAttribute("aria-expanded", String(open));
+});
+nav.querySelectorAll(".nav__links a").forEach((a) =>
+  a.addEventListener("click", () => {
+    nav.classList.remove("is-open");
+    burger?.setAttribute("aria-expanded", "false");
+  })
+);
+
+// Scroll reveal
+const reveals = document.querySelectorAll(".reveal");
+if ("IntersectionObserver" in window) {
+  const io = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add("is-in");
+          io.unobserve(e.target);
+        }
+      });
+    },
+    { threshold: 0.12, rootMargin: "0px 0px -8% 0px" }
+  );
+  reveals.forEach((el) => io.observe(el));
+} else {
+  reveals.forEach((el) => el.classList.add("is-in"));
+}
+
+// Copy-to-clipboard for the install snippet
+document.querySelectorAll(".copy").forEach((btn) => {
+  btn.addEventListener("click", async () => {
+    const text = (btn.dataset.copy || "").replace(/&#10;/g, "\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      const original = btn.textContent;
+      btn.textContent = "Copied";
+      btn.classList.add("is-done");
+      setTimeout(() => {
+        btn.textContent = original;
+        btn.classList.remove("is-done");
+      }, 1600);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  });
+});
+
+/**
+ * Auto-swap a media slot if a matching asset exists.
+ * Drop a file at website/assets/<name>.{gif,png,jpg,webp,mp4} and it appears
+ * automatically — no markup edits needed. Falls back to the placeholder hint.
+ */
+function hydrateMedia() {
+  const slots = document.querySelectorAll("[data-media]");
+  const exts = ["gif", "webp", "png", "jpg", "jpeg", "mp4"];
+  slots.forEach((slot) => {
+    const name = slot.dataset.media;
+    // The hero slot lives inside .window; the figure itself may be the slot.
+    const target = slot.classList.contains("media-slot")
+      ? slot
+      : slot.querySelector(".media-slot");
+    if (!target) return;
+    tryNext(target, name, exts, 0);
+  });
+}
+
+function tryNext(target, name, exts, i) {
+  if (i >= exts.length) return; // keep the placeholder
+  const ext = exts[i];
+  const url = `assets/${name}.${ext}`;
+  if (ext === "mp4") {
+    fetch(url, { method: "HEAD" })
+      .then((r) => {
+        if (r.ok) mountVideo(target, url);
+        else tryNext(target, name, exts, i + 1);
+      })
+      .catch(() => tryNext(target, name, exts, i + 1));
+    return;
+  }
+  const img = new Image();
+  img.onload = () => mountImage(target, url, name);
+  img.onerror = () => tryNext(target, name, exts, i + 1);
+  img.src = url;
+}
+
+function mountImage(target, url, name) {
+  const img = document.createElement("img");
+  img.src = url;
+  img.alt = `Parley — ${name.replace(/showcase-?/, "").replace(/-/g, " ")}`.trim();
+  img.loading = "lazy";
+  target.replaceChildren(img);
+  target.style.border = "0";
+}
+
+function mountVideo(target, url) {
+  const v = document.createElement("video");
+  v.src = url;
+  v.autoplay = true;
+  v.loop = true;
+  v.muted = true;
+  v.playsInline = true;
+  target.replaceChildren(v);
+  target.style.border = "0";
+}
+
+hydrateMedia();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,506 @@
+/* ============================================================
+   Parley — website styles
+   Brand gradient: #5eead4 (teal) → #38bdf8 (sky) → #818cf8 (indigo)
+   ============================================================ */
+
+:root {
+  --bg: #0a0b0e;
+  --bg-2: #0f1117;
+  --panel: rgba(255, 255, 255, 0.025);
+  --panel-2: rgba(255, 255, 255, 0.04);
+  --line: rgba(255, 255, 255, 0.08);
+  --line-2: rgba(255, 255, 255, 0.14);
+  --text: #e7e9ee;
+  --muted: #9aa3b2;
+  --muted-2: #6b7382;
+
+  --teal: #5eead4;
+  --sky: #38bdf8;
+  --indigo: #818cf8;
+  --grad: linear-gradient(105deg, #5eead4 0%, #38bdf8 52%, #818cf8 100%);
+  --grad-soft: linear-gradient(105deg, rgba(94, 234, 212, 0.16), rgba(56, 189, 248, 0.16), rgba(129, 140, 248, 0.16));
+
+  --radius: 16px;
+  --radius-sm: 10px;
+  --maxw: 1160px;
+  --font: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; scroll-padding-top: 90px; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+
+::selection { background: rgba(56, 189, 248, 0.3); }
+
+/* ---------- Ambient background ---------- */
+.bg-aura {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 90% at 50% -10%, #12151d 0%, var(--bg) 55%),
+    var(--bg);
+}
+.aura {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.5;
+  will-change: transform;
+}
+.aura--1 { width: 540px; height: 540px; top: -160px; left: -80px; background: radial-gradient(circle, rgba(94, 234, 212, 0.45), transparent 70%); animation: float1 22s ease-in-out infinite; }
+.aura--2 { width: 620px; height: 620px; top: 10%; right: -180px; background: radial-gradient(circle, rgba(129, 140, 248, 0.42), transparent 70%); animation: float2 26s ease-in-out infinite; }
+.aura--3 { width: 520px; height: 520px; top: 60%; left: 30%; background: radial-gradient(circle, rgba(56, 189, 248, 0.32), transparent 70%); animation: float1 30s ease-in-out infinite reverse; }
+.grid-overlay {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(110% 80% at 50% 0%, #000 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(110% 80% at 50% 0%, #000 30%, transparent 80%);
+}
+@keyframes float1 { 0%,100% { transform: translate(0,0); } 50% { transform: translate(40px, 50px); } }
+@keyframes float2 { 0%,100% { transform: translate(0,0); } 50% { transform: translate(-50px, 30px); } }
+
+/* ---------- Buttons ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.btn--lg { padding: 14px 26px; font-size: 15px; }
+.btn--primary {
+  background: var(--grad);
+  color: #07131a;
+  font-weight: 600;
+  box-shadow: 0 6px 24px -8px rgba(56, 189, 248, 0.55);
+}
+.btn--primary:hover { transform: translateY(-2px); box-shadow: 0 12px 34px -8px rgba(56, 189, 248, 0.7); }
+.btn--ghost {
+  background: var(--panel-2);
+  border-color: var(--line);
+  color: var(--text);
+  backdrop-filter: blur(8px);
+}
+.btn--ghost:hover { border-color: var(--line-2); background: rgba(255, 255, 255, 0.07); transform: translateY(-2px); }
+
+/* ---------- Nav ---------- */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px clamp(18px, 5vw, 48px);
+  transition: background 0.25s ease, border-color 0.25s ease, padding 0.25s ease;
+  border-bottom: 1px solid transparent;
+}
+.nav.is-scrolled {
+  background: rgba(10, 11, 14, 0.72);
+  backdrop-filter: blur(14px);
+  border-bottom-color: var(--line);
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+.nav__brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 600; font-size: 17px; letter-spacing: -0.01em; }
+.nav__links { display: flex; gap: 28px; }
+.nav__links a { color: var(--muted); font-size: 14px; transition: color 0.15s ease; }
+.nav__links a:hover { color: var(--text); }
+.nav__actions { display: flex; align-items: center; gap: 10px; }
+.nav__burger { display: none; background: none; border: 0; flex-direction: column; gap: 5px; cursor: pointer; padding: 8px; }
+.nav__burger span { width: 22px; height: 2px; background: var(--text); border-radius: 2px; transition: transform 0.25s ease, opacity 0.25s ease; }
+
+/* ---------- Hero ---------- */
+.hero {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: clamp(120px, 16vh, 180px) clamp(18px, 5vw, 48px) 40px;
+  text-align: center;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 14px 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  font-size: 13px;
+  color: var(--muted);
+  backdrop-filter: blur(8px);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+.pill:hover { border-color: var(--line-2); transform: translateY(-1px); }
+.pill__dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); box-shadow: 0 0 0 4px rgba(94, 234, 212, 0.18); }
+.pill__arrow { color: var(--sky); transition: transform 0.2s ease; }
+.pill:hover .pill__arrow { transform: translateX(3px); }
+
+.hero__title {
+  font-size: clamp(36px, 6.4vw, 68px);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  font-weight: 600;
+  margin: 26px auto 0;
+  max-width: 14ch;
+}
+.grad {
+  background: var(--grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.hero__sub {
+  max-width: 60ch;
+  margin: 22px auto 0;
+  color: var(--muted);
+  font-size: clamp(15px, 1.6vw, 18px);
+}
+.hero__cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-top: 32px; }
+.hero__meta {
+  display: flex; gap: 26px; justify-content: center; flex-wrap: wrap;
+  list-style: none; padding: 0; margin: 34px 0 0;
+  font-size: 13.5px; color: var(--muted);
+}
+.hero__meta li { display: inline-flex; align-items: center; gap: 8px; }
+.hero__meta strong { color: var(--text); font-weight: 600; }
+.dot { width: 8px; height: 8px; border-radius: 50%; }
+.dot--me { background: var(--teal); }
+.dot--live { background: var(--sky); box-shadow: 0 0 0 0 rgba(56,189,248,0.6); animation: pulse 2s infinite; }
+.dot--ai { background: var(--indigo); }
+@keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(56,189,248,0.55);} 70% { box-shadow: 0 0 0 7px rgba(56,189,248,0);} 100% { box-shadow: 0 0 0 0 rgba(56,189,248,0);} }
+
+/* ---------- Window mock ---------- */
+.window {
+  max-width: 940px;
+  margin: 56px auto 0;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.015));
+  box-shadow: 0 40px 120px -40px rgba(56, 189, 248, 0.35), 0 10px 40px -20px rgba(0,0,0,0.8);
+  overflow: hidden;
+  backdrop-filter: blur(6px);
+}
+.window__bar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255,255,255,0.02);
+}
+.traffic { display: inline-flex; gap: 7px; }
+.traffic i { width: 11px; height: 11px; border-radius: 50%; background: #3a3f4b; }
+.traffic i:nth-child(1){ background:#ff5f57; } .traffic i:nth-child(2){ background:#febc2e; } .traffic i:nth-child(3){ background:#28c840; }
+.window__title { font-size: 12.5px; color: var(--muted-2); font-family: var(--mono); }
+
+/* ---------- Media slots (GIF / image placeholders) ---------- */
+.media-slot {
+  position: relative;
+  display: grid;
+  place-items: center;
+  background:
+    var(--grad-soft),
+    repeating-linear-gradient(45deg, rgba(255,255,255,0.015) 0 12px, transparent 12px 24px);
+  border: 1px dashed var(--line-2);
+  margin: 0;
+  overflow: hidden;
+}
+.media-slot--hero { aspect-ratio: 16 / 9; border: 0; border-radius: 0; }
+.media-slot--wide { aspect-ratio: 16 / 10; border-radius: var(--radius); }
+.media-slot img, .media-slot video { width: 100%; height: 100%; object-fit: cover; display: block; }
+.media-slot__hint {
+  text-align: center;
+  color: var(--muted);
+  padding: 24px;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+}
+.media-slot__hint svg { color: var(--sky); opacity: 0.8; margin-bottom: 4px; }
+.media-slot__hint strong { color: var(--text); font-size: 15px; font-weight: 600; }
+.media-slot__hint code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--sky);
+  background: rgba(56,189,248,0.1);
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+.media-slot__hint span { font-size: 12px; color: var(--muted-2); }
+
+/* ---------- Positioning strip ---------- */
+.strip {
+  max-width: var(--maxw);
+  margin: 70px auto 0;
+  padding: 0 clamp(18px, 5vw, 48px);
+  text-align: center;
+}
+.strip p { color: var(--muted-2); font-size: 13px; text-transform: uppercase; letter-spacing: 0.14em; margin: 0 0 18px; }
+.strip ul {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-wrap: wrap; gap: 12px 14px; justify-content: center;
+}
+.strip li {
+  padding: 8px 16px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+/* ---------- Sections ---------- */
+.section {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: clamp(80px, 12vh, 130px) clamp(18px, 5vw, 48px);
+}
+.section--alt { max-width: none; background: linear-gradient(180deg, transparent, rgba(255,255,255,0.018), transparent); }
+.section--alt > * { max-width: var(--maxw); margin-left: auto; margin-right: auto; }
+.section__head { text-align: center; max-width: 64ch; margin: 0 auto 56px; }
+.section__head h2 { font-size: clamp(28px, 4vw, 42px); letter-spacing: -0.025em; font-weight: 600; margin: 14px 0 0; line-height: 1.12; }
+.section__head p { color: var(--muted); margin: 16px auto 0; font-size: 16px; }
+.eyebrow {
+  display: inline-block;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.eyebrow--sm { letter-spacing: 0.1em; }
+
+/* ---------- Feature grid ---------- */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.card {
+  padding: 26px 24px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+.card:hover { transform: translateY(-4px); border-color: var(--line-2); background: var(--panel-2); }
+.card__icon {
+  width: 46px; height: 46px;
+  display: grid; place-items: center;
+  border-radius: 12px;
+  background: var(--grad-soft);
+  border: 1px solid var(--line);
+  margin-bottom: 18px;
+}
+.card__icon svg { width: 24px; height: 24px; color: var(--sky); }
+.card h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -0.01em; }
+.card p { margin: 0; color: var(--muted); font-size: 14.5px; }
+.card em { color: var(--teal); font-style: normal; font-weight: 500; }
+
+/* ---------- Steps ---------- */
+.steps {
+  list-style: none; padding: 0; margin: 0;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px;
+  counter-reset: step;
+}
+.step {
+  position: relative;
+  padding: 28px 24px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.step__n {
+  font-family: var(--mono);
+  font-size: 14px;
+  background: var(--grad);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  font-weight: 600;
+}
+.step h3 { margin: 14px 0 8px; font-size: 19px; }
+.step p { margin: 0; color: var(--muted); font-size: 14.5px; }
+
+/* ---------- Feature rows (showcase) ---------- */
+.feature-rows { display: grid; gap: 64px; }
+.feature-row {
+  display: grid;
+  grid-template-columns: 1fr 1.15fr;
+  gap: clamp(30px, 5vw, 70px);
+  align-items: center;
+}
+.feature-row--rev .feature-row__copy { order: 2; }
+.feature-row--rev .media-slot { order: 1; }
+.feature-row__copy h3 { font-size: clamp(24px, 3vw, 32px); letter-spacing: -0.02em; margin: 12px 0 14px; line-height: 1.15; }
+.feature-row__copy > p { color: var(--muted); font-size: 16px; margin: 0 0 20px; }
+.feature-row__copy em { color: var(--teal); font-style: normal; }
+.checklist { list-style: none; padding: 0; margin: 0; display: grid; gap: 10px; }
+.checklist li { position: relative; padding-left: 28px; color: var(--text); font-size: 15px; }
+.checklist li::before {
+  content: "";
+  position: absolute; left: 0; top: 4px;
+  width: 17px; height: 17px;
+  border-radius: 50%;
+  background: var(--grad-soft);
+  border: 1px solid rgba(56,189,248,0.4);
+}
+.checklist li::after {
+  content: "";
+  position: absolute; left: 5px; top: 8px;
+  width: 6px; height: 3px;
+  border-left: 1.6px solid var(--teal);
+  border-bottom: 1.6px solid var(--teal);
+  transform: rotate(-45deg);
+}
+
+/* ---------- Stack ---------- */
+.stack-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.stack-card {
+  padding: 22px 22px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  display: grid;
+  gap: 6px;
+  transition: border-color 0.2s ease;
+}
+.stack-card:hover { border-color: var(--line-2); }
+.stack-card__k { font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted-2); }
+.stack-card__v { font-size: 15px; color: var(--text); }
+
+/* ---------- CTA ---------- */
+.cta-section { padding-bottom: clamp(90px, 14vh, 150px); }
+.cta {
+  position: relative;
+  text-align: center;
+  padding: clamp(48px, 7vw, 80px) clamp(24px, 5vw, 64px);
+  border-radius: 28px;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012));
+  overflow: hidden;
+}
+.cta__glow {
+  position: absolute; inset: auto 0 -50% 0; height: 360px;
+  background: radial-gradient(60% 100% at 50% 100%, rgba(56,189,248,0.3), transparent 70%);
+  pointer-events: none;
+}
+.cta h2 { font-size: clamp(28px, 4vw, 44px); letter-spacing: -0.025em; margin: 12px 0 0; }
+.cta > p { color: var(--muted); max-width: 60ch; margin: 16px auto 0; font-size: 16px; }
+.codeblock {
+  position: relative;
+  max-width: 460px;
+  margin: 30px auto 0;
+  text-align: left;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(0,0,0,0.4);
+  overflow: hidden;
+}
+.codeblock pre { margin: 0; padding: 20px 22px; overflow-x: auto; }
+.codeblock code { font-family: var(--mono); font-size: 14px; color: #cbd5e1; line-height: 1.8; }
+.c-cmt { color: var(--muted-2); }
+.copy {
+  position: absolute; top: 10px; right: 10px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-family: var(--font);
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.copy:hover { color: var(--text); border-color: var(--line-2); }
+.copy.is-done { color: var(--teal); border-color: rgba(94,234,212,0.4); }
+.cta__actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-top: 30px; }
+.cta__note { color: var(--muted-2); font-size: 13px; margin-top: 22px; }
+
+/* ---------- Footer ---------- */
+.footer {
+  border-top: 1px solid var(--line);
+  background: rgba(10,11,14,0.5);
+  padding: 44px clamp(18px, 5vw, 48px) 36px;
+}
+.footer__top {
+  max-width: var(--maxw); margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap;
+}
+.footer__links { display: flex; gap: 24px; flex-wrap: wrap; }
+.footer__links a { color: var(--muted); font-size: 14px; transition: color 0.15s ease; }
+.footer__links a:hover { color: var(--text); }
+.footer__bottom {
+  max-width: var(--maxw); margin: 24px auto 0;
+  padding-top: 22px; border-top: 1px solid var(--line);
+  display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+  color: var(--muted-2); font-size: 13px;
+}
+.footer__bottom a { color: var(--muted); }
+.footer__bottom a:hover { color: var(--sky); }
+
+/* ---------- Scroll reveal ---------- */
+.reveal { opacity: 0; transform: translateY(22px); transition: opacity 0.6s ease, transform 0.6s ease; }
+.reveal.is-in { opacity: 1; transform: none; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .grid, .steps, .stack-grid { grid-template-columns: repeat(2, 1fr); }
+  .nav__links { display: none; }
+  .nav__burger { display: flex; }
+  .nav__actions .btn--ghost { display: none; }
+  .feature-row { grid-template-columns: 1fr; }
+  .feature-row--rev .feature-row__copy { order: 0; }
+  .feature-row--rev .media-slot { order: 0; }
+
+  /* Mobile menu */
+  .nav.is-open { background: rgba(10,11,14,0.95); backdrop-filter: blur(14px); }
+  .nav.is-open .nav__links {
+    display: flex; flex-direction: column; gap: 4px;
+    position: absolute; top: 100%; left: 0; right: 0;
+    padding: 12px clamp(18px, 5vw, 48px) 22px;
+    background: rgba(10, 11, 14, 0.98);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--line);
+    box-shadow: 0 24px 40px -20px rgba(0, 0, 0, 0.8);
+  }
+  .nav.is-open .nav__links a { padding: 10px 0; font-size: 16px; }
+  .nav.is-open .nav__burger span:nth-child(1) { transform: translateY(3.5px) rotate(45deg); }
+  .nav.is-open .nav__burger span:nth-child(2) { transform: translateY(-3.5px) rotate(-45deg); }
+}
+@media (max-width: 560px) {
+  .grid, .steps, .stack-grid { grid-template-columns: 1fr; }
+  .hero__meta { gap: 14px 20px; }
+  .footer__top, .footer__bottom { flex-direction: column; align-items: flex-start; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
+  .reveal { opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## What

A modern, zero-build static landing page for Parley, living in `website/`.

Plain HTML/CSS/vanilla JS — no dependencies, no build step, never touches the Tauri app build.

### Design
- Dark theme matching Parley's brand: the teal→sky→indigo gradient (`#5eead4 → #38bdf8 → #818cf8`), Geist font, and the "P" monogram.
- Sections: hero, features grid (all 8 features), how-it-works, alternating showcase rows, tech stack, and a two-command install CTA.
- Ambient glow + grid background, scroll-reveal animations, copy-to-clipboard, fully responsive (mobile menu included).

### Showcase media slots
Marked slots for your GIFs/screenshots. Drop a file into `website/assets/` named `showcase-hero`, `showcase-transcript`, `showcase-qa`, or `showcase-eval` (`.gif/.png/.jpg/.webp/.mp4`) and it auto-loads — **no markup edits needed**. Until then, each slot shows a styled placeholder telling you the exact filename.

### Deploy
- `.github/workflows/deploy-website.yml` publishes `website/` to GitHub Pages on push to `main`.
- `website/README.md` documents local dev, the media slots, and the **Cloudflare custom-domain** path (DNS records, SSL Full, Enforce HTTPS).

## Verify
Previewed across desktop + mobile during development (hero, features, showcase rows, tech, CTA, mobile nav). No console errors except expected 404s from the media auto-probe before assets are added.

## Follow-ups for the maintainer
1. Settings → Pages → Source: **GitHub Actions** (one-time).
2. Add showcase media to `website/assets/`.
3. (Optional) Add `website/CNAME` + Cloudflare DNS for a custom domain — see `website/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)