### PR TITLE
[feat] MCP: add_finding tool to insert one timeline finding without overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It runs in two complementary modes:
 
 - **Bring your own providers** — pick your transcription vendor and LLM (Claude, OpenAI, Gemini, Groq, Ollama, OpenRouter, and more).
 - **Local-first** — audio and transcripts go straight to the providers you configure; no Pathors AI proxy in between.
-- **Built-in MCP server** — connect Claude (or any MCP client) to the live meeting while the app is open: read the transcript, manage agenda TODOs, and read/overwrite/edit the timeline analysis, plus manage evaluation/agenda templates.
+- **Built-in MCP server** — connect Claude (or any MCP client) to the live meeting while the app is open: read the transcript, manage agenda TODOs, and read/add/overwrite/edit the timeline analysis, plus manage evaluation/agenda templates.
 - **Traditional Chinese** — on-the-fly conversion of transcribed text.
 - **Native macOS UI** — clean, custom window chrome.
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -369,6 +369,14 @@ fn tools() -> Vec<Value> {
             json!({ "type": "object", "properties": {} }),
         ),
         tool(
+            "add_finding",
+            "Add one timeline-analysis finding",
+            "Insert a SINGLE finding without touching the rest of the list (unlike set_findings, \
+             which replaces everything). The new marker is placed in chronological order by atMs. \
+             Applied within ~1.5s. Omit id to mint a new one.",
+            finding_schema(),
+        ),
+        tool(
             "set_findings",
             "Overwrite timeline-analysis findings",
             "Replace the ENTIRE timeline-analysis findings list with the provided events \
@@ -528,6 +536,7 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
             .get("findings")
             .cloned()
             .unwrap_or_else(|| json!([])),
+        "add_finding" => append_command(&state.commands_path, "add_finding", args)?,
         "set_findings" => append_command(
             &state.commands_path,
             "set_findings",

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -82,6 +82,12 @@ function applyCommand(cmd: SessionCommand): void {
         s.updateSettings({ evaluations: s.settings.evaluations.filter((e) => e.id !== a.id) });
       }
       break;
+    case "add_finding": {
+      // The whole args object IS the finding to insert.
+      const finding = normalizeFinding(a);
+      if (finding) s.addFinding(finding);
+      break;
+    }
     case "set_findings":
       if (Array.isArray(a.events)) {
         const events = a.events

--- a/src/lib/store.actions.test.ts
+++ b/src/lib/store.actions.test.ts
@@ -233,6 +233,37 @@ describe("findings selection invalidation", () => {
     expect(s.findingSolutions).toEqual({ a: { ...entry } }); // its solution preserved; "gone" cleared
   });
 
+  it("addFinding inserts one finding in atMs order without replacing the list", () => {
+    useStore.setState({
+      findings: [
+        { ...makeFinding("a"), atMs: 1000 },
+        { ...makeFinding("c"), atMs: 3000 },
+      ],
+      selectedFindingId: "a",
+      findingSolutions: { a: { status: "done", solution: null, error: null } },
+    });
+
+    useStore.getState().addFinding({ ...makeFinding("b"), atMs: 2000 });
+
+    const s = useStore.getState();
+    expect(s.findings.map((f) => f.id)).toEqual(["a", "b", "c"]); // chronological
+    expect(s.selectedFindingId).toBe("a"); // existing selection untouched
+    expect(s.findingSolutions.a).toBeDefined(); // existing solution untouched
+  });
+
+  it("addFinding reassigns a colliding id so the existing finding is never clobbered", () => {
+    useStore.setState({ findings: [{ ...makeFinding("dup"), title: "original", atMs: 0 }] });
+
+    useStore.getState().addFinding({ ...makeFinding("dup"), title: "incoming", atMs: 5000 });
+
+    const s = useStore.getState();
+    expect(s.findings).toHaveLength(2);
+    const original = s.findings.find((f) => f.title === "original");
+    const incoming = s.findings.find((f) => f.title === "incoming");
+    expect(original?.id).toBe("dup"); // kept its id
+    expect(incoming?.id).not.toBe("dup"); // got a fresh one
+  });
+
   it("updateFinding patches one finding in place and never rewrites its id", () => {
     useStore.setState({ findings: [makeFinding("a"), makeFinding("b")] });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -196,6 +196,9 @@ interface ParleyState {
    *  When it differs from the active eval set, the findings are stale → re-analyze. */
   analyzedEvalSig: string;
   setFindings: (events: TimelineEvent[]) => void;
+  /** Insert one finding (MCP/external add) without replacing the list, keeping it
+   *  ordered by atMs. A colliding id is reassigned so existing findings are safe. */
+  addFinding: (event: TimelineEvent) => void;
   /** Patch a single finding by id (MCP/external edit). The id stays fixed. */
   updateFinding: (id: string, patch: Partial<TimelineEvent>) => void;
   /** Delete a single finding by id (MCP/external edit), clearing any selection
@@ -481,6 +484,17 @@ export const useStore = create<ParleyState>()(
         selectedFindingId: keepSel ? s.selectedFindingId : null,
         solutionFindingId: keepSol ? s.solutionFindingId : null,
         findingSolutions,
+      };
+    }),
+
+  addFinding: (event) =>
+    set((s) => {
+      // Never clobber an existing finding's id (it keys selection + solutions).
+      const id = s.findings.some((f) => f.id === event.id) ? crypto.randomUUID() : event.id;
+      // Re-sort by atMs to preserve the chronological invariant the analysis
+      // pipeline establishes (timeline.ts) and the findings list renders in.
+      return {
+        findings: [...s.findings, { ...event, id }].sort((a, b) => a.atMs - b.atMs),
       };
     }),
 


### PR DESCRIPTION
## What

Follow-up to #47. `set_findings` replaces the **entire** timeline-analysis list, which is heavy when you only want to append one marker. This adds `add_finding` to insert a single finding.

### New MCP tool (`src-tauri/src/mcp.rs`)
| Tool | Action |
|---|---|
| `add_finding` | Insert ONE `TimelineEvent` without touching the rest of the list |

Reuses the shared `finding_schema()` (required: `atMs`, `side`, `severity`, `title`, `detail`; `id` optional → minted).

### Behaviour (`store.ts` `addFinding`)
- Inserts in **`atMs` order**, preserving the chronological invariant the analysis pipeline (`timeline.ts`) and the findings list rely on.
- A **colliding id is reassigned** so an existing finding (and its selection / cached solution keys) is never clobbered.

### Plumbing
- `sessionCommands.ts` — apply `add_finding` via the existing lenient `normalizeFinding`.
- tests: +2 cases (chronological insert, id-collision guard).

## Verification
- `tsc --noEmit` ✅
- `bun run test` ✅ 79 passed
- `cargo check` ✅ (with `OPUS_LIB_DIR` + `fetch-onnxruntime.sh` per local build setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)