### PR TITLE
[fix] macOS: proper ad-hoc signing so downloads aren't "damaged"

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -8,5 +8,10 @@
 	<!-- Allow the JIT/dynamic codegen the webview needs under hardened runtime. -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<!-- The ONNX Runtime dylib is loaded dynamically at runtime (via ORT_DYLIB_PATH)
+	     and is signed with a different (ad-hoc) identity than the app; without this,
+	     library validation under the hardened runtime would refuse to load it. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,8 @@
       "onnxruntime/libonnxruntime.dylib"
     ],
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "signingIdentity": "-"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Problem
Downloaded builds open with **"Parley is damaged and can't be opened"** (a hard block), not the bypassable security warning.

**Root cause (verified on the shipped v0.5.0 DMG):** the app is only **"linker-signed"** — `flags=0x20002(adhoc,linker-signed)`, the minimal signature the Rust linker auto-adds. That signature is **invalid as a bundle**:
```
codesign --verify --deep --strict Parley.app
→ "code has no resources but signature indicates they must be present"
```
macOS treats an *invalid* signature on a quarantined download as **"damaged"** (hard block). An app with a *valid* signature — even ad-hoc — gets the **bypassable** "Apple cannot check it for malicious software" prompt instead.

## Fix (no Apple Developer account needed)
- `tauri.conf.json` → `bundle.macOS.signingIdentity: "-"`: Tauri now properly codesigns the whole bundle (ad-hoc) instead of leaving the linker default.
- `entitlements.plist` → add `com.apple.security.cs.disable-library-validation`: the ONNX Runtime dylib is loaded dynamically (`ORT_DYLIB_PATH`) and signed with a different identity; without this, library validation under the hardened runtime (which proper signing enables) would refuse to load it → broken diarization.

## Result
- `codesign --verify --deep --strict` → **valid on disk / satisfies its Designated Requirement**
- Quarantined download → bypassable **right-click → Open** instead of "damaged".

## Verification
Re-signed the actual shipped v0.5.0 bundle with this exact config (adhoc + hardened runtime + these entitlements): signature verifies valid, flags `0x10002(adhoc,runtime)`, all three entitlements applied. (For a later **zero-warning** experience, this composes with a Developer ID cert + notarization — a separate, paid step.)