### PR TITLE
[fix] onboarding: live-refresh permission status on focus

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -41,8 +41,24 @@ export function Onboarding() {
     }
   }
 
+  // Permissions step (4): re-check on entry AND whenever the app regains focus /
+  // becomes visible, plus a slow fallback poll — so granting mic/screen access in
+  // the system prompt or System Settings flips the row to ✓ on its own when the
+  // user comes back, instead of staying stale until a manual re-check. (Webview
+  // focus events aren't fully reliable across the app-switch to System Settings,
+  // hence the 2 s poll; it stops when the user leaves the step.)
   useEffect(() => {
-    if (step === 4) void recheck();
+    if (step !== 4) return;
+    void recheck();
+    const recheckNow = () => void recheck();
+    window.addEventListener("focus", recheckNow);
+    document.addEventListener("visibilitychange", recheckNow);
+    const id = window.setInterval(recheckNow, 2000);
+    return () => {
+      window.removeEventListener("focus", recheckNow);
+      document.removeEventListener("visibilitychange", recheckNow);
+      window.clearInterval(id);
+    };
   }, [step]);
 
   function finish() {


### PR DESCRIPTION
## Problem
On the onboarding **Permissions** step, granting microphone (or screen-recording) access in the system prompt / System Settings didn't update the row — it stayed showing "not authorized" until you manually hit **Re-check**.

## Cause
The step only re-checked permissions on *entry* (`useEffect` keyed on `step === 4`). When you switch to System Settings, grant, and come back, nothing triggers a re-check.

## Fix
Re-check on **window focus** + **visibilitychange**, plus a **2 s fallback poll** while on the step (webview focus events aren't fully reliable across the app-switch). The Rust `microphone_status()` reads the live `AVCaptureDevice` authorization status, so the re-check reflects the grant immediately and the row flips to ✓ on its own. The poll is torn down when leaving the step.

## Testing
`bunx tsc --noEmit` clean · `bun run build` succeeds.