### PR TITLE
[fix] i18n built-in eval/TODO templates so they follow the UI language

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,4 @@
-# SonarQube Cloud analysis configuration (Automatic Analysis).
+# SonarQube Cloud Automatic Analysis configuration.
 #
 # Copy-paste detection is disabled for declarative data files where structural
 # repetition is inherent and not a maintainability concern:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+# SonarQube Cloud analysis configuration (Automatic Analysis).
+#
+# Copy-paste detection is disabled for declarative data files where structural
+# repetition is inherent and not a maintainability concern:
+#   - i18n message dictionaries mirror the same key set across every locale, so
+#     the zh-TW and en blocks are necessarily parallel.
+#   - the eval / TODO preset registries are lists of same-shaped literal entries.
+sonar.cpd.exclusions=src/i18n/**,src/lib/evaluations/presets.ts,src/lib/todoTemplates.ts

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,15 +1,8 @@
 import { useStore } from "../lib/store";
-import type { AppLanguage } from "../lib/types";
-import { DICTS, LANGUAGE_OPTIONS, zhTW, type TranslationKey } from "./messages";
+import { LANGUAGE_OPTIONS, translate, type TranslationKey } from "./messages";
 
-export { LANGUAGE_OPTIONS };
+export { LANGUAGE_OPTIONS, translate };
 export type { TranslationKey };
-
-export function translate(language: AppLanguage, key: TranslationKey, vars?: Record<string, string | number>): string {
-  const template = DICTS[language]?.[key] ?? zhTW[key] ?? key;
-  if (!vars) return template;
-  return template.replace(/\{(\w+)\}/g, (_, name: string) => String(vars[name] ?? ""));
-}
 
 export function useI18n() {
   const language = useStore((s) => s.settings.language);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -223,6 +223,83 @@ export const zhTW = {
   "speaker.speaker": "說話者 {number}",
   "speaker.remote": "遠端 {number}",
   "speaker.them": "對方",
+
+  // Built-in template content — eval definitions, eval template sets, and TODO
+  // templates. These are resolved into settings at seed/reconcile time (and when
+  // the language changes) so built-in templates follow the UI language.
+  "tpl.evalSet.tpl-general.name": "通用 / General",
+  "tpl.evalSet.tpl-interview.name": "面試 / Job interview",
+  "tpl.evalSet.tpl-salary.name": "薪資談判 / Salary negotiation",
+  "tpl.evalSet.tpl-sales.name": "銷售電話 / Sales call",
+  "tpl.evalSet.tpl-negotiation.name": "商務談判 / Deal-making",
+  "tpl.evalSet.tpl-diligence.name": "盡職調查 / Diligence call",
+
+  "tpl.eval.deception.name": "詐術 / 不一致偵測",
+  "tpl.eval.deception.desc": "對方說法前後矛盾、迴避、誇大或施壓話術",
+  "tpl.eval.pushback.name": "該 push back 的時機",
+  "tpl.eval.pushback.desc": "對方提出不合理條件或單方面有利的條款",
+  "tpl.eval.unanswered.name": "未回答的問題",
+  "tpl.eval.unanswered.desc": "我方提問但對方含糊帶過、沒正面回應",
+  "tpl.eval.checklist.name": "流程遺漏",
+  "tpl.eval.checklist.desc": "依會議類型該問卻還沒問的項目",
+  "tpl.eval.claims.name": "待查證宣稱",
+  "tpl.eval.claims.desc": "對方提出的可驗證事實主張，標記為之後查證",
+  "tpl.eval.topic-shift.name": "話題偏移 / 模糊焦點",
+  "tpl.eval.topic-shift.desc": "對方突然轉移話題、答非所問、或用無關細節稀釋你提出的重點",
+  "tpl.eval.nextmove.name": "下一步建議 / Next move",
+  "tpl.eval.nextmove.desc": "根據目前進展，建議我接下來該說 / 問 / 提出的條件",
+  "tpl.eval.iv-exaggeration.name": "誇大 / 灌水偵測",
+  "tpl.eval.iv-exaggeration.desc": "候選人對技能、年資、貢獻的誇大或含糊其詞",
+  "tpl.eval.iv-consistency.name": "經歷一致性",
+  "tpl.eval.iv-consistency.desc": "候選人前後說法 / 時間線 / 數字是否一致",
+  "tpl.eval.iv-redflags.name": "紅旗訊號",
+  "tpl.eval.iv-redflags.desc": "態度、責任歸屬、對前東家/同事的描述等警訊",
+  "tpl.eval.iv-followup.name": "值得追問",
+  "tpl.eval.iv-followup.desc": "候選人提到、但你還沒深入追問的點",
+  "tpl.eval.sl-qualification.name": "資格判定缺口 (MEDDICC)",
+  "tpl.eval.sl-qualification.desc": "Metrics / 決策者 / 決策標準 / 痛點 / 流程 / Champion 等尚未釐清的項目",
+  "tpl.eval.sl-pain.name": "痛點深度與急迫性",
+  "tpl.eval.sl-pain.desc": "對方痛點是否具體、可量化、有急迫性",
+  "tpl.eval.sl-objections.name": "異議 / 顧慮",
+  "tpl.eval.sl-objections.desc": "對方提出的反對意見或顧慮，標記尚未被處理的",
+  "tpl.eval.sl-nextstep.name": "下一步承諾",
+  "tpl.eval.sl-nextstep.desc": "是否約定明確、雙方同意的下一步",
+  "tpl.eval.sa-market.name": "行情 / 薪酬主張",
+  "tpl.eval.sa-market.desc": "對方對市場行情、預算、薪酬結構的主張，標記待查證",
+  "tpl.eval.sa-components.name": "薪酬組成追蹤",
+  "tpl.eval.sa-components.desc": "底薪 / 獎金 / 股票 / 簽約金 / 福利等各項與已談到的條件",
+  "tpl.eval.sa-pressure.name": "錨定 / 施壓話術",
+  "tpl.eval.sa-pressure.desc": "錨定、人為期限、take-it-or-leave-it 等施壓手法",
+  "tpl.eval.ng-concessions.name": "讓步追蹤",
+  "tpl.eval.ng-concessions.desc": "雙方已提出/已同意的讓步與條件",
+  "tpl.eval.dd-claims.name": "重點宣稱待查證",
+  "tpl.eval.dd-claims.desc": "財務 / 客戶 / 成長 / 法務等可驗證主張，列為查證清單",
+  "tpl.eval.dd-risk.name": "風險訊號",
+  "tpl.eval.dd-risk.desc": "財務 / 法務 / 營運 / 團隊面的風險或不一致",
+  "tpl.eval.dd-checklist.name": "盡調項目遺漏",
+  "tpl.eval.dd-checklist.desc": "標準盡職調查面向中尚未觸及的部分",
+
+  "tpl.todo.todo-interview.name": "面試候選人 / Job interview",
+  "tpl.todo.todo-interview.items":
+    "自我介紹與職缺說明\n請候選人介紹背景與動機\n深入追問一個代表性專案\n驗證核心技術／能力\n詢問過去的衝突與處理方式\n保留候選人提問時間\n確認薪資期待與可到職時間\n說明後續流程與時程",
+  "tpl.todo.todo-salary.name": "薪資談判 / Salary negotiation",
+  "tpl.todo.todo-salary.items":
+    "先讓對方提出數字／區間\n確認薪酬全貌：底薪、獎金、股票、簽約金、福利\n說明自身價值與市場行情依據\n提出有依據的目標數字（錨定）\n釐清股票條件（數量、估值、vesting）\n確認升遷／調薪的時程與標準\n處理對方的施壓或人為期限\n爭取書面 offer 與考慮時間",
+  "tpl.todo.todo-sales-discovery.name": "銷售電話 / Sales call",
+  "tpl.todo.todo-sales-discovery.items":
+    "確認對方的角色與決策權\n了解現況與目前做法\n挖掘核心痛點與其影響\n量化痛點的成本／損失\n確認預算範圍\n釐清決策流程與關鍵人\n了解時程與急迫性\n詢問現有方案／競品\n約定明確的下一步",
+  "tpl.todo.todo-deal.name": "商務談判 / Deal-making",
+  "tpl.todo.todo-deal.items":
+    "確認雙方目標與底線（BATNA）\n釐清對方真正在意的優先順序\n盤點價格／條款／時程等變數\n先談整體框架再談細節\n每次讓步都換回對等條件\n記錄雙方已同意與待決事項\n確認決策流程與簽約時程\n總結共識並約定下一步",
+  "tpl.todo.todo-diligence.name": "盡職調查 / Diligence call",
+  "tpl.todo.todo-diligence.items":
+    "確認核心財務數據與成長趨勢\n了解營收結構與客戶集中度\n確認留存／churn 與單位經濟\n釐清競爭與市場風險\n確認團隊、關鍵人與股權結構\n了解法務／合規／智財狀況\n詢問技術債與資安現況\n索取佐證文件並約定 follow-up",
+  "tpl.todo.todo-coffee-chat.name": "Coffee chat（創業前輩）",
+  "tpl.todo.todo-coffee-chat.items":
+    "簡短自我介紹與來意\n請教對方的創業歷程與關鍵轉折\n請教他們現階段最大的挑戰\n針對我目前的方向請教看法\n請教常見的坑與建議\n詢問值得認識的人／引薦\n請教推薦的資源或書\n約定下次 follow-up 的方式",
+  "tpl.todo.todo-fundraising.name": "投資人 pitch",
+  "tpl.todo.todo-fundraising.items":
+    "一句話講清楚在做什麼\n說明問題與市場規模\nDemo 產品\n商業模式與關鍵數據（traction）\n介紹團隊與為何是我們\n競爭與護城河\n募資金額與資金用途\n確認對方的投資範圍與決策流程",
 } as const satisfies Dict;
 
 export const en = {
@@ -441,6 +518,81 @@ export const en = {
   "speaker.speaker": "Speaker {number}",
   "speaker.remote": "Remote {number}",
   "speaker.them": "Them",
+
+  // Built-in template content (see the zh-TW block above for notes).
+  "tpl.evalSet.tpl-general.name": "General",
+  "tpl.evalSet.tpl-interview.name": "Job interview",
+  "tpl.evalSet.tpl-salary.name": "Salary negotiation",
+  "tpl.evalSet.tpl-sales.name": "Sales call",
+  "tpl.evalSet.tpl-negotiation.name": "Deal-making",
+  "tpl.evalSet.tpl-diligence.name": "Diligence call",
+
+  "tpl.eval.deception.name": "Deception / inconsistency",
+  "tpl.eval.deception.desc": "Contradictions, evasion, exaggeration, or pressure tactics from the other party",
+  "tpl.eval.pushback.name": "When to push back",
+  "tpl.eval.pushback.desc": "Unreasonable demands or one-sided terms from the other party",
+  "tpl.eval.unanswered.name": "Unanswered questions",
+  "tpl.eval.unanswered.desc": "Questions I asked that they dodged or never answered directly",
+  "tpl.eval.checklist.name": "Process gaps",
+  "tpl.eval.checklist.desc": "Standard topics for this meeting type that haven't been covered yet",
+  "tpl.eval.claims.name": "Claims to verify",
+  "tpl.eval.claims.desc": "Verifiable factual claims by the other party, flagged to check later",
+  "tpl.eval.topic-shift.name": "Topic drift / blurred focus",
+  "tpl.eval.topic-shift.desc": "Them changing the subject, answering a different question, or burying your point in irrelevant detail",
+  "tpl.eval.nextmove.name": "Next move",
+  "tpl.eval.nextmove.desc": "Based on progress so far, what to say / ask / propose next",
+  "tpl.eval.iv-exaggeration.name": "Exaggeration / inflation",
+  "tpl.eval.iv-exaggeration.desc": "A candidate overstating or being vague about skills, tenure, or contributions",
+  "tpl.eval.iv-consistency.name": "Background consistency",
+  "tpl.eval.iv-consistency.desc": "Whether the candidate's statements, timelines, and numbers stay consistent",
+  "tpl.eval.iv-redflags.name": "Red flags",
+  "tpl.eval.iv-redflags.desc": "Warning signs in attitude, accountability, or how they describe past employers/colleagues",
+  "tpl.eval.iv-followup.name": "Worth following up",
+  "tpl.eval.iv-followup.desc": "Points the candidate raised that you haven't probed yet",
+  "tpl.eval.sl-qualification.name": "Qualification gaps (MEDDICC)",
+  "tpl.eval.sl-qualification.desc": "MEDDICC dimensions still unclear: Metrics, economic buyer, decision criteria, pain, process, Champion",
+  "tpl.eval.sl-pain.name": "Pain depth & urgency",
+  "tpl.eval.sl-pain.desc": "Whether their pain is specific, quantified, and urgent",
+  "tpl.eval.sl-objections.name": "Objections / concerns",
+  "tpl.eval.sl-objections.desc": "Objections or concerns they raise, flagging any not yet addressed",
+  "tpl.eval.sl-nextstep.name": "Next-step commitment",
+  "tpl.eval.sl-nextstep.desc": "Whether a concrete, mutually agreed next step has been set",
+  "tpl.eval.sa-market.name": "Market rate / comp claims",
+  "tpl.eval.sa-market.desc": "The employer's claims about market rate, budget, or comp structure, flagged to verify",
+  "tpl.eval.sa-components.name": "Compensation tracking",
+  "tpl.eval.sa-components.desc": "Tracking base, bonus, equity, sign-on, benefits, and the terms discussed",
+  "tpl.eval.sa-pressure.name": "Anchoring / pressure tactics",
+  "tpl.eval.sa-pressure.desc": "Anchoring, artificial deadlines, take-it-or-leave-it framing, and similar pressure",
+  "tpl.eval.ng-concessions.name": "Concession tracking",
+  "tpl.eval.ng-concessions.desc": "Concessions and terms each side has offered or agreed to",
+  "tpl.eval.dd-claims.name": "Key claims to verify",
+  "tpl.eval.dd-claims.desc": "Verifiable claims about financials, customers, growth, or legal — listed for diligence",
+  "tpl.eval.dd-risk.name": "Risk signals",
+  "tpl.eval.dd-risk.desc": "Financial, legal, operational, or team risks and inconsistencies",
+  "tpl.eval.dd-checklist.name": "Diligence gaps",
+  "tpl.eval.dd-checklist.desc": "Standard diligence areas not yet covered",
+
+  "tpl.todo.todo-interview.name": "Job interview",
+  "tpl.todo.todo-interview.items":
+    "Introduce yourself and the role\nAsk the candidate about their background and motivation\nDig into one representative project\nVerify core technical skills / abilities\nAsk about past conflicts and how they handled them\nLeave time for the candidate's questions\nConfirm salary expectations and start date\nExplain next steps and timeline",
+  "tpl.todo.todo-salary.name": "Salary negotiation",
+  "tpl.todo.todo-salary.items":
+    "Let them put out a number / range first\nCover the full package: base, bonus, equity, sign-on, benefits\nState your value with market-rate evidence\nPropose a justified target number (anchor)\nClarify equity terms (amount, valuation, vesting)\nConfirm promotion / raise timeline and criteria\nHandle pressure or artificial deadlines\nGet a written offer and time to consider",
+  "tpl.todo.todo-sales-discovery.name": "Sales call",
+  "tpl.todo.todo-sales-discovery.items":
+    "Confirm their role and decision authority\nUnderstand the current situation and approach\nUncover the core pain and its impact\nQuantify the cost / loss of the pain\nConfirm the budget range\nClarify the decision process and key people\nUnderstand timeline and urgency\nAsk about existing solutions / competitors\nAgree on a concrete next step",
+  "tpl.todo.todo-deal.name": "Deal-making",
+  "tpl.todo.todo-deal.items":
+    "Confirm both sides' goals and walk-away (BATNA)\nClarify what they truly prioritize\nMap out the variables: price, terms, timeline\nAgree on the overall framework before details\nTrade every concession for something of equal value\nRecord what's agreed and what's still open\nConfirm the decision process and signing timeline\nSummarize agreements and set the next step",
+  "tpl.todo.todo-diligence.name": "Diligence call",
+  "tpl.todo.todo-diligence.items":
+    "Confirm core financials and growth trends\nUnderstand revenue mix and customer concentration\nCheck retention / churn and unit economics\nClarify competitive and market risks\nConfirm the team, key people, and cap table\nReview legal / compliance / IP status\nAsk about tech debt and security posture\nRequest supporting documents and set a follow-up",
+  "tpl.todo.todo-coffee-chat.name": "Coffee chat (founder mentor)",
+  "tpl.todo.todo-coffee-chat.items":
+    "Briefly introduce yourself and why you're here\nAsk about their startup journey and key turning points\nAsk about their biggest current challenge\nGet their take on my current direction\nAsk about common pitfalls and advice\nAsk who's worth meeting / for intros\nAsk for recommended resources or books\nAgree on how to follow up next",
+  "tpl.todo.todo-fundraising.name": "Investor pitch",
+  "tpl.todo.todo-fundraising.items":
+    "Explain what you do in one sentence\nLay out the problem and market size\nDemo the product\nBusiness model and key metrics (traction)\nIntroduce the team and why it's us\nCompetition and moat\nRaise amount and use of funds\nConfirm their investment range and decision process",
 } as const satisfies Record<keyof typeof zhTW, string>;
 
 export const DICTS: Record<AppLanguage, Dict> = {
@@ -449,3 +601,18 @@ export const DICTS: Record<AppLanguage, Dict> = {
 };
 
 export type TranslationKey = keyof typeof zhTW;
+
+/**
+ * Pure translation lookup (no React/store dependency) so it can be used while
+ * seeding/reconciling built-in templates as well as from the `useI18n` hook.
+ * Falls back to zh-TW, then to the raw key.
+ */
+export function translate(
+  language: AppLanguage,
+  key: TranslationKey,
+  vars?: Record<string, string | number>
+): string {
+  const template = DICTS[language]?.[key] ?? zhTW[key] ?? key;
+  if (!vars) return template;
+  return template.replace(/\{(\w+)\}/g, (_, name: string) => String(vars[name] ?? ""));
+}

--- a/src/lib/evaluations/presets.ts
+++ b/src/lib/evaluations/presets.ts
@@ -1,264 +1,287 @@
 import type { EvalDef, EvalTemplate, Evaluation } from "../types";
+import type { TranslationKey } from "../../i18n/messages";
 
 /**
- * Built-in evaluation definitions that ship with Parley. Used as the default
- * `settings.evaluations`; the user can edit/add/remove them in Settings.
+ * Built-in evaluation definitions and the template library that ship with
+ * Parley, covering the use-cases Parley markets: job interviews, salary
+ * negotiations, sales calls, deal-making, and diligence calls — plus a
+ * general-purpose set.
  *
- * The built-in template library below maps onto the use-cases Parley markets:
- * job interviews, salary negotiations, sales calls, deal-making, and diligence
- * calls — plus a general-purpose set.
+ * Display strings (names/descriptions) are looked up through i18n so built-in
+ * templates follow the UI language. The `prompt` field is the instruction handed
+ * to the LLM and stays in English on purpose — it's model input, not UI.
  */
-export const PRESET_EVAL_DEFS: EvalDef[] = [
-  {
-    id: "deception",
-    name: "詐術 / 不一致偵測",
-    description: "對方說法前後矛盾、迴避、誇大或施壓話術",
-    prompt:
-      "You are monitoring the OTHER party ('them') for signs of deception or manipulation. " +
-      "Look for: internal contradictions across what they've said, evasive non-answers, " +
-      "unverifiable grand claims, moving goalposts, false urgency, or pressure tactics. " +
-      "Flag only when you have concrete textual evidence. Cite the exact conflicting or suspicious quotes.",
-  },
-  {
-    id: "pushback",
-    name: "該 push back 的時機",
-    description: "對方提出不合理條件或單方面有利的條款",
-    prompt:
-      "Identify moments where I ('me') should push back. Look for one-sided terms, unreasonable " +
-      "demands, assumptions stated as facts, or concessions being extracted from me without reciprocity. " +
-      "If found, flag it and suggest specifically what to push back on.",
-  },
-  {
-    id: "unanswered",
-    name: "未回答的問題",
-    description: "我方提問但對方含糊帶過、沒正面回應",
-    prompt:
-      "Track questions I ('me') asked that the other party did NOT clearly answer — they deflected, " +
-      "gave a vague response, or changed the subject. Flag each open question so I can re-ask it. " +
-      "Quote my original question and their evasive reply.",
-  },
-  {
-    id: "checklist",
-    name: "流程遺漏",
-    description: "依會議類型該問卻還沒問的項目",
-    prompt:
-      "Given the meeting context provided, identify important topics or questions that are standard for " +
-      "this kind of meeting but have NOT yet been covered. Flag what's missing so I can raise it before " +
-      "the meeting ends.",
-  },
-  {
-    id: "claims",
-    name: "待查證宣稱",
-    description: "對方提出的可驗證事實主張，標記為之後查證",
-    prompt:
-      "Extract concrete, verifiable factual claims made by the other party ('them') — numbers, dates, " +
-      "credentials, references, commitments. These are things worth fact-checking later. List each claim. " +
-      "Severity is informational unless a claim is central to the deal/decision.",
-  },
-  {
-    id: "topic-shift",
-    name: "話題偏移 / 模糊焦點",
-    description: "對方突然轉移話題、答非所問、或用無關細節稀釋你提出的重點",
-    prompt:
-      "Watch for the other party ('them') steering away from the point: a sudden topic change, answering a " +
-      "different question than the one asked, retreating into vague generalities, or burying the issue under " +
-      "irrelevant detail — especially right after I ('me') raised something they'd rather avoid. When it " +
-      "happens, flag it, name the specific point they slid off, and suggest how I can steer back. This helps " +
-      "a less-experienced operator catch deflection in the moment.",
-  },
-];
+
+/** A translate function bound to the current language: `(key) => string`. */
+type T = (key: TranslationKey) => string;
+
+/** Core, general-purpose evaluation definitions (the default active set). */
+export function buildPresetEvalDefs(t: T): EvalDef[] {
+  return [
+    {
+      id: "deception",
+      name: t("tpl.eval.deception.name"),
+      description: t("tpl.eval.deception.desc"),
+      prompt:
+        "You are monitoring the OTHER party ('them') for signs of deception or manipulation. " +
+        "Look for: internal contradictions across what they've said, evasive non-answers, " +
+        "unverifiable grand claims, moving goalposts, false urgency, or pressure tactics. " +
+        "Flag only when you have concrete textual evidence. Cite the exact conflicting or suspicious quotes.",
+    },
+    {
+      id: "pushback",
+      name: t("tpl.eval.pushback.name"),
+      description: t("tpl.eval.pushback.desc"),
+      prompt:
+        "Identify moments where I ('me') should push back. Look for one-sided terms, unreasonable " +
+        "demands, assumptions stated as facts, or concessions being extracted from me without reciprocity. " +
+        "If found, flag it and suggest specifically what to push back on.",
+    },
+    {
+      id: "unanswered",
+      name: t("tpl.eval.unanswered.name"),
+      description: t("tpl.eval.unanswered.desc"),
+      prompt:
+        "Track questions I ('me') asked that the other party did NOT clearly answer — they deflected, " +
+        "gave a vague response, or changed the subject. Flag each open question so I can re-ask it. " +
+        "Quote my original question and their evasive reply.",
+    },
+    {
+      id: "checklist",
+      name: t("tpl.eval.checklist.name"),
+      description: t("tpl.eval.checklist.desc"),
+      prompt:
+        "Given the meeting context provided, identify important topics or questions that are standard for " +
+        "this kind of meeting but have NOT yet been covered. Flag what's missing so I can raise it before " +
+        "the meeting ends.",
+    },
+    {
+      id: "claims",
+      name: t("tpl.eval.claims.name"),
+      description: t("tpl.eval.claims.desc"),
+      prompt:
+        "Extract concrete, verifiable factual claims made by the other party ('them') — numbers, dates, " +
+        "credentials, references, commitments. These are things worth fact-checking later. List each claim. " +
+        "Severity is informational unless a claim is central to the deal/decision.",
+    },
+    {
+      id: "topic-shift",
+      name: t("tpl.eval.topic-shift.name"),
+      description: t("tpl.eval.topic-shift.desc"),
+      prompt:
+        "Watch for the other party ('them') steering away from the point: a sudden topic change, answering a " +
+        "different question than the one asked, retreating into vague generalities, or burying the issue under " +
+        "irrelevant detail — especially right after I ('me') raised something they'd rather avoid. When it " +
+        "happens, flag it, name the specific point they slid off, and suggest how I can steer back. This helps " +
+        "a less-experienced operator catch deflection in the moment.",
+    },
+  ];
+}
 
 /**
  * Forward-looking "what should I do next" evaluation. Beyond flagging issues,
- * this proactively recommends my next move — the seed of Parley's coaching /
- * next-step-recommendation direction.
+ * this proactively recommends my next move.
  */
-const NEXT_MOVE: EvalDef = {
-  id: "nextmove",
-  name: "下一步建議 / Next move",
-  description: "根據目前進展，建議我接下來該說 / 問 / 提出的條件",
-  prompt:
-    "Based on the conversation so far, recommend the single best next move for me ('me') to advance my goal — " +
-    "the specific question to ask, point to make, or term/number to propose right now. Make it concrete and " +
-    "say it in words I could use, plus one short line on why now. Only surface a new suggestion when the " +
-    "situation has meaningfully moved.",
-};
+function nextMove(t: T): EvalDef {
+  return {
+    id: "nextmove",
+    name: t("tpl.eval.nextmove.name"),
+    description: t("tpl.eval.nextmove.desc"),
+    prompt:
+      "Based on the conversation so far, recommend the single best next move for me ('me') to advance my goal — " +
+      "the specific question to ask, point to make, or term/number to propose right now. Make it concrete and " +
+      "say it in words I could use, plus one short line on why now. Only surface a new suggestion when the " +
+      "situation has meaningfully moved.",
+  };
+}
 
-// Job-interview evaluations.
-const INTERVIEW_DEFS: EvalDef[] = [
-  {
-    id: "iv-exaggeration",
-    name: "誇大 / 灌水偵測",
-    description: "候選人對技能、年資、貢獻的誇大或含糊其詞",
-    prompt:
-      "You are helping interview a candidate ('them'). Flag exaggeration or inflation: vague ownership " +
-      "claims ('we built…' vs concrete personal contribution), inflated scope/seniority/years, buzzwords " +
-      "without substance, or dodging specifics when asked to go deeper. Quote the suspicious lines.",
-  },
-  {
-    id: "iv-consistency",
-    name: "經歷一致性",
-    description: "候選人前後說法 / 時間線 / 數字是否一致",
-    prompt:
-      "Track the candidate's statements about roles, timelines, team sizes, and metrics. Flag any internal " +
-      "contradiction or timeline that doesn't add up, citing the conflicting quotes.",
-  },
-  {
-    id: "iv-redflags",
-    name: "紅旗訊號",
-    description: "態度、責任歸屬、對前東家/同事的描述等警訊",
-    prompt:
-      "Watch for behavioral red flags: blaming others for all failures, lack of accountability, " +
-      "dismissiveness, ethical concerns, or contradictions about why they left roles. Flag with the quote.",
-  },
-  {
-    id: "iv-followup",
-    name: "值得追問",
-    description: "候選人提到、但你還沒深入追問的點",
-    prompt:
-      "Identify claims or topics the candidate raised that deserve a deeper follow-up question and that I " +
-      "('me') have not yet probed. Suggest the specific follow-up to ask.",
-  },
-  PRESET_EVAL_DEFS[5], // topic shift / focus dilution (candidate dodging)
-];
+/** Build the full built-in template library for a given language. */
+export function buildPresetEvalTemplates(t: T): EvalTemplate[] {
+  const core = buildPresetEvalDefs(t);
+  const [deception, pushback, unanswered, , claims, topicShift] = core;
 
-// Sales-call evaluations (qualification-driven, MEDDICC-flavored).
-const SALES_DEFS: EvalDef[] = [
-  {
-    id: "sl-qualification",
-    name: "資格判定缺口 (MEDDICC)",
-    description: "Metrics / 決策者 / 決策標準 / 痛點 / 流程 / Champion 等尚未釐清的項目",
-    prompt:
-      "You are helping qualify a sales opportunity. Track the MEDDICC-style dimensions: quantified Metrics, " +
-      "Economic buyer, Decision criteria, Decision process, identified Pain, and a Champion. Flag which " +
-      "dimensions are still unknown or weak so I ('me') can ask about them before the call ends.",
-  },
-  {
-    id: "sl-pain",
-    name: "痛點深度與急迫性",
-    description: "對方痛點是否具體、可量化、有急迫性",
-    prompt:
-      "Assess the prospect's pain. Flag when their problem is stated vaguely, is not quantified (cost, time, " +
-      "risk), or lacks urgency / a compelling event. Suggest the specific question that would deepen or " +
-      "quantify the pain.",
-  },
-  {
-    id: "sl-objections",
-    name: "異議 / 顧慮",
-    description: "對方提出的反對意見或顧慮，標記尚未被處理的",
-    prompt:
-      "Detect objections or concerns the prospect ('them') raises — price, timing, fit, competitor, risk, " +
-      "authority. Flag each one, and especially any that I ('me') have NOT yet addressed. Quote the objection.",
-  },
-  {
-    id: "sl-nextstep",
-    name: "下一步承諾",
-    description: "是否約定明確、雙方同意的下一步",
-    prompt:
-      "Check whether a concrete, mutually-agreed next step has been established (a scheduled meeting, a trial, " +
-      "an intro to the economic buyer). Flag if the call is heading toward ending without a committed next step.",
-  },
-  PRESET_EVAL_DEFS[4], // claims to verify
-  PRESET_EVAL_DEFS[5], // topic shift / focus dilution
-  NEXT_MOVE, // recommend the next move
-];
+  const interviewDefs: EvalDef[] = [
+    {
+      id: "iv-exaggeration",
+      name: t("tpl.eval.iv-exaggeration.name"),
+      description: t("tpl.eval.iv-exaggeration.desc"),
+      prompt:
+        "You are helping interview a candidate ('them'). Flag exaggeration or inflation: vague ownership " +
+        "claims ('we built…' vs concrete personal contribution), inflated scope/seniority/years, buzzwords " +
+        "without substance, or dodging specifics when asked to go deeper. Quote the suspicious lines.",
+    },
+    {
+      id: "iv-consistency",
+      name: t("tpl.eval.iv-consistency.name"),
+      description: t("tpl.eval.iv-consistency.desc"),
+      prompt:
+        "Track the candidate's statements about roles, timelines, team sizes, and metrics. Flag any internal " +
+        "contradiction or timeline that doesn't add up, citing the conflicting quotes.",
+    },
+    {
+      id: "iv-redflags",
+      name: t("tpl.eval.iv-redflags.name"),
+      description: t("tpl.eval.iv-redflags.desc"),
+      prompt:
+        "Watch for behavioral red flags: blaming others for all failures, lack of accountability, " +
+        "dismissiveness, ethical concerns, or contradictions about why they left roles. Flag with the quote.",
+    },
+    {
+      id: "iv-followup",
+      name: t("tpl.eval.iv-followup.name"),
+      description: t("tpl.eval.iv-followup.desc"),
+      prompt:
+        "Identify claims or topics the candidate raised that deserve a deeper follow-up question and that I " +
+        "('me') have not yet probed. Suggest the specific follow-up to ask.",
+    },
+    topicShift, // topic shift / focus dilution (candidate dodging)
+  ];
 
-// Salary-negotiation evaluations.
-const SALARY_DEFS: EvalDef[] = [
-  {
-    id: "sa-market",
-    name: "行情 / 薪酬主張",
-    description: "對方對市場行情、預算、薪酬結構的主張，標記待查證",
-    prompt:
-      "The other party ('them') is the employer/recruiter in a compensation discussion. Extract claims about " +
-      "market rate, internal bands, budget limits, or 'this is the most we can do' — these are negotiable " +
-      "positions, not facts. List each so I ('me') can verify or challenge it.",
-  },
-  {
-    id: "sa-components",
-    name: "薪酬組成追蹤",
-    description: "底薪 / 獎金 / 股票 / 簽約金 / 福利等各項與已談到的條件",
-    prompt:
-      "Track every compensation component discussed: base, bonus, equity (amount, vesting, strike), sign-on, " +
-      "benefits, title, start date, review timing. Summarize what has been offered vs. still open, and flag " +
-      "where I ('me') gave ground without getting something back.",
-  },
-  PRESET_EVAL_DEFS[1], // when to push back
-  {
-    id: "sa-pressure",
-    name: "錨定 / 施壓話術",
-    description: "錨定、人為期限、take-it-or-leave-it 等施壓手法",
-    prompt:
-      "Watch for negotiation pressure tactics from the employer: low anchoring, artificial deadlines, " +
-      "'exploding' offers, take-it-or-leave-it framing, or appeals to fairness/policy to shut down asks. " +
-      "Flag the tactic and suggest how I ('me') can hold my position.",
-  },
-  PRESET_EVAL_DEFS[2], // unanswered questions
-  PRESET_EVAL_DEFS[5], // topic shift / focus dilution
-  NEXT_MOVE, // recommend the next move
-];
+  const salesDefs: EvalDef[] = [
+    {
+      id: "sl-qualification",
+      name: t("tpl.eval.sl-qualification.name"),
+      description: t("tpl.eval.sl-qualification.desc"),
+      prompt:
+        "You are helping qualify a sales opportunity. Track the MEDDICC-style dimensions: quantified Metrics, " +
+        "Economic buyer, Decision criteria, Decision process, identified Pain, and a Champion. Flag which " +
+        "dimensions are still unknown or weak so I ('me') can ask about them before the call ends.",
+    },
+    {
+      id: "sl-pain",
+      name: t("tpl.eval.sl-pain.name"),
+      description: t("tpl.eval.sl-pain.desc"),
+      prompt:
+        "Assess the prospect's pain. Flag when their problem is stated vaguely, is not quantified (cost, time, " +
+        "risk), or lacks urgency / a compelling event. Suggest the specific question that would deepen or " +
+        "quantify the pain.",
+    },
+    {
+      id: "sl-objections",
+      name: t("tpl.eval.sl-objections.name"),
+      description: t("tpl.eval.sl-objections.desc"),
+      prompt:
+        "Detect objections or concerns the prospect ('them') raises — price, timing, fit, competitor, risk, " +
+        "authority. Flag each one, and especially any that I ('me') have NOT yet addressed. Quote the objection.",
+    },
+    {
+      id: "sl-nextstep",
+      name: t("tpl.eval.sl-nextstep.name"),
+      description: t("tpl.eval.sl-nextstep.desc"),
+      prompt:
+        "Check whether a concrete, mutually-agreed next step has been established (a scheduled meeting, a trial, " +
+        "an intro to the economic buyer). Flag if the call is heading toward ending without a committed next step.",
+    },
+    claims, // claims to verify
+    topicShift, // topic shift / focus dilution
+    nextMove(t), // recommend the next move
+  ];
 
-// Deal-making / business-negotiation evaluations.
-const DEAL_DEFS: EvalDef[] = [
-  PRESET_EVAL_DEFS[0], // deception / pressure tactics
-  PRESET_EVAL_DEFS[1], // when to push back
-  {
-    id: "ng-concessions",
-    name: "讓步追蹤",
-    description: "雙方已提出/已同意的讓步與條件",
-    prompt:
-      "Track concessions and commitments on both sides: what each party has offered, conceded, or agreed to. " +
-      "Flag asymmetric exchanges where I ('me') gave more than I received. Summarize the current state of the deal.",
-  },
-  PRESET_EVAL_DEFS[2], // unanswered questions
-  PRESET_EVAL_DEFS[4], // claims to verify
-  PRESET_EVAL_DEFS[5], // topic shift / focus dilution
-  NEXT_MOVE, // recommend the next move
-];
+  const salaryDefs: EvalDef[] = [
+    {
+      id: "sa-market",
+      name: t("tpl.eval.sa-market.name"),
+      description: t("tpl.eval.sa-market.desc"),
+      prompt:
+        "The other party ('them') is the employer/recruiter in a compensation discussion. Extract claims about " +
+        "market rate, internal bands, budget limits, or 'this is the most we can do' — these are negotiable " +
+        "positions, not facts. List each so I ('me') can verify or challenge it.",
+    },
+    {
+      id: "sa-components",
+      name: t("tpl.eval.sa-components.name"),
+      description: t("tpl.eval.sa-components.desc"),
+      prompt:
+        "Track every compensation component discussed: base, bonus, equity (amount, vesting, strike), sign-on, " +
+        "benefits, title, start date, review timing. Summarize what has been offered vs. still open, and flag " +
+        "where I ('me') gave ground without getting something back.",
+    },
+    pushback, // when to push back
+    {
+      id: "sa-pressure",
+      name: t("tpl.eval.sa-pressure.name"),
+      description: t("tpl.eval.sa-pressure.desc"),
+      prompt:
+        "Watch for negotiation pressure tactics from the employer: low anchoring, artificial deadlines, " +
+        "'exploding' offers, take-it-or-leave-it framing, or appeals to fairness/policy to shut down asks. " +
+        "Flag the tactic and suggest how I ('me') can hold my position.",
+    },
+    unanswered, // unanswered questions
+    topicShift, // topic shift / focus dilution
+    nextMove(t), // recommend the next move
+  ];
 
-// Diligence-call evaluations (verify claims, surface risk).
-const DILIGENCE_DEFS: EvalDef[] = [
-  {
-    id: "dd-claims",
-    name: "重點宣稱待查證",
-    description: "財務 / 客戶 / 成長 / 法務等可驗證主張，列為查證清單",
-    prompt:
-      "This is a due-diligence call. Extract every concrete, verifiable claim the other party ('them') makes " +
-      "about financials, revenue, growth, customers, churn, headcount, legal status, or IP. List each as a " +
-      "diligence item to verify against documents later, quoting the claim.",
-  },
-  {
-    id: "dd-risk",
-    name: "風險訊號",
-    description: "財務 / 法務 / 營運 / 團隊面的風險或不一致",
-    prompt:
-      "Surface risk signals: financial, legal, operational, customer-concentration, or team risks, and any " +
-      "numbers or statements that are internally inconsistent or seem too good. Flag each with the quote and " +
-      "why it warrants follow-up.",
-  },
-  PRESET_EVAL_DEFS[2], // unanswered questions
-  {
-    id: "dd-checklist",
-    name: "盡調項目遺漏",
-    description: "標準盡職調查面向中尚未觸及的部分",
-    prompt:
-      "Given a due-diligence context, identify standard areas that have NOT yet been covered — financials, " +
-      "customer concentration, churn/retention, unit economics, legal/compliance, cap table, key-person risk, " +
-      "tech debt/security. Flag the gaps so I ('me') can raise them before the call ends.",
-  },
-  PRESET_EVAL_DEFS[0], // deception / inconsistency
-  PRESET_EVAL_DEFS[5], // topic shift / focus dilution
-];
+  const dealDefs: EvalDef[] = [
+    deception, // deception / pressure tactics
+    pushback, // when to push back
+    {
+      id: "ng-concessions",
+      name: t("tpl.eval.ng-concessions.name"),
+      description: t("tpl.eval.ng-concessions.desc"),
+      prompt:
+        "Track concessions and commitments on both sides: what each party has offered, conceded, or agreed to. " +
+        "Flag asymmetric exchanges where I ('me') gave more than I received. Summarize the current state of the deal.",
+    },
+    unanswered, // unanswered questions
+    claims, // claims to verify
+    topicShift, // topic shift / focus dilution
+    nextMove(t), // recommend the next move
+  ];
 
-/** Built-in template library. The first is the default active set. */
-export const PRESET_EVAL_TEMPLATES: EvalTemplate[] = [
-  { id: "tpl-general", name: "通用 / General", builtin: true, evals: PRESET_EVAL_DEFS },
-  { id: "tpl-interview", name: "面試 / Job interview", builtin: true, evals: INTERVIEW_DEFS },
-  { id: "tpl-salary", name: "薪資談判 / Salary negotiation", builtin: true, evals: SALARY_DEFS },
-  { id: "tpl-sales", name: "銷售電話 / Sales call", builtin: true, evals: SALES_DEFS },
-  { id: "tpl-negotiation", name: "商務談判 / Deal-making", builtin: true, evals: DEAL_DEFS },
-  { id: "tpl-diligence", name: "盡職調查 / Diligence call", builtin: true, evals: DILIGENCE_DEFS },
-];
+  const diligenceDefs: EvalDef[] = [
+    {
+      id: "dd-claims",
+      name: t("tpl.eval.dd-claims.name"),
+      description: t("tpl.eval.dd-claims.desc"),
+      prompt:
+        "This is a due-diligence call. Extract every concrete, verifiable claim the other party ('them') makes " +
+        "about financials, revenue, growth, customers, churn, headcount, legal status, or IP. List each as a " +
+        "diligence item to verify against documents later, quoting the claim.",
+    },
+    {
+      id: "dd-risk",
+      name: t("tpl.eval.dd-risk.name"),
+      description: t("tpl.eval.dd-risk.desc"),
+      prompt:
+        "Surface risk signals: financial, legal, operational, customer-concentration, or team risks, and any " +
+        "numbers or statements that are internally inconsistent or seem too good. Flag each with the quote and " +
+        "why it warrants follow-up.",
+    },
+    unanswered, // unanswered questions
+    {
+      id: "dd-checklist",
+      name: t("tpl.eval.dd-checklist.name"),
+      description: t("tpl.eval.dd-checklist.desc"),
+      prompt:
+        "Given a due-diligence context, identify standard areas that have NOT yet been covered — financials, " +
+        "customer concentration, churn/retention, unit economics, legal/compliance, cap table, key-person risk, " +
+        "tech debt/security. Flag the gaps so I ('me') can raise them before the call ends.",
+    },
+    deception, // deception / inconsistency
+    topicShift, // topic shift / focus dilution
+  ];
+
+  return [
+    { id: "tpl-general", name: t("tpl.evalSet.tpl-general.name"), builtin: true, evals: core },
+    { id: "tpl-interview", name: t("tpl.evalSet.tpl-interview.name"), builtin: true, evals: interviewDefs },
+    { id: "tpl-salary", name: t("tpl.evalSet.tpl-salary.name"), builtin: true, evals: salaryDefs },
+    { id: "tpl-sales", name: t("tpl.evalSet.tpl-sales.name"), builtin: true, evals: salesDefs },
+    { id: "tpl-negotiation", name: t("tpl.evalSet.tpl-negotiation.name"), builtin: true, evals: dealDefs },
+    { id: "tpl-diligence", name: t("tpl.evalSet.tpl-diligence.name"), builtin: true, evals: diligenceDefs },
+  ];
+}
+
+/**
+ * A map of every built-in evaluation id → its localized name/description, used
+ * to relabel the active evaluation set when the language changes.
+ */
+export function buildBuiltinEvalLabels(t: T): Map<string, { name: string; description: string }> {
+  const labels = new Map<string, { name: string; description: string }>();
+  for (const tpl of buildPresetEvalTemplates(t)) {
+    for (const e of tpl.evals) labels.set(e.id, { name: e.name, description: e.description });
+  }
+  return labels;
+}
 
 /** Build runtime evaluations from definitions, preserving runtime state by id. */
 export function evalsFromDefs(defs: EvalDef[], prev: Evaluation[] = []): Evaluation[] {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type {
+  AppLanguage,
   Evaluation,
   EvalResult,
   EvalStatus,
@@ -9,10 +10,40 @@ import type {
   TodoItem,
   TranscriptSegment,
 } from "./types";
-import { PRESET_EVAL_DEFS, PRESET_EVAL_TEMPLATES, evalsFromDefs } from "./evaluations/presets";
+import {
+  buildBuiltinEvalLabels,
+  buildPresetEvalDefs,
+  buildPresetEvalTemplates,
+  evalsFromDefs,
+} from "./evaluations/presets";
 import { reconcileTemplates } from "./templates";
-import { PRESET_TODO_TEMPLATES } from "./todoTemplates";
+import { buildPresetTodoTemplates } from "./todoTemplates";
+import { translate, type TranslationKey } from "../i18n/messages";
 import { DEFAULT_MODELS } from "./ai/providers";
+
+/** A translate function bound to a language, for resolving built-in templates. */
+const tFor = (language: AppLanguage) => (key: TranslationKey) => translate(language, key);
+
+/**
+ * Re-resolve all built-in template content (eval templates, TODO templates, and
+ * the labels of any active built-in evaluations) into `settings.language`,
+ * keeping the user's own custom templates. Called whenever the language changes
+ * so built-in content follows the UI language. Custom templates and custom
+ * evaluations (ids not in the built-in set) are left untouched.
+ */
+function relocalizeBuiltins(settings: Settings): Settings {
+  const t = tFor(settings.language);
+  const labels = buildBuiltinEvalLabels(t);
+  return {
+    ...settings,
+    evalTemplates: reconcileTemplates(buildPresetEvalTemplates(t), settings.evalTemplates),
+    todoTemplates: reconcileTemplates(buildPresetTodoTemplates(t), settings.todoTemplates),
+    evaluations: settings.evaluations.map((e) => {
+      const label = labels.get(e.id);
+      return label ? { ...e, name: label.name, description: label.description } : e;
+    }),
+  };
+}
 
 /**
  * Optional dev convenience: API keys from a gitignored `.env` (VITE_* vars).
@@ -34,6 +65,11 @@ const ENV_KEYS: Partial<Settings> = Object.fromEntries(
     ] as const
   ).filter(([, v]) => !!v)
 ) as Partial<Settings>;
+
+// Built-in templates are seeded in the default language; the persist `merge`
+// (rehydrate) and `relocalizeBuiltins` (on language change) re-resolve them to
+// the active language afterward.
+const tDefault = tFor("zh-TW");
 
 const DEFAULT_SETTINGS: Settings = {
   language: "zh-TW",
@@ -59,9 +95,9 @@ const DEFAULT_SETTINGS: Settings = {
   deepgramApiKey: "",
   assemblyaiApiKey: "",
   inputDevice: "",
-  evaluations: PRESET_EVAL_DEFS,
-  evalTemplates: PRESET_EVAL_TEMPLATES,
-  todoTemplates: PRESET_TODO_TEMPLATES,
+  evaluations: buildPresetEvalDefs(tDefault),
+  evalTemplates: buildPresetEvalTemplates(tDefault),
+  todoTemplates: buildPresetTodoTemplates(tDefault),
   ...ENV_KEYS,
 };
 
@@ -232,7 +268,12 @@ export const useStore = create<ParleyState>()(
 
   updateSettings: (patch) =>
     set((state) => {
-      const settings = { ...state.settings, ...patch };
+      let settings = { ...state.settings, ...patch };
+      // When the UI language changes, re-resolve built-in templates so they
+      // follow the new language (this is the onboarding language-switch path).
+      if (patch.language && patch.language !== state.settings.language) {
+        settings = relocalizeBuiltins(settings);
+      }
       return {
         settings,
         evaluations: evalsFromDefs(settings.evaluations, state.evaluations),
@@ -241,6 +282,9 @@ export const useStore = create<ParleyState>()(
 
   applySettings: (settings) =>
     set((state) => ({
+      // Trust the incoming settings: the broadcasting window already re-resolves
+      // built-in templates whenever its language changes, so they arrive in the
+      // right language (and any user edits are preserved).
       settings,
       evaluations: evalsFromDefs(settings.evaluations, state.evaluations),
     })),
@@ -267,6 +311,21 @@ export const useStore = create<ParleyState>()(
             ? { ask: persistedReasoning, eval: persistedReasoning }
             : { ...DEFAULT_SETTINGS.reasoningEffort, ...(persistedReasoning ?? {}) };
 
+        // Resolve built-in templates into the persisted language so they match
+        // the UI on rehydrate.
+        const language = (p.language as AppLanguage) ?? DEFAULT_SETTINGS.language;
+        const t = tFor(language);
+
+        // Relabel built-in active evaluations to the persisted language too,
+        // keeping any custom (non-built-in id) evaluations as saved.
+        const builtinLabels = buildBuiltinEvalLabels(t);
+        const persistedEvals =
+          (p.evaluations as Settings["evaluations"]) ?? buildPresetEvalDefs(t);
+        const relabeledEvals = persistedEvals.map((e) => {
+          const label = builtinLabels.get(e.id);
+          return label ? { ...e, name: label.name, description: label.description } : e;
+        });
+
         return {
           ...current,
           settings: {
@@ -278,19 +337,17 @@ export const useStore = create<ParleyState>()(
             reasoningEffort,
             // Fold latest built-in templates over persisted ones, keeping customs.
             todoTemplates: reconcileTemplates(
-              PRESET_TODO_TEMPLATES,
+              buildPresetTodoTemplates(t),
               validTodoTpls ? p.todoTemplates! : []
             ),
             evalTemplates: reconcileTemplates(
-              PRESET_EVAL_TEMPLATES,
+              buildPresetEvalTemplates(t),
               validEvalTpls ? p.evalTemplates! : []
             ),
             // Dev .env keys win over persisted-empty values (no-op in prod).
             ...ENV_KEYS,
           },
-          evaluations: evalsFromDefs(
-            (p.evaluations as Settings["evaluations"]) ?? DEFAULT_SETTINGS.evaluations
-          ),
+          evaluations: evalsFromDefs(relabeledEvals),
         };
       },
     }

--- a/src/lib/templatesSync.ts
+++ b/src/lib/templatesSync.ts
@@ -2,8 +2,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { useStore } from "./store";
 import { isTauri } from "./tauriEvents";
 import { reconcileTemplates } from "./templates";
-import { PRESET_EVAL_TEMPLATES } from "./evaluations/presets";
-import { PRESET_TODO_TEMPLATES } from "./todoTemplates";
+import { buildPresetEvalTemplates } from "./evaluations/presets";
+import { buildPresetTodoTemplates } from "./todoTemplates";
+import { translate, type TranslationKey } from "../i18n/messages";
 import type { EvalTemplate, TodoTemplate } from "./types";
 
 /**
@@ -30,14 +31,16 @@ async function loadFromFile(): Promise<void> {
     }
     const data = JSON.parse(raw) as TemplatesFile;
     // Always fold in the latest built-in templates (so new presets ship to
-    // existing users), keeping any custom templates from the file.
+    // existing users), keeping any custom templates from the file. Built-ins are
+    // resolved into the current UI language.
+    const t = (key: TranslationKey) => translate(useStore.getState().settings.language, key);
     const patch = {
       evalTemplates: reconcileTemplates(
-        PRESET_EVAL_TEMPLATES,
+        buildPresetEvalTemplates(t),
         Array.isArray(data.evalTemplates) ? data.evalTemplates : []
       ),
       todoTemplates: reconcileTemplates(
-        PRESET_TODO_TEMPLATES,
+        buildPresetTodoTemplates(t),
         Array.isArray(data.todoTemplates) ? data.todoTemplates : []
       ),
     };

--- a/src/lib/todoTemplates.ts
+++ b/src/lib/todoTemplates.ts
@@ -1,116 +1,62 @@
 import type { TodoTemplate } from "./types";
+import type { TranslationKey } from "../i18n/messages";
+
+/** A translate function bound to the current language: `(key) => string`. */
+type T = (key: TranslationKey) => string;
 
 /**
  * Built-in TODO/agenda templates. The first five mirror Parley's core
  * use-cases (job interviews, salary negotiations, sales calls, deal-making,
  * diligence calls); the rest are extra starting points. Users can apply,
  * edit, or add their own.
+ *
+ * Names and items are looked up through i18n (items are stored as a single
+ * newline-joined string per template) so built-in templates follow the UI
+ * language.
  */
-export const PRESET_TODO_TEMPLATES: TodoTemplate[] = [
-  {
-    id: "todo-interview",
-    name: "面試候選人 / Job interview",
-    builtin: true,
-    items: [
-      "自我介紹與職缺說明",
-      "請候選人介紹背景與動機",
-      "深入追問一個代表性專案",
-      "驗證核心技術／能力",
-      "詢問過去的衝突與處理方式",
-      "保留候選人提問時間",
-      "確認薪資期待與可到職時間",
-      "說明後續流程與時程",
-    ],
-  },
-  {
-    id: "todo-salary",
-    name: "薪資談判 / Salary negotiation",
-    builtin: true,
-    items: [
-      "先讓對方提出數字／區間",
-      "確認薪酬全貌：底薪、獎金、股票、簽約金、福利",
-      "說明自身價值與市場行情依據",
-      "提出有依據的目標數字（錨定）",
-      "釐清股票條件（數量、估值、vesting）",
-      "確認升遷／調薪的時程與標準",
-      "處理對方的施壓或人為期限",
-      "爭取書面 offer 與考慮時間",
-    ],
-  },
-  {
-    id: "todo-sales-discovery",
-    name: "銷售電話 / Sales call",
-    builtin: true,
-    items: [
-      "確認對方的角色與決策權",
-      "了解現況與目前做法",
-      "挖掘核心痛點與其影響",
-      "量化痛點的成本／損失",
-      "確認預算範圍",
-      "釐清決策流程與關鍵人",
-      "了解時程與急迫性",
-      "詢問現有方案／競品",
-      "約定明確的下一步",
-    ],
-  },
-  {
-    id: "todo-deal",
-    name: "商務談判 / Deal-making",
-    builtin: true,
-    items: [
-      "確認雙方目標與底線（BATNA）",
-      "釐清對方真正在意的優先順序",
-      "盤點價格／條款／時程等變數",
-      "先談整體框架再談細節",
-      "每次讓步都換回對等條件",
-      "記錄雙方已同意與待決事項",
-      "確認決策流程與簽約時程",
-      "總結共識並約定下一步",
-    ],
-  },
-  {
-    id: "todo-diligence",
-    name: "盡職調查 / Diligence call",
-    builtin: true,
-    items: [
-      "確認核心財務數據與成長趨勢",
-      "了解營收結構與客戶集中度",
-      "確認留存／churn 與單位經濟",
-      "釐清競爭與市場風險",
-      "確認團隊、關鍵人與股權結構",
-      "了解法務／合規／智財狀況",
-      "詢問技術債與資安現況",
-      "索取佐證文件並約定 follow-up",
-    ],
-  },
-  {
-    id: "todo-coffee-chat",
-    name: "Coffee chat（創業前輩）",
-    builtin: true,
-    items: [
-      "簡短自我介紹與來意",
-      "請教對方的創業歷程與關鍵轉折",
-      "請教他們現階段最大的挑戰",
-      "針對我目前的方向請教看法",
-      "請教常見的坑與建議",
-      "詢問值得認識的人／引薦",
-      "請教推薦的資源或書",
-      "約定下次 follow-up 的方式",
-    ],
-  },
-  {
-    id: "todo-fundraising",
-    name: "投資人 pitch",
-    builtin: true,
-    items: [
-      "一句話講清楚在做什麼",
-      "說明問題與市場規模",
-      "Demo 產品",
-      "商業模式與關鍵數據（traction）",
-      "介紹團隊與為何是我們",
-      "競爭與護城河",
-      "募資金額與資金用途",
-      "確認對方的投資範圍與決策流程",
-    ],
-  },
-];
+export function buildPresetTodoTemplates(t: T): TodoTemplate[] {
+  return [
+    {
+      id: "todo-interview",
+      name: t("tpl.todo.todo-interview.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-interview.items").split("\n"),
+    },
+    {
+      id: "todo-salary",
+      name: t("tpl.todo.todo-salary.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-salary.items").split("\n"),
+    },
+    {
+      id: "todo-sales-discovery",
+      name: t("tpl.todo.todo-sales-discovery.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-sales-discovery.items").split("\n"),
+    },
+    {
+      id: "todo-deal",
+      name: t("tpl.todo.todo-deal.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-deal.items").split("\n"),
+    },
+    {
+      id: "todo-diligence",
+      name: t("tpl.todo.todo-diligence.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-diligence.items").split("\n"),
+    },
+    {
+      id: "todo-coffee-chat",
+      name: t("tpl.todo.todo-coffee-chat.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-coffee-chat.items").split("\n"),
+    },
+    {
+      id: "todo-fundraising",
+      name: t("tpl.todo.todo-fundraising.name"),
+      builtin: true,
+      items: t("tpl.todo.todo-fundraising.items").split("\n"),
+    },
+  ];
+}


### PR DESCRIPTION
## Problem

Onboarding into the **English** UI, then seeing the built-in **templates in Chinese** — confusing and inconsistent with the rest of the localized app.

Root cause: the built-in evaluation and TODO templates (`src/lib/evaluations/presets.ts`, `src/lib/todoTemplates.ts`) shipped with **hardcoded Traditional Chinese** names, descriptions, and items. They were never looked up through the i18n system, so switching the UI language left template content in Chinese.

## Fix

Make built-in template **display content** language-aware, resolved into the active UI language wherever templates are seeded/reconciled.

- **Strings → i18n**: eval template names, eval definition name/description, TODO template names, and TODO items now live in the `zh-TW` + `en` dictionaries in `src/i18n/messages.ts`. (TODO items are stored as a newline-joined string per template and split at build time.)
- **Builders replace static constants**: `PRESET_EVAL_DEFS` / `PRESET_EVAL_TEMPLATES` / `PRESET_TODO_TEMPLATES` → `buildPresetEvalDefs(t)` / `buildPresetEvalTemplates(t)` / `buildPresetTodoTemplates(t)`, plus `buildBuiltinEvalLabels(t)` to relabel the active evaluation set.
- **LLM prompts stay English** on purpose — the `prompt` field is model input, not UI, and already worked in both languages.
- **Re-resolve at every entry point**: store defaults, persist rehydrate (`merge`), and `templatesSync.loadFromFile` resolve built-ins into the persisted/current language; `updateSettings` re-localizes on language change — this is the **onboarding language-switch path** that triggered the report. Custom templates and custom evaluations (non-built-in ids) are always preserved.
- **No import cycle**: the pure `translate()` helper moved to `messages.ts` (store-independent) so presets/store can resolve strings without depending on the React store.

## Behavior

- Fresh user picks English in onboarding → built-in eval/TODO templates render in English.
- Existing installs **self-heal**: because built-ins are always re-sourced from the presets in the persisted language on the next load, the shared `templates.json` is rewritten in the correct language.
- The shared MCP `templates.json` contract is unchanged (still `EvalTemplate[]` / `TodoTemplate[]`).

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` (`tsc && vite build`) — succeeds