### PR TITLE
[feature] updater: periodic re-check while the app stays open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,11 +54,18 @@ function App() {
     };
   }, []);
 
-  // Check for an app update shortly after launch — surfaces a dismissible banner
-  // only; applying is always user-initiated, so it never interrupts a meeting.
+  // Check for an app update shortly after launch, then keep re-checking on a slow
+  // interval so a long-running window still catches a release that lands while
+  // it's open. Surfaces a dismissible banner only; applying is always
+  // user-initiated, so it never interrupts a meeting.
   useEffect(() => {
-    const id = setTimeout(() => void checkForUpdate({ silent: true }), 3000);
-    return () => clearTimeout(id);
+    const RECHECK_MS = 30 * 60 * 1000; // every 30 min while the app stays open
+    const first = setTimeout(() => void checkForUpdate({ silent: true }), 3000);
+    const recheck = setInterval(() => void checkForUpdate({ silent: true }), RECHECK_MS);
+    return () => {
+      clearTimeout(first);
+      clearInterval(recheck);
+    };
   }, []);
 
   // LIVE background engine: optional auto-analyze interval + TODO agenda auto-check.


### PR DESCRIPTION
## Summary
The in-app updater only checked once, 3 seconds after launch ([src/App.tsx](src/App.tsx)). A window left open for hours never noticed a release that shipped after startup.

This adds a slow recurring check on top of the launch check:
- Launch check at +3s (unchanged)
- Re-check every **30 minutes** while the app stays open
- Both use the same silent check and only surface the dismissible `UpdateBanner`; applying an update is still user-initiated, so it never interrupts a meeting

30 min (not 1 min) because the check hits the GitHub releases endpoint — unauthenticated requests are rate-limited to 60/hour, and a tighter interval risks failed checks for no real benefit.

## Test Coverage
No new code paths to unit-test meaningfully — the change is a `setInterval` inside an existing `useEffect`, with the timer cleared on unmount. Existing suite covers the rest.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Vitest: 75 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)