### PR TITLE
[fix] a11y: history card rename wrapper + silence objc cfg warnings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints.rust]
+# `objc` 0.2's `msg_send!` / `class!` macros expand to `cfg(feature = "cargo-clippy")`,
+# which Rust's `unexpected_cfgs` lint flags in THIS crate (the cfg is evaluated in the
+# destination crate). Declare it expected so the build stays warning-clean, without
+# blanket-suppressing genuinely-unexpected cfgs.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.

--- a/src/history/HistoryApp.tsx
+++ b/src/history/HistoryApp.tsx
@@ -316,8 +316,11 @@ function HistoryCard({
     <div
       role="button"
       tabIndex={0}
-      onClick={onOpen}
+      onClick={() => {
+        if (!editing) onOpen();
+      }}
       onKeyDown={(ev) => {
+        if (editing) return; // while renaming, the input owns the keyboard
         if (ev.key === "Enter" || ev.key === " ") {
           ev.preventDefault();
           onOpen();
@@ -372,7 +375,9 @@ function HistoryCard({
         </span>
 
         {editing ? (
-          <div className="flex items-center gap-1" onClick={(ev) => ev.stopPropagation()}>
+          // The card's onClick/onKeyDown already bail while editing, so this
+          // wrapper needs no interaction handlers (keeps it a plain element).
+          <div className="flex items-center gap-1">
             <input
               ref={inputRef}
               value={draft}


### PR DESCRIPTION
Two small fixes flagged after the cloud-sync merge.

**Accessibility (`src/history/HistoryApp.tsx`)** — the rename wrapper `<div>` had an `onClick` (stopPropagation) with no keyboard listener (`jsx-a11y/click-events-have-key-events`). Rather than add a redundant key handler, the card's own `onClick`/`onKeyDown` now bail while `editing`, so the wrapper needs no interaction handlers at all — the violation is removed at the source.

**Rust build warnings (`src-tauri/Cargo.toml`)** — `objc` 0.2's `msg_send!`/`class!` macros expand to `cfg(feature = "cargo-clippy")`, which Rust's `unexpected_cfgs` lint flags in this crate. Declared it expected via `[lints.rust]` `check-cfg`, so the build is warning-clean without blanket-suppressing genuinely-unexpected cfgs.

Verified: `tsc --noEmit` clean, `cargo check` reports 0 `cargo-clippy` warnings.