### PR TITLE
[feature] auto-update: in-app updater (launch banner + Settings check)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,11 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Updater artifact signing (minisign) — lets the app verify auto-updates
+          # against the pubkey in tauri.conf.json. tauri-action signs the bundle and
+          # attaches `latest.json` to the release when these are present.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ steps.release.outputs.tag }}
           releaseName: "Parley ${{ steps.release.outputs.tag }}"

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,8 @@
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-log": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "ai": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -449,6 +451,10 @@
     "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.8.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-log": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "ai": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,7 +860,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -1010,6 +1019,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1344,6 +1364,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2281,6 +2311,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2652,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2995,6 +3061,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,7 +3135,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive",
@@ -3102,6 +3180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,6 +3221,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3223,6 +3321,8 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tokio",
  "tokio-tungstenite",
  "uuid",
@@ -3802,15 +3902,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3968,6 +4073,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +4093,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4016,6 +4160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4080,6 +4233,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4352,6 +4528,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -4750,7 +4936,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk 0.9.0",
@@ -4790,6 +4976,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,7 +5010,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "http-range",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5012,6 +5209,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,7 +5261,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5044,7 +5284,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5964,6 +6204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6654,7 +6903,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk 0.9.0",
  "objc2",
@@ -6708,6 +6957,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6872,6 +7131,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
+tauri-plugin-process = "2"
+tauri-plugin-updater = "2"
 log = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,8 @@
     "core:window:allow-start-dragging",
     "core:event:allow-emit",
     "core:event:allow-emit-to",
-    "core:event:allow-listen"
+    "core:event:allow-listen",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,8 @@ pub fn run() {
         )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(MeetingState::default())
         // Native menu-bar "Diagnostics" submenu (View Logs + Clear Cache).
         .menu(|handle| menu::build(handle))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,8 +31,17 @@
       }
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/pathorsAI/parley/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI5N0Y3QzdENTkyMjg1NUUKUldSZWhTSlpmWHgvdWIyMlQ3MGlxM2JURm9JRlZFNG9nZHRnZmdnTUc2YXJQbS9qZXVmbkYydVMK"
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "resources": [
       "onnxruntime/libonnxruntime.dylib"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { LiveScreen } from "./components/live/LiveScreen";
 import { ReplayScreen } from "./components/replay/ReplayScreen";
 import { Onboarding } from "./components/Onboarding";
 import { AnalysisErrorDialog } from "./components/AnalysisErrorDialog";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { IngestWizard } from "./components/IngestWizard";
 import { FindingSolutionWindow } from "./components/analysis/FindingSolutionWindow";
 import { useFindingSolutionHost } from "./components/analysis/useFindingSolutionHost";
@@ -19,6 +20,7 @@ import { useThemePreference } from "./lib/theme";
 import { useAnalysisEngine, listenForCacheClear } from "./lib/analysis/engine";
 import { listenForSpeakerCacheClear } from "./lib/speakers/namesCache";
 import { listenForHistoryOpen, listenForRecordingSaved } from "./lib/history/history";
+import { checkForUpdate } from "./lib/update";
 
 function App() {
   useThemePreference();
@@ -52,6 +54,13 @@ function App() {
     };
   }, []);
 
+  // Check for an app update shortly after launch — surfaces a dismissible banner
+  // only; applying is always user-initiated, so it never interrupts a meeting.
+  useEffect(() => {
+    const id = setTimeout(() => void checkForUpdate({ silent: true }), 3000);
+    return () => clearTimeout(id);
+  }, []);
+
   // LIVE background engine: optional auto-analyze interval + TODO agenda auto-check.
   useAnalysisEngine();
 
@@ -62,6 +71,7 @@ function App() {
     <div className="flex h-screen flex-col bg-background text-foreground">
       {!onboarded && <Onboarding />}
       <AnalysisErrorDialog />
+      <UpdateBanner />
       <IngestWizard />
       {/* In the Tauri app the drilldown is its own OS window (see
           useFindingSolutionHost); in plain browser dev we fall back to the

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { Download, Loader2, X } from "lucide-react";
+import { useStore } from "../lib/store";
+import { applyPendingUpdate } from "../lib/update";
+import { useI18n } from "../i18n";
+
+/**
+ * Non-intrusive "update available" banner just under the TitleBar. Shown when an
+ * update was found (on launch or via Settings); applying is always user-initiated
+ * — it downloads, installs, and relaunches, so it never interrupts a meeting on
+ * its own. Dismissible until the next check.
+ */
+export function UpdateBanner() {
+  const { t } = useI18n();
+  const update = useStore((s) => s.update);
+  const setUpdate = useStore((s) => s.setUpdate);
+  const [busy, setBusy] = useState(false);
+  const [pct, setPct] = useState(0);
+
+  if (!update) return null;
+
+  async function apply() {
+    setBusy(true);
+    try {
+      await applyPendingUpdate(setPct); // relaunches on success — never returns
+    } catch (e) {
+      console.error("[update] apply failed", e);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-[60px] z-50 flex justify-center">
+      <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-sky-500/40 bg-sky-500/10 px-3.5 py-1.5 text-xs font-medium text-sky-700 shadow-sm backdrop-blur animate-in fade-in-0 slide-in-from-top-2 dark:text-sky-200">
+        <Download className="size-3.5 shrink-0" />
+        <span>{t("update.available", { version: update.version })}</span>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void apply()}
+          className="rounded-full bg-sky-600 px-2.5 py-0.5 text-[11px] font-semibold text-white transition-colors hover:bg-sky-500 disabled:opacity-60"
+        >
+          {busy ? (
+            <span className="flex items-center gap-1">
+              <Loader2 className="size-3 animate-spin" />
+              {pct > 0 ? `${pct}%` : t("update.updating")}
+            </span>
+          ) : (
+            t("update.restart")
+          )}
+        </button>
+        {!busy && (
+          <button
+            type="button"
+            onClick={() => setUpdate(null)}
+            className="shrink-0 opacity-60 transition-opacity hover:opacity-100"
+            aria-label={t("update.dismiss")}
+          >
+            <X className="size-3" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -494,6 +494,17 @@ export const zhTW = {
   "tpl.todo.todo-fundraising.name": "投資人簡報",
   "tpl.todo.todo-fundraising.items":
     "一句話講清楚在做什麼\n說明問題與市場規模\n展示產品\n商業模式與關鍵成長數據\n介紹團隊與為何是我們\n競爭與護城河\n募資金額與資金用途\n確認對方的投資範圍與決策流程",
+
+  // App auto-update
+  "update.available": "有新版本 {version} — 重新啟動以更新",
+  "update.restart": "更新並重啟",
+  "update.updating": "更新中…",
+  "update.dismiss": "關閉",
+  "update.found": "找到新版 {version}",
+  "update.upToDate": "已是最新版本",
+  "settings.update.title": "軟體更新",
+  "settings.update.check": "檢查更新",
+  "settings.update.help": "Parley 啟動時會自動檢查更新；有新版本時上方會出現橫幅，點「更新並重啟」即可。",
 } as const satisfies Dict;
 
 export const en = {
@@ -981,6 +992,17 @@ export const en = {
   "tpl.todo.todo-fundraising.name": "Investor pitch",
   "tpl.todo.todo-fundraising.items":
     "Explain what you do in one sentence\nLay out the problem and market size\nDemo the product\nBusiness model and key metrics (traction)\nIntroduce the team and why it's us\nCompetition and moat\nRaise amount and use of funds\nConfirm their investment range and decision process",
+
+  // App auto-update
+  "update.available": "Version {version} available — restart to update",
+  "update.restart": "Update & restart",
+  "update.updating": "Updating…",
+  "update.dismiss": "Dismiss",
+  "update.found": "Found {version}",
+  "update.upToDate": "You're up to date",
+  "settings.update.title": "Software updates",
+  "settings.update.check": "Check for updates",
+  "settings.update.help": "Parley checks for updates on launch; when one's available a banner appears up top — click Update & restart.",
 } as const satisfies Record<keyof typeof zhTW, string>;
 
 export const DICTS: Record<AppLanguage, Dict> = {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -260,6 +260,10 @@ interface ParleyState {
   highlightMs: number | null;
   setHighlightMs: (ms: number | null) => void;
 
+  /** An available app update (drives the banner prompt); null = none / up to date. */
+  update: { version: string; body: string } | null;
+  setUpdate: (update: { version: string; body: string } | null) => void;
+
   // todos
   addTodo: (text: string) => void;
   toggleTodo: (id: string) => void;
@@ -327,10 +331,12 @@ export const useStore = create<ParleyState>()(
       meetingTarget: "",
       meetingFloor: "",
       highlightMs: null,
+      update: null,
 
   setMeetingContext: (text) => set({ meetingContext: text }),
   setNegotiationField: (field, value) => set({ [field]: value }),
   setHighlightMs: (ms) => set({ highlightMs: ms }),
+  setUpdate: (update) => set({ update }),
 
   enterReplay: (session) => {
     log.info("store: enter replay", {

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -1,0 +1,62 @@
+import type { Update } from "@tauri-apps/plugin-updater";
+import { isTauri } from "./tauriEvents";
+import { useStore } from "./store";
+import { log } from "./log";
+
+/**
+ * In-app auto-updater. Checks the GitHub releases endpoint (see
+ * tauri.conf.json `plugins.updater`) for a newer SIGNED build, surfaces it as a
+ * dismissible banner, and — only on the user's click — downloads, verifies,
+ * installs, and relaunches. Never updates mid-meeting on its own.
+ */
+
+// The live Update handle (carries downloadAndInstall); not serializable, so it
+// lives here rather than in the store, which only holds the display info.
+let pending: Update | null = null;
+
+/**
+ * Check for an update. On a hit, stash the handle and publish `{version, body}`
+ * to the store so the banner shows. `silent` quiets the "up to date" log for the
+ * automatic launch check (vs. the manual Settings button). No-op outside Tauri.
+ */
+export async function checkForUpdate(opts?: { silent?: boolean }): Promise<{ version: string; body: string } | null> {
+  if (!isTauri()) return null;
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    const update = await check();
+    if (update) {
+      pending = update;
+      const info = { version: update.version, body: update.body ?? "" };
+      useStore.getState().setUpdate(info);
+      log.info("update: available", { version: update.version });
+      return info;
+    }
+    useStore.getState().setUpdate(null);
+    if (!opts?.silent) log.info("update: up to date");
+    return null;
+  } catch (e) {
+    // Network down / no release / endpoint hiccup — non-fatal, just don't prompt.
+    log.warn("update: check failed", { error: String(e) });
+    return null;
+  }
+}
+
+/**
+ * Download + verify + install the pending update, then relaunch into it.
+ * `onProgress` reports 0–100. Throws on failure (caller resets its busy state);
+ * on success the process relaunches and this never returns.
+ */
+export async function applyPendingUpdate(onProgress?: (pct: number) => void): Promise<void> {
+  if (!pending) return;
+  let total = 0;
+  let got = 0;
+  await pending.downloadAndInstall((e) => {
+    if (e.event === "Started") total = e.data.contentLength ?? 0;
+    else if (e.event === "Progress") {
+      got += e.data.chunkLength;
+      if (total > 0) onProgress?.(Math.min(100, Math.round((got / total) * 100)));
+    }
+  });
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  await relaunch();
+}

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -72,6 +72,8 @@ export function SettingsApp() {
   const [templatesPath, setTemplatesPath] = useState("");
   const [mcpInfo, setMcpInfo] = useState<McpServerInfo | null>(null);
   const [logPath, setLogPath] = useState("");
+  const [updateChecking, setUpdateChecking] = useState(false);
+  const [updateMsg, setUpdateMsg] = useState("");
   const info = PROVIDER_BY_ID[settings.provider];
   const providerLabel = info.label;
   const sttInfo = STT_BY_ID[settings.transcriptionProvider];
@@ -250,6 +252,29 @@ export function SettingsApp() {
               >
                 {t("settings.basic.rerunSetup")}
               </Button>
+            </Field>
+            <Field label={t("settings.update.title")}>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-fit text-xs"
+                  disabled={updateChecking}
+                  onClick={async () => {
+                    setUpdateChecking(true);
+                    setUpdateMsg("");
+                    const { checkForUpdate } = await import("../lib/update");
+                    const r = await checkForUpdate({ silent: false });
+                    setUpdateMsg(r ? t("update.found", { version: r.version }) : t("update.upToDate"));
+                    setUpdateChecking(false);
+                  }}
+                >
+                  {updateChecking ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
+                  {t("settings.update.check")}
+                </Button>
+                {updateMsg && <span className="text-[11px] text-muted-foreground">{updateMsg}</span>}
+              </div>
+              <p className="max-w-sm text-[11px] text-muted-foreground">{t("settings.update.help")}</p>
             </Field>
           </Section>
         )}


### PR DESCRIPTION
Adds Tauri's updater so users stop hand-downloading every release. On launch the app checks GitHub Releases for a newer **signed** build; if there is one, a dismissible banner appears under the TitleBar. Applying is always user-initiated (download → verify → install → relaunch), so it never updates mid-meeting.

## How it works
- `tauri-plugin-updater` + `tauri-plugin-process` (Rust + JS). Update artifacts are signed with a minisign key (separate from Apple signing); the app verifies against the pubkey baked into `tauri.conf.json`.
- Endpoint: `releases/latest/download/latest.json` on this repo. `bundle.createUpdaterArtifacts: true` + the CI now passes `TAURI_SIGNING_PRIVATE_KEY` / `…_PASSWORD` (already set as repo secrets) to `tauri-action`, which signs the `.app.tar.gz` and attaches `latest.json` to each release automatically.
- **UX:** launch check → banner (`update.*` i18n, zh-TW + en) + a **Check for updates** button in Settings → Basic. The banner shows download %.

## macOS note (the good part)
We're ad-hoc signed (not notarized), which is why *browser* downloads hit the "damaged"/Gatekeeper prompt — that comes from the `com.apple.quarantine` flag macOS puts on browser downloads. The updater downloads in-process, so the swapped bundle generally isn't quarantined → **auto-updates should apply cleanly without the prompt.** Only the first manual install hits Gatekeeper.

## Rollout caveat
The updater can only run from a build that contains it, so it goes live for users on **the first release cut after this merges (v0.6.4)** — that version still needs a one-time manual install, then every update after is in-app.

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 75/75
- `cargo check` — clean (0 errors, 0 warnings)
- Signing secrets `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` set on the repo; private key backed up locally for the maintainer.

Branched off latest `main` (v0.6.3, includes the history feature #40).