### PR TITLE
[fix] updater: auto-relaunch after install + show current version

### DIFF
--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -16,6 +16,7 @@ export function UpdateBanner() {
   const setUpdate = useStore((s) => s.setUpdate);
   const [busy, setBusy] = useState(false);
   const [pct, setPct] = useState(0);
+  const [installedNeedsReopen, setInstalledNeedsReopen] = useState(false);
 
   if (!update) return null;
 
@@ -24,9 +25,31 @@ export function UpdateBanner() {
     try {
       await applyPendingUpdate(setPct); // relaunches on success — never returns
     } catch (e) {
+      // The update finished installing but the auto-relaunch failed — tell the
+      // user to reopen rather than silently resetting (the new version IS staged).
       console.error("[update] apply failed", e);
       setBusy(false);
+      setInstalledNeedsReopen(true);
     }
+  }
+
+  if (installedNeedsReopen) {
+    return (
+      <div className="pointer-events-none fixed inset-x-0 top-[60px] z-50 flex justify-center">
+        <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3.5 py-1.5 text-xs font-medium text-emerald-700 shadow-sm backdrop-blur dark:text-emerald-200">
+          <Download className="size-3.5 shrink-0" />
+          <span>{t("update.reopen")}</span>
+          <button
+            type="button"
+            onClick={() => setUpdate(null)}
+            className="shrink-0 opacity-60 transition-opacity hover:opacity-100"
+            aria-label={t("update.dismiss")}
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -502,7 +502,9 @@ export const zhTW = {
   "update.dismiss": "關閉",
   "update.found": "找到新版 {version}",
   "update.upToDate": "已是最新版本",
+  "update.reopen": "更新已安裝——請手動關閉並重新開啟 Parley 完成更新",
   "settings.update.title": "軟體更新",
+  "settings.update.current": "目前版本 v{version}",
   "settings.update.check": "檢查更新",
   "settings.update.help": "Parley 啟動時會自動檢查更新；有新版本時上方會出現橫幅，點「更新並重啟」即可。",
 } as const satisfies Dict;
@@ -1000,7 +1002,9 @@ export const en = {
   "update.dismiss": "Dismiss",
   "update.found": "Found {version}",
   "update.upToDate": "You're up to date",
+  "update.reopen": "Update installed — please quit and reopen Parley to finish",
   "settings.update.title": "Software updates",
+  "settings.update.current": "Current version v{version}",
   "settings.update.check": "Check for updates",
   "settings.update.help": "Parley checks for updates on launch; when one's available a banner appears up top — click Update & restart.",
 } as const satisfies Record<keyof typeof zhTW, string>;

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -1,4 +1,5 @@
-import type { Update } from "@tauri-apps/plugin-updater";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
 import { isTauri } from "./tauriEvents";
 import { useStore } from "./store";
 import { log } from "./log";
@@ -8,6 +9,13 @@ import { log } from "./log";
  * tauri.conf.json `plugins.updater`) for a newer SIGNED build, surfaces it as a
  * dismissible banner, and — only on the user's click — downloads, verifies,
  * installs, and relaunches. Never updates mid-meeting on its own.
+ *
+ * NOTE: `check` and `relaunch` are imported STATICALLY (not dynamically). A
+ * dynamic import of `relaunch` AFTER downloadAndInstall would try to fetch its JS
+ * chunk from the app bundle that the install just replaced on disk — the import
+ * then rejects and the app never restarts. Loading both at startup avoids
+ * touching the swapped bundle. They're side-effect-free in the browser (guarded
+ * by isTauri before any call), so this is safe in plain web dev too.
  */
 
 // The live Update handle (carries downloadAndInstall); not serializable, so it
@@ -22,7 +30,6 @@ let pending: Update | null = null;
 export async function checkForUpdate(opts?: { silent?: boolean }): Promise<{ version: string; body: string } | null> {
   if (!isTauri()) return null;
   try {
-    const { check } = await import("@tauri-apps/plugin-updater");
     const update = await check();
     if (update) {
       pending = update;
@@ -43,20 +50,23 @@ export async function checkForUpdate(opts?: { silent?: boolean }): Promise<{ ver
 
 /**
  * Download + verify + install the pending update, then relaunch into it.
- * `onProgress` reports 0–100. Throws on failure (caller resets its busy state);
- * on success the process relaunches and this never returns.
+ * `onProgress` reports 0–100. Throws on failure (the caller surfaces a "please
+ * reopen" fallback); on success the process relaunches and this never returns.
  */
 export async function applyPendingUpdate(onProgress?: (pct: number) => void): Promise<void> {
   if (!pending) return;
   let total = 0;
   let got = 0;
+  log.info("update: downloading + installing", { version: pending.version });
   await pending.downloadAndInstall((e) => {
     if (e.event === "Started") total = e.data.contentLength ?? 0;
     else if (e.event === "Progress") {
       got += e.data.chunkLength;
       if (total > 0) onProgress?.(Math.min(100, Math.round((got / total) * 100)));
+    } else if (e.event === "Finished") {
+      log.info("update: download finished, installed");
     }
   });
-  const { relaunch } = await import("@tauri-apps/plugin-process");
+  log.info("update: relaunching into the new version");
   await relaunch();
 }

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { getVersion } from "@tauri-apps/api/app";
 import { appLogDir, join } from "@tauri-apps/api/path";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { log } from "../lib/log";
@@ -74,6 +75,7 @@ export function SettingsApp() {
   const [logPath, setLogPath] = useState("");
   const [updateChecking, setUpdateChecking] = useState(false);
   const [updateMsg, setUpdateMsg] = useState("");
+  const [appVersion, setAppVersion] = useState("");
   const info = PROVIDER_BY_ID[settings.provider];
   const providerLabel = info.label;
   const sttInfo = STT_BY_ID[settings.transcriptionProvider];
@@ -85,6 +87,7 @@ export function SettingsApp() {
 
   useEffect(() => {
     if (!isTauri()) return;
+    getVersion().then(setAppVersion).catch(() => {});
     invoke<string[]>("list_input_devices").then(setDevices).catch(() => {});
     invoke<string>("get_templates_path").then(setTemplatesPath).catch(() => {});
     appLogDir().then((d) => join(d, "parley.log")).then(setLogPath).catch(() => {});
@@ -254,6 +257,11 @@ export function SettingsApp() {
               </Button>
             </Field>
             <Field label={t("settings.update.title")}>
+              {appVersion && (
+                <p className="text-sm">
+                  {t("settings.update.current", { version: appVersion })}
+                </p>
+              )}
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"


### PR DESCRIPTION
Two fixes to the in-app updater shipped in v0.6.4–v0.6.5.

## Auto-relaunch after update (the bug)
Clicking "Update & restart" downloaded + installed but **never restarted**. Root cause: `applyPendingUpdate` did a **dynamic** `import("@tauri-apps/plugin-process")` for `relaunch` *after* `downloadAndInstall` had already swapped the app bundle on disk. Vite content-hashes lazy chunks, so the old `plugin-process-<hash>.js` filename the running webview expects no longer exists in the freshly-installed bundle → the import 404s, `relaunch()` never runs, and the banner silently resets.

Fix: import `check` and `relaunch` **statically** (top of `update.ts`) so they're loaded at startup, before any bundle swap — no post-install chunk fetch. Both are side-effect-free outside Tauri (guarded by `isTauri`), so browser dev is unaffected. Added step logging (`update:` lines in parley.log) and a graceful "update installed — quit & reopen" fallback banner if relaunch ever fails for another reason (e.g. App Translocation).

## Show current version
Settings → Basic → Software updates now shows **Current version vX.Y.Z** (via `getVersion()`), next to the Check-for-updates button.

## Rollout note
The broken relaunch lives in the *installed* v0.6.4/v0.6.5, so updating **to** the first build with this fix still won't auto-restart (the old code runs the update) — one manual reopen. From that build onward, auto-restart works.

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 75/75