### PR TITLE
[refactor] tier-1 good-taste cleanups (dedup + remove sentinel)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,6 +7,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::audio::{microphone::Microphone, AudioSource};
+use crate::transcription::common::{LevelMeter, LEVEL_EVENT};
 use crate::transcription::{self, SttProvider, TranscribeConfig};
 
 /// Path to the shared templates file (app config dir). The local MCP server
@@ -73,26 +74,14 @@ pub fn start_mic_test(
     .map_err(|e| e.to_string())?;
 
     tauri::async_runtime::spawn(async move {
-        let mut peak: i32 = 0;
-        let mut n: u64 = 0;
+        // Reuse the shared metering primitive so peak/window logic lives in one place.
+        let mut meter = LevelMeter::new(app.clone(), "test");
         while let Some(chunk) = rx.recv().await {
-            for &s in &chunk {
-                peak = peak.max((s as i32).abs());
-            }
-            n += chunk.len() as u64;
-            if n >= 1600 {
-                let level = (peak as f32 / 32767.0).clamp(0.0, 1.0);
-                let _ = app.emit(
-                    "audio://level",
-                    serde_json::json!({ "source": "test", "level": level }),
-                );
-                peak = 0;
-                n = 0;
-            }
+            meter.push(&chunk);
         }
         // Channel closed → mic stopped; signal zero so the meter resets.
         let _ = app.emit(
-            "audio://level",
+            LEVEL_EVENT,
             serde_json::json!({ "source": "test", "level": 0.0 }),
         );
     });

--- a/src-tauri/src/transcription/common.rs
+++ b/src-tauri/src/transcription/common.rs
@@ -170,7 +170,8 @@ pub struct SegmentBuilder {
     app: AppHandle,
     source: &'static str,
     seg_index: u64,
-    cur_speaker: i64, // -1 = no open run
+    /// Speaker of the open run, or `None` when no run is open.
+    cur_speaker: Option<i64>,
     cur_final: String,
     cur_start: u64,
     cur_end: u64,
@@ -182,7 +183,7 @@ impl SegmentBuilder {
             app,
             source,
             seg_index: 0,
-            cur_speaker: -1,
+            cur_speaker: None,
             cur_final: String::new(),
             cur_start: 0,
             cur_end: 0,
@@ -191,7 +192,7 @@ impl SegmentBuilder {
 
     /// The current open run's speaker (0 if none open) — useful for tail labels.
     pub fn current_speaker(&self) -> i64 {
-        self.cur_speaker.max(0)
+        self.cur_speaker.unwrap_or(0)
     }
 
     /// The end timestamp of the current open run — useful as a tail start.
@@ -203,16 +204,20 @@ impl SegmentBuilder {
     /// (emitting it solid) and starts a new one. Whitespace is preserved as the
     /// adapter supplies it.
     pub fn push_final(&mut self, text: &str, speaker: i64, start_ms: u64, end_ms: u64) {
-        if self.cur_speaker == -1 {
-            self.cur_speaker = speaker;
-            self.cur_start = start_ms;
-        } else if speaker != self.cur_speaker {
-            if !self.cur_final.trim().is_empty() {
-                self.commit();
+        match self.cur_speaker {
+            None => {
+                self.cur_speaker = Some(speaker);
+                self.cur_start = start_ms;
             }
-            self.cur_speaker = speaker;
-            self.cur_final.clear();
-            self.cur_start = start_ms;
+            Some(cur) if speaker != cur => {
+                if !self.cur_final.trim().is_empty() {
+                    self.commit();
+                }
+                self.cur_speaker = Some(speaker);
+                self.cur_final.clear();
+                self.cur_start = start_ms;
+            }
+            Some(_) => {}
         }
         self.cur_final.push_str(text);
         self.cur_end = end_ms;
@@ -224,7 +229,7 @@ impl SegmentBuilder {
             &self.app,
             self.source,
             format!("{}-{}", self.source, self.seg_index),
-            self.cur_speaker,
+            self.current_speaker(),
             self.cur_final.clone(),
             true,
             self.cur_start,
@@ -241,7 +246,7 @@ impl SegmentBuilder {
                 &self.app,
                 self.source,
                 format!("{}-{}", self.source, self.seg_index),
-                self.cur_speaker,
+                self.current_speaker(),
                 self.cur_final.clone(),
                 true,
                 self.cur_start,
@@ -270,7 +275,7 @@ impl SegmentBuilder {
         if !self.cur_final.trim().is_empty() {
             self.commit();
         }
-        self.cur_speaker = -1;
+        self.cur_speaker = None;
         self.cur_final.clear();
     }
 }

--- a/src/lib/transcription/providers.ts
+++ b/src/lib/transcription/providers.ts
@@ -1,4 +1,5 @@
 import type { Settings, SttProviderId } from "../types";
+import { PROVIDER_BY_ID } from "../ai/providers";
 
 /**
  * Single source of truth for speech-to-text providers, mirroring the Rust
@@ -18,13 +19,22 @@ export interface SttProviderInfo {
   icon: string;
 }
 
+/**
+ * OpenAI / Gemini transcription share everything but diarization with their LLM
+ * provider (same brand, same API key), so borrow their identity from the single
+ * LLM registry instead of duplicating it here.
+ */
+function fromLlm(id: "openai" | "gemini"): Omit<SttProviderInfo, "diarization"> {
+  const p = PROVIDER_BY_ID[id];
+  return { id, label: p.label, apiKeyField: p.apiKeyField, keyPlaceholder: p.keyPlaceholder, icon: p.icon };
+}
+
 export const STT_PROVIDERS: SttProviderInfo[] = [
   { id: "soniox", label: "Soniox", diarization: true, apiKeyField: "sonioxApiKey", keyPlaceholder: "…", icon: "/providers/soniox.png" },
   { id: "deepgram", label: "Deepgram", diarization: true, apiKeyField: "deepgramApiKey", keyPlaceholder: "…", icon: "/providers/deepgram.png" },
   { id: "assemblyai", label: "AssemblyAI", diarization: false, apiKeyField: "assemblyaiApiKey", keyPlaceholder: "…", icon: "/providers/assemblyai.png" },
-  // OpenAI / Gemini transcription reuse the same key as their LLM provider.
-  { id: "openai", label: "OpenAI", diarization: false, apiKeyField: "openaiApiKey", keyPlaceholder: "sk-…", icon: "/providers/openai.png" },
-  { id: "gemini", label: "Gemini", diarization: false, apiKeyField: "geminiApiKey", keyPlaceholder: "AIza…", icon: "/providers/gemini.png" },
+  { ...fromLlm("openai"), diarization: false },
+  { ...fromLlm("gemini"), diarization: false },
 ];
 
 export const STT_BY_ID = Object.fromEntries(STT_PROVIDERS.map((p) => [p.id, p])) as Record<

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -67,10 +67,6 @@ export function SettingsApp() {
   const [newTplName, setNewTplName] = useState("");
   const [templatesPath, setTemplatesPath] = useState("");
   const [mcpInfo, setMcpInfo] = useState<McpServerInfo | null>(null);
-  const [copiedConfig, setCopiedConfig] = useState(false);
-  const [copiedPath, setCopiedPath] = useState(false);
-  const [copiedUrl, setCopiedUrl] = useState(false);
-  const [copiedCli, setCopiedCli] = useState(false);
   const info = PROVIDER_BY_ID[settings.provider];
   const providerLabel = info.label;
   const sttInfo = STT_BY_ID[settings.transcriptionProvider];
@@ -554,23 +550,12 @@ export function SettingsApp() {
                     {mcpInfo?.endpoint || t("settings.mcp.endpointPending")}
                   </p>
                   {mcpInfo?.endpoint && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-6 shrink-0 text-muted-foreground"
+                    <CopyButton
+                      iconOnly
+                      value={mcpInfo.endpoint}
                       title={t("settings.mcp.copyUrl")}
-                      onClick={() => {
-                        navigator.clipboard.writeText(mcpInfo.endpoint);
-                        setCopiedUrl(true);
-                        setTimeout(() => setCopiedUrl(false), 2000);
-                      }}
-                    >
-                      {copiedUrl ? (
-                        <Check className="size-3 text-emerald-500" />
-                      ) : (
-                        <Copy className="size-3" />
-                      )}
-                    </Button>
+                      className="size-6 shrink-0 text-muted-foreground"
+                    />
                   )}
                 </div>
               </div>
@@ -583,60 +568,25 @@ export function SettingsApp() {
                   value={templatesPath || mcpInfo?.templates_path || "Loading..."}
                   className="bg-muted/30 font-mono text-xs"
                 />
-                <Button
-                  variant="outline"
-                  size="sm"
+                <CopyButton
                   className="h-9 shrink-0 gap-1"
-                  onClick={() => {
-                    navigator.clipboard.writeText(templatesPath || mcpInfo?.templates_path || "");
-                    setCopiedPath(true);
-                    setTimeout(() => setCopiedPath(false), 2000);
-                  }}
+                  value={templatesPath || mcpInfo?.templates_path || ""}
+                  label={t("settings.mcp.copyPath")}
                   disabled={!templatesPath && !mcpInfo?.templates_path}
-                >
-                  {copiedPath ? (
-                    <>
-                      <Check className="size-3.5 text-emerald-500" />
-                      <span>{t("settings.mcp.copied")}</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="size-3.5" />
-                      <span>{t("settings.mcp.copyPath")}</span>
-                    </>
-                  )}
-                </Button>
+                />
               </div>
             </Field>
 
             <div className="flex flex-col gap-3 rounded-lg border bg-muted/20 p-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-xs font-semibold tracking-tight">{t("settings.mcp.claudeCodeInstructions")}</h3>
-                <Button
-                  variant="outline"
-                  size="sm"
+                <CopyButton
                   className="h-8 gap-1"
-                  onClick={() => {
-                    const endpoint = mcpInfo?.endpoint || "http://127.0.0.1:3011/mcp";
-                    navigator.clipboard.writeText(
-                      `claude mcp add --transport http parley-templates ${endpoint}`
-                    );
-                    setCopiedCli(true);
-                    setTimeout(() => setCopiedCli(false), 2000);
-                  }}
-                >
-                  {copiedCli ? (
-                    <>
-                      <Check className="size-3.5 text-emerald-500" />
-                      <span>{t("settings.mcp.copied")}</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="size-3.5" />
-                      <span>{t("settings.mcp.copyCommand")}</span>
-                    </>
-                  )}
-                </Button>
+                  value={() =>
+                    `claude mcp add --transport http parley-templates ${mcpInfo?.endpoint || "http://127.0.0.1:3011/mcp"}`
+                  }
+                  label={t("settings.mcp.copyCommand")}
+                />
               </div>
               <p className="text-[11px] text-muted-foreground">{t("settings.mcp.claudeCodeHelp")}</p>
               <pre className="rounded bg-muted p-2.5 font-mono text-xs text-foreground overflow-x-auto border">
@@ -647,41 +597,24 @@ export function SettingsApp() {
             <div className="flex flex-col gap-3 rounded-lg border bg-muted/20 p-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-xs font-semibold tracking-tight">{t("settings.mcp.configInstructions")}</h3>
-                <Button
-                  variant="outline"
-                  size="sm"
+                <CopyButton
                   className="h-8 gap-1"
-                  onClick={() => {
-                    const endpoint = mcpInfo?.endpoint || "http://127.0.0.1:3011/mcp";
-                    const configJson = JSON.stringify(
+                  value={() =>
+                    JSON.stringify(
                       {
                         mcpServers: {
                           "parley-templates": {
                             type: "http",
-                            url: endpoint,
+                            url: mcpInfo?.endpoint || "http://127.0.0.1:3011/mcp",
                           },
                         },
                       },
                       null,
                       2
-                    );
-                    navigator.clipboard.writeText(configJson);
-                    setCopiedConfig(true);
-                    setTimeout(() => setCopiedConfig(false), 2000);
-                  }}
-                >
-                  {copiedConfig ? (
-                    <>
-                      <Check className="size-3.5 text-emerald-500" />
-                      <span>{t("settings.mcp.copied")}</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="size-3.5" />
-                      <span>{t("settings.mcp.copyConfig")}</span>
-                    </>
-                  )}
-                </Button>
+                    )
+                  }
+                  label={t("settings.mcp.copyConfig")}
+                />
               </div>
               <p className="text-[11px] text-muted-foreground">{t("settings.mcp.configHelp")}</p>
               <pre className="rounded bg-muted p-2.5 font-mono text-xs text-foreground overflow-x-auto border">
@@ -705,6 +638,54 @@ export function SettingsApp() {
         )}
       </div>
     </div>
+  );
+}
+
+/** Copy-to-clipboard button with a 2s "copied" confirmation. */
+function CopyButton({
+  value,
+  label,
+  title,
+  className,
+  iconOnly,
+  disabled,
+}: {
+  /** Text to copy, or a thunk evaluated at click time for computed values. */
+  value: string | (() => string);
+  label?: string;
+  title?: string;
+  className?: string;
+  iconOnly?: boolean;
+  disabled?: boolean;
+}) {
+  const { t } = useI18n();
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(typeof value === "function" ? value() : value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  if (iconOnly) {
+    return (
+      <Button variant="ghost" size="icon" className={className} title={title} disabled={disabled} onClick={copy}>
+        {copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
+      </Button>
+    );
+  }
+  return (
+    <Button variant="outline" size="sm" className={className} title={title} disabled={disabled} onClick={copy}>
+      {copied ? (
+        <>
+          <Check className="size-3.5 text-emerald-500" />
+          <span>{t("settings.mcp.copied")}</span>
+        </>
+      ) : (
+        <>
+          <Copy className="size-3.5" />
+          <span>{label}</span>
+        </>
+      )}
+    </Button>
   );
 }
 


### PR DESCRIPTION
## Context

A clean-architecture / "good taste" (Linus: *simple but elegant*) review of the whole project. **Verdict: the codebase is already clean and pragmatic for its size — no rewrite warranted.** Most reviewer suggestions (IPC adapter layers, strategy traits, an `SttAdapter` trait, an `initializeApp()` wrapper) were rejected as over-engineering for an app this size.

This PR is the **Tier-1** subset: only the changes that genuinely reduce code, kill duplication, or remove a special-case — all low-risk, **no behavior change**.

## Changes

- **`SettingsApp.tsx`** — extract one `<CopyButton>` component. Removes 4 parallel `copied*` `useState` flags and 4 duplicated "copy + 2s confirmation" closures.
- **`transcription/providers.ts`** — OpenAI/Gemini STT entries now derive their brand metadata (label, icon, API-key field, placeholder) from the single LLM provider registry instead of hand-duplicating it. One source of truth; no drift.
- **`commands.rs`** — `start_mic_test` reuses the shared `LevelMeter` instead of reimplementing peak/window metering inline (same 16kHz/10 window, same `{source, level}` payload).
- **`common.rs`** — `SegmentBuilder` uses `Option<i64>` instead of a `-1` "no open run" sentinel, removing the special-case comparisons.

## Explicitly *not* done (would be bad taste here)

- IPC `backends/` adapter layer, `initializeApp()` indirection, transcription-provider trait extraction, strategy-pattern traits — speculative abstraction for an app this size.
- "Fixing" `upsertSegment`'s append-vs-replace branch — the current form is the faster one on a hot path.
- `apiKeyField` is already compile-time-checked via `keyof Settings` — left as-is.

## Verification

`npx tsc --noEmit`, `npm run build`, `cargo check`, and `cargo clippy` all clean.