### PR TITLE
[fix] release: build Apple Silicon-only with native Opus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,19 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: aarch64-apple-darwin
+
+      - name: Install Opus (for audiopus_sys)
+        # Apple Silicon-only build: install a native arm64 libopus so audiopus_sys
+        # links it via pkg-config instead of compiling Opus from source. (Building
+        # Opus from source does NOT cross-compile cleanly, which is why the universal
+        # build's x86_64 slice failed to link `_opus_decode` &c.) autotools is kept as
+        # a fallback in case the source path is taken anyway; Homebrew names libtoolize
+        # `glibtoolize` (libtool is keg-only on macOS), so expose it under that name.
+        run: |
+          set -euxo pipefail
+          brew install opus pkg-config autoconf automake libtool
+          ln -sf "$(brew --prefix libtool)/bin/glibtoolize" "$(brew --prefix)/bin/libtoolize"
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -93,5 +105,5 @@ jobs:
           releaseDraft: false
           prerelease: false
           tauriScript: bun run tauri
-          args: --target universal-apple-darwin
+          args: --target aarch64-apple-darwin
           releaseAssetNamePattern: "[name]-[version]-[platform]-[arch].[ext]"


### PR DESCRIPTION
## Problem
The macOS release has been broken since `audiopus_sys` (libopus bindings) landed in #20. `v0.2.0` (pre-Opus) built fine, but **`v0.3.0` and `v0.4.0` both failed** — neither produced an artifact.

Two failures, in order:
1. `audiopus_sys` fell back to compiling libopus from source and the runner had no `autoreconf`.
2. With autotools installed, the from-source Opus build **does not cross-compile** — it built arm64 objects for the x86_64 slice of the universal build, so linking failed: `Undefined symbols for architecture x86_64: _opus_decode, _opus_encoder_create…`.

## Fix
Per maintainer decision, **build Apple Silicon (aarch64) only** and install a **native arm64 libopus** via Homebrew so `audiopus_sys` links it through pkg-config (no from-source build, no cross-compile). One native DMG, reliable. Intel Macs are no longer targeted.

## Validation
Re-dispatched the `v0.4.0` build from this branch (run 27929958900). Merging once it's green so future tag-triggered releases work.