### PR TITLE
[fix] mic level meter dead during diarized meetings

### DIFF
--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -5,9 +5,11 @@
 
 use std::collections::VecDeque;
 
+use tauri::AppHandle;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::TARGET_SAMPLE_RATE;
+use crate::transcription::common::LevelMeter;
 
 /// Drop the oldest samples once a side backs up beyond this (the other side
 /// stalled). Bounds memory and keeps the two streams roughly time-aligned.
@@ -15,12 +17,16 @@ const MAX_BACKLOG: usize = TARGET_SAMPLE_RATE as usize * 2; // 2 seconds
 
 /// Sum `rx_a` and `rx_b` sample-by-sample into `tx_out` until both close.
 /// Mixes only where both sides have data; once one side ends, the remainder of
-/// the other passes through untouched.
+/// the other passes through untouched. The mic side (`rx_a`) is metered and
+/// emitted as the "me" input level so the header mic meter still moves even though
+/// mic + system are merged into a single (diarized) transcription session.
 pub async fn mix_streams(
+    app: AppHandle,
     mut rx_a: UnboundedReceiver<Vec<i16>>,
     mut rx_b: UnboundedReceiver<Vec<i16>>,
     tx_out: UnboundedSender<Vec<i16>>,
 ) {
+    let mut mic_meter = LevelMeter::new(app, "me");
     let mut a: VecDeque<i16> = VecDeque::new();
     let mut b: VecDeque<i16> = VecDeque::new();
     let mut a_open = true;
@@ -29,7 +35,10 @@ pub async fn mix_streams(
     while a_open || b_open {
         tokio::select! {
             chunk = rx_a.recv(), if a_open => match chunk {
-                Some(c) => a.extend(c),
+                Some(c) => {
+                    mic_meter.push(&c);
+                    a.extend(c);
+                }
                 None => a_open = false,
             },
             chunk = rx_b.recv(), if b_open => match chunk {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -142,7 +142,7 @@ pub fn start_meeting(
             match (rx_me, rx_them) {
                 (Some(a), Some(b)) => {
                     let (tx_mix, rx_mix) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
-                    tauri::async_runtime::spawn(crate::audio::mixer::mix_streams(a, b, tx_mix));
+                    tauri::async_runtime::spawn(crate::audio::mixer::mix_streams(app.clone(), a, b, tx_mix));
                     run_metered_session(&app, provider, make_config(), "mix", rx_mix);
                 }
                 // If one capture failed, transcribe whichever started.


### PR DESCRIPTION
## Problem
During a live meeting the header **mic level bar** doesn't move, even though transcription works.

## Cause
The header mounts `<LevelMeter source="me">` (TitleBar.tsx:183). With a **diarizing provider** (the default), `start_meeting` merges mic + system into a single `"mix"` transcription session ([commands.rs:139-146](src-tauri/src/commands.rs)) and the level meter is created for source `"mix"` — so `audio://level` events are tagged `"mix"`, never `"me"`. The header's `"me"` listener gets nothing → dead bar. (Non-diarizing mode keeps separate `"me"`/`"them"` sessions, so it worked there.)

## Fix
Meter the **mic stream itself** as `"me"` inside the mixer (which already receives the mic as `rx_a`), so the header bar reflects the user's actual mic regardless of capture mode. The `"mix"` session still meters separately; the header just listens for `"me"`.

## Testing
`cargo check` clean. (Runtime: with the default diarizing provider, the bar now tracks your mic; the bar is mic-only, not mic+counterpart.)