### PR TITLE
[feat] ui: native macOS window chrome for the main window

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["protocol-asset", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "core:window:allow-destroy",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-set-fullscreen",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:event:allow-emit",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,9 +18,11 @@
         "minWidth": 900,
         "minHeight": 600,
         "decorations": false,
+        "transparent": true,
         "shadow": true
       }
     ],
+    "macOSPrivateApi": true,
     "security": {
       "csp": null,
       "assetProtocol": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { TitleBar } from "./components/TitleBar";
 import { LiveScreen } from "./components/live/LiveScreen";
 import { ReplayScreen } from "./components/replay/ReplayScreen";
@@ -19,10 +19,44 @@ import { useThemePreference } from "./lib/theme";
 import { useAnalysisEngine, listenForCacheClear } from "./lib/analysis/engine";
 import { listenForSpeakerCacheClear } from "./lib/speakers/namesCache";
 
+/**
+ * Track main-window fullscreen state. Drives both the rounded corners (a
+ * fullscreen window fills the display edge-to-edge, so it squares off; a
+ * zoomed/maximized window is still a floating window and stays rounded) and the
+ * auto-hiding titlebar.
+ */
+function useFullscreen(): boolean {
+  const [fullscreen, setFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isTauri()) return;
+    let active = true;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const win = getCurrentWindow();
+      const sync = async () => {
+        const fs = await win.isFullscreen();
+        if (active) setFullscreen(fs);
+      };
+      await sync();
+      const un = await win.onResized(() => void sync());
+      if (active) unlisten = un;
+      else un();
+    })();
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+  return fullscreen;
+}
+
 function App() {
   useThemePreference();
   const appMode = useStore((s) => s.appMode);
   const onboarded = useStore((s) => s.settings.onboarded);
+  const fullscreen = useFullscreen();
+  const rounded = isTauri() && !fullscreen;
 
   useEffect(() => {
     const unTranscript = listenForTranscript();
@@ -54,7 +88,11 @@ function App() {
   useFindingSolutionHost();
 
   return (
-    <div className="flex h-screen flex-col bg-background text-foreground">
+    <div
+      className={`flex h-screen flex-col overflow-hidden bg-background text-foreground ${
+        rounded ? "rounded-[12px]" : ""
+      }`}
+    >
       {!onboarded && <Onboarding />}
       <AnalysisErrorDialog />
       <IngestWizard />
@@ -62,7 +100,7 @@ function App() {
           useFindingSolutionHost); in plain browser dev we fall back to the
           in-app overlay so the feature still works without multi-window. */}
       {!isTauri() && <FindingSolutionWindow />}
-      <TitleBar />
+      <TitleBar fullscreen={fullscreen} />
       {appMode === "replay" ? <ReplayScreen /> : <LiveScreen />}
     </div>
   );

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Circle, FileAudio, Loader2, LogOut, Maximize2, Mic, Minus, Settings, Square, X } from "lucide-react";
+import { Circle, FileAudio, Loader2, LogOut, Mic, Minus, Settings, Square, X } from "lucide-react";
 import { useStore } from "../lib/store";
 import { log } from "../lib/log";
 import { STT_BY_ID, sttApiKey } from "../lib/transcription/providers";
@@ -13,11 +13,49 @@ import { Button } from "@/components/ui/button";
 import { LevelMeter } from "./LevelMeter";
 
 /**
+ * Track main-window focus so the traffic lights can dim to grey when the window
+ * is inactive — matching native macOS behaviour. Defaults to focused (and stays
+ * focused in browser dev, where there's no window to query).
+ */
+function useWindowFocused(): boolean {
+  const [focused, setFocused] = useState(true);
+  useEffect(() => {
+    if (!isTauri()) return;
+    let active = true;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      const win = getCurrentWindow();
+      try {
+        const initial = await win.isFocused();
+        if (active) setFocused(initial);
+      } catch {
+        /* ignore — keep default */
+      }
+      const un = await win.onFocusChanged(({ payload }) => {
+        if (active) setFocused(payload);
+      });
+      if (active) unlisten = un;
+      else un();
+    })();
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+  return focused;
+}
+
+/**
  * Custom window titlebar. The main Tauri window is undecorated, so this header
  * owns both the draggable region and the window controls.
+ *
+ * In fullscreen there are no window controls (macOS hides the traffic lights and
+ * reveals its own menu bar at the top edge), so we drop our traffic lights and
+ * let the logo + brand sit at the leading edge.
  */
-export function TitleBar() {
+export function TitleBar({ fullscreen = false }: { fullscreen?: boolean }) {
   const { t } = useI18n();
+  const focused = useWindowFocused();
   const status = useStore((s) => s.meetingStatus);
   const transcriptionProvider = useStore((s) => s.settings.transcriptionProvider);
   const sttKey = useStore((s) => sttApiKey(s.settings, s.settings.transcriptionProvider));
@@ -102,13 +140,14 @@ export function TitleBar() {
     }
   }
 
-  async function controlWindow(action: "close" | "minimize" | "maximize") {
+  async function controlWindow(action: "close" | "minimize" | "fullscreen") {
     if (!isTauri()) return;
     const appWindow = getCurrentWindow();
     try {
       if (action === "close") await appWindow.close();
       if (action === "minimize") await appWindow.minimize();
-      if (action === "maximize") await appWindow.toggleMaximize();
+      // Native macOS maps the green button to full screen (not window zoom).
+      if (action === "fullscreen") await appWindow.setFullscreen(!(await appWindow.isFullscreen()));
     } catch (e) {
       log.warn("window: action failed", { action, error: String(e) });
     }
@@ -117,34 +156,64 @@ export function TitleBar() {
   return (
     <header
       data-tauri-drag-region
-      className="relative flex h-[52px] shrink-0 items-center justify-between border-b bg-background/85 pl-[104px] pr-3 backdrop-blur"
+      className={`relative flex h-[52px] shrink-0 items-center justify-between border-b bg-background/85 pr-3 backdrop-blur ${
+        fullscreen ? "pl-4" : "pl-[104px]"
+      }`}
     >
-      <div className="absolute left-4 top-1/2 flex -translate-y-1/2 items-center gap-2">
+      {/* macOS traffic lights: native sizing/colours, glyphs reveal on hover of
+          the whole cluster (not per-button), and the trio dims to grey when the
+          window loses focus — matching the system buttons. Hidden in fullscreen,
+          where macOS shows no window controls. */}
+      {!fullscreen && (
+      <div className="group/traffic absolute left-4 top-1/2 flex -translate-y-1/2 items-center gap-2">
         <button
           type="button"
           aria-label={t("titlebar.closeWindow")}
           onClick={() => void controlWindow("close")}
-          className="group grid size-3.5 place-items-center rounded-full bg-red-500 text-red-950 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18)] transition hover:bg-red-400"
+          className={`grid size-3 place-items-center rounded-full shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.14)] transition-colors ${
+            focused ? "bg-[#FF5F57]" : "bg-[#c7c7c9] group-hover/traffic:bg-[#FF5F57] dark:bg-[#565658]"
+          }`}
         >
-          <X className="size-2.5 opacity-0 transition-opacity group-hover:opacity-75" strokeWidth={3} />
+          <X
+            className="size-2 text-black/55 opacity-0 transition-opacity group-hover/traffic:opacity-100"
+            strokeWidth={3}
+          />
         </button>
         <button
           type="button"
           aria-label={t("titlebar.minimizeWindow")}
           onClick={() => void controlWindow("minimize")}
-          className="group grid size-3.5 place-items-center rounded-full bg-yellow-500 text-yellow-950 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18)] transition hover:bg-yellow-400"
+          className={`grid size-3 place-items-center rounded-full shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.14)] transition-colors ${
+            focused ? "bg-[#FEBC2E]" : "bg-[#c7c7c9] group-hover/traffic:bg-[#FEBC2E] dark:bg-[#565658]"
+          }`}
         >
-          <Minus className="size-2.5 opacity-0 transition-opacity group-hover:opacity-75" strokeWidth={3} />
+          <Minus
+            className="size-2 text-black/55 opacity-0 transition-opacity group-hover/traffic:opacity-100"
+            strokeWidth={3}
+          />
         </button>
         <button
           type="button"
-          aria-label={t("titlebar.maximizeWindow")}
-          onClick={() => void controlWindow("maximize")}
-          className="group grid size-3.5 place-items-center rounded-full bg-emerald-500 text-emerald-950 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18)] transition hover:bg-emerald-400"
+          aria-label={t("titlebar.fullscreenWindow")}
+          onClick={() => void controlWindow("fullscreen")}
+          className={`grid size-3 place-items-center rounded-full shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.14)] transition-colors ${
+            focused ? "bg-[#28C840]" : "bg-[#c7c7c9] group-hover/traffic:bg-[#28C840] dark:bg-[#565658]"
+          }`}
         >
-          <Maximize2 className="size-2 opacity-0 transition-opacity group-hover:opacity-75" strokeWidth={3} />
+          {/* Native zoom/fullscreen glyph: two filled triangles tucked into
+              opposite corners, leaving a diagonal gap — not lucide's thin
+              double-arrow, which reads wrong at this size. */}
+          <svg
+            viewBox="0 0 10 10"
+            aria-hidden
+            className="size-2 fill-current text-black/55 opacity-0 transition-opacity group-hover/traffic:opacity-100"
+          >
+            <path d="M1.4 1.4H6L1.4 6Z" />
+            <path d="M8.6 8.6H4L8.6 4Z" />
+          </svg>
         </button>
       </div>
+      )}
 
       <div data-tauri-drag-region className="flex items-center gap-2.5">
         <img src="/parley.svg" alt="" className="h-5 w-5 rounded-[5px]" />

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -67,6 +67,7 @@ export const zhTW = {
   "titlebar.closeWindow": "關閉視窗",
   "titlebar.minimizeWindow": "最小化視窗",
   "titlebar.maximizeWindow": "最大化視窗",
+  "titlebar.fullscreenWindow": "全螢幕",
 
   "settings.nav.basic": "基本設定",
   "settings.nav.provider": "模型供應商",
@@ -534,6 +535,7 @@ export const en = {
   "titlebar.closeWindow": "Close window",
   "titlebar.minimizeWindow": "Minimize window",
   "titlebar.maximizeWindow": "Maximize window",
+  "titlebar.fullscreenWindow": "Toggle full screen",
 
   "settings.nav.basic": "Basic Settings",
   "settings.nav.provider": "LLM Provider",

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,16 @@ body,
   margin: 0;
 }
 
+/* The main window is undecorated + transparent so the app shell can draw its
+   own rounded macOS-style corners (see App.tsx). Keep the surface transparent
+   so the corner notches reveal the desktop and macOS draws a rounded shadow.
+   Secondary windows use native decorations, so this is scoped to the main one. */
+html[data-app-window="main"],
+html[data-app-window="main"] body,
+html[data-app-window="main"] #root {
+  background: transparent;
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
@@ -165,26 +175,8 @@ textarea,
   }
 }
 
-/* Unlayered: wins over Tailwind's `cursor-default` utilities on shadcn parts.
-   Interactive controls get a pointer; disabled ones get not-allowed. */
-button:not(:disabled),
-[role="button"]:not([aria-disabled="true"]),
-[role="combobox"],
-[role="option"],
-[role="menuitem"],
-[role="menuitemradio"],
-[role="menuitemcheckbox"],
-[role="tab"],
-[role="switch"],
-[role="radio"],
-a[href],
-summary,
-select {
+/* Native-app cursor behaviour: controls use the default arrow, not the web
+   pointing-hand. Real text hyperlinks keep the pointer. */
+a[href] {
   cursor: pointer;
-}
-
-button:disabled,
-[aria-disabled="true"],
-[data-disabled] {
-  cursor: not-allowed;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,11 @@ const window_ = route.startsWith("settings")
       : "main";
 log.info("ui: boot", { window: window_ });
 
+// Scope window-chrome CSS to the right surface: only the main window is
+// undecorated + transparent (rounded macOS-style corners); the secondary
+// windows keep native decorations and an opaque background.
+document.documentElement.dataset.appWindow = window_;
+
 const SettingsApp = lazy(() =>
   import("./settings/SettingsApp").then((module) => ({ default: module.SettingsApp }))
 );


### PR DESCRIPTION
## What & why

The main window is undecorated (custom titlebar with our own controls), which on macOS left a hard rectangular frame and web-flavoured chrome. This makes the whole window feel native macOS.

## Changes

**Rounded corners**
- `tauri.conf`: main window `transparent: true` + `macOSPrivateApi: true` (required for transparent windows on macOS). `Cargo.toml` enables the `macos-private-api` feature. macOS derives a matching rounded drop shadow from the opaque content mask, so `shadow: true` still works.
- `main.tsx` tags `<html>` with `data-app-window` so the transparency CSS is scoped to the main window only — the Settings / Field Log / How-to-reply windows keep native decorations (already natively rounded).
- `App.tsx` rounds + clips the shell to ~12px, squared off **only in true fullscreen** (a zoomed/maximized window stays a rounded floating window, matching macOS).

**Traffic lights**
- Native sizing (12px) and exact colours (`#FF5F57` / `#FEBC2E` / `#28C840`); glyphs reveal on hover of the whole cluster (not per-button); the trio dims to grey when the window loses focus. Green uses the native two-triangle zoom glyph.

**Fullscreen (green button)**
- Maps the green button to full screen (not window zoom), matching native macOS; needs the `core:window:allow-set-fullscreen` capability. In fullscreen the traffic lights are dropped and the logo + brand move to the leading edge (macOS hides window controls and owns the top edge there).

**Cursor**
- Controls use the native arrow cursor instead of the web pointing-hand; only real text hyperlinks keep the pointer.

## Note on `macOSPrivateApi`
This flag blocks Mac App Store submission, but Parley is distributed as a direct-signed `.dmg` (ad-hoc signing identity), so it doesn't affect the release path.

## Test plan
- [x] `bun run tauri dev` builds and runs locally
- [x] Rounded 12px corners + native rounded shadow on the main window
- [x] Traffic lights: native colours/size, cluster-hover glyphs, grey-on-blur
- [x] Green button toggles fullscreen; corners square in fullscreen, restore on exit
- [x] Fullscreen hides traffic lights, logo/brand shifts to the leading edge
- [x] No pointing-hand cursor on buttons/controls
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)