### PR TITLE
[feature] persist resizable panel proportions to localStorage

### DIFF
--- a/src/components/live/LiveScreen.tsx
+++ b/src/components/live/LiveScreen.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+import { useDefaultLayout } from "react-resizable-panels";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -20,24 +22,39 @@ export function LiveScreen() {
   const showTranscript = layout !== "assistant";
   const showEvals = layout !== "transcript";
 
+  // Persist the dragged column proportions to localStorage. `panelIds` makes the
+  // library store a separate layout per visible set, so each preset (full /
+  // assistant / transcript) keeps its own sizes — no reset on reload. key=layout
+  // remounts the group on a preset switch so the saved sizes re-apply in-session too.
+  const panelIds = useMemo(
+    () => [...(showTranscript ? ["transcript"] : []), "work", ...(showEvals ? ["findings"] : [])],
+    [showTranscript, showEvals]
+  );
+  const saved = useDefaultLayout({ id: "parley:live", panelIds, storage: window.localStorage });
+
   return (
-    // key=layout remounts the group so panel sizes reset cleanly on change.
-    <ResizablePanelGroup key={layout} orientation="horizontal" className="min-h-0 flex-1">
+    <ResizablePanelGroup
+      key={layout}
+      orientation="horizontal"
+      className="min-h-0 flex-1"
+      defaultLayout={saved.defaultLayout}
+      onLayoutChanged={saved.onLayoutChanged}
+    >
       {showTranscript && (
         <>
-          <ResizablePanel defaultSize={26} minSize={15}>
+          <ResizablePanel id="transcript" defaultSize={26} minSize={15}>
             <MeetingView />
           </ResizablePanel>
           <ResizableHandle withHandle />
         </>
       )}
-      <ResizablePanel defaultSize={showTranscript && showEvals ? 46 : 60} minSize={30}>
+      <ResizablePanel id="work" defaultSize={showTranscript && showEvals ? 46 : 60} minSize={30}>
         <WorkPanel />
       </ResizablePanel>
       {showEvals && (
         <>
           <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={28} minSize={18}>
+          <ResizablePanel id="findings" defaultSize={28} minSize={18}>
             <FindingsPanel mode="live" onSeek={setHighlightMs} />
           </ResizablePanel>
         </>

--- a/src/components/replay/ReplayScreen.tsx
+++ b/src/components/replay/ReplayScreen.tsx
@@ -1,3 +1,4 @@
+import { useDefaultLayout } from "react-resizable-panels";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -52,6 +53,10 @@ export function ReplayScreen() {
   const evalTemplates = useStore((s) => s.settings.evalTemplates);
   const evaluations = useStore((s) => s.settings.evaluations);
   const analyzedEvalSig = useStore((s) => s.analyzedEvalSig);
+
+  // Persist the dragged column proportions (transcript / center / findings) to
+  // localStorage so they survive reloads.
+  const saved = useDefaultLayout({ id: "parley:replay", storage: window.localStorage });
 
   if (!session) {
     return (
@@ -114,8 +119,13 @@ export function ReplayScreen() {
         stale={templateStale}
       />
 
-      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
-        <ResizablePanel defaultSize={42} minSize={24}>
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="min-h-0 flex-1"
+        defaultLayout={saved.defaultLayout}
+        onLayoutChanged={saved.onLayoutChanged}
+      >
+        <ResizablePanel id="transcript" defaultSize={42} minSize={24}>
           <div className="flex h-full min-h-0 flex-col">
             <div className="flex h-9 shrink-0 items-center border-b px-4">
               <span className="text-xs font-medium text-foreground">{t("replay.transcript")}</span>
@@ -137,7 +147,7 @@ export function ReplayScreen() {
 
         <ResizableHandle withHandle />
 
-        <ResizablePanel defaultSize={34} minSize={22}>
+        <ResizablePanel id="center" defaultSize={34} minSize={22}>
           <Tabs defaultValue="actions" className="flex h-full min-h-0 flex-col gap-0">
             <div className="px-3 pt-2.5">
               <TabsList className="w-full">
@@ -156,7 +166,7 @@ export function ReplayScreen() {
 
         <ResizableHandle withHandle />
 
-        <ResizablePanel defaultSize={24} minSize={18}>
+        <ResizablePanel id="findings" defaultSize={24} minSize={18}>
           <FindingsPanel mode="replay" onSeek={player.seek} />
         </ResizablePanel>
       </ResizablePanelGroup>


### PR DESCRIPTION
## What
The **Live** (recording) and **Replay** (analysis) screens use `react-resizable-panels`, but neither set up persistence — so the column widths you drag reset to the defaults on every reload. This wires up persistence so your layout proportions stick.

## How
Uses the library's v4 `useDefaultLayout` hook (`defaultLayout` + `onLayoutChanged`, storage = `localStorage`) with stable panel `id`s. Verified against the package source: layouts are stored under `react-resizable-panels:<id>`, and when `panelIds` is supplied the panel ids are appended to the key — so conditionally-rendered panels get their own entry.

- **Replay**: one saved layout — transcript / center / findings (key `parley:replay`).
- **Live**: `panelIds` makes each layout preset (`full` / `assistant` / `transcript`) keep its **own** proportions under its own key; `key={layout}` remounts the group on a preset switch so saved sizes re-apply in-session too, not just on reload.

No new dependency, no store/schema changes — the library handles read/write to localStorage.

## Testing
- `bunx tsc --noEmit` clean
- `bun run test` 70/70 pass
- `bun run build` (tsc + vite) succeeds
- Confirmed the storage-key + `panelIds` behavior by reading the installed package implementation