### PR TITLE
[fix] audio: lock the mic during a meeting so a device switch can't break transcription

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -69,6 +69,13 @@ pub fn start_mic_test(
     state: State<MeetingState>,
     input_device: Option<String>,
 ) -> Result<(), String> {
+    // The meeting owns the mic until it ends — never open a competing input stream
+    // while recording. On macOS a second stream can make CoreAudio renegotiate the
+    // device and silently kill the meeting's capture (transcription stops). The UI
+    // also disables the test while recording; this is the reliable backstop.
+    if state.running.load(Ordering::SeqCst) {
+        return Ok(());
+    }
     if state.test_running.swap(true, Ordering::SeqCst) {
         return Ok(());
     }
@@ -100,6 +107,14 @@ pub fn stop_mic_test(state: State<MeetingState>) {
     state.test_running.store(false, Ordering::SeqCst);
 }
 
+/// Whether a live meeting is currently recording. The Settings UI uses this to
+/// disable the mic test + device picker while recording (switching the input
+/// mid-meeting can disrupt the meeting's capture).
+#[tauri::command]
+pub fn meeting_active(state: State<MeetingState>) -> bool {
+    state.running.load(Ordering::SeqCst)
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub fn start_meeting(
@@ -120,6 +135,9 @@ pub fn start_meeting(
     if state.running.swap(true, Ordering::SeqCst) {
         return Ok(());
     }
+    // Tear down any Settings "test mic" stream so it can't contend with the
+    // meeting's capture (its thread exits when this flag clears).
+    state.test_running.store(false, Ordering::SeqCst);
     let running = state.running.clone();
     // Arm a fresh recording buffer for this meeting (the designated session below
     // tees its PCM into it; stop_meeting encodes + clears it).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::list_input_devices,
             commands::start_mic_test,
             commands::stop_mic_test,
+            commands::meeting_active,
             commands::save_transcript,
             commands::export_recording,
             commands::start_oauth_loopback,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -185,6 +185,7 @@ export const zhTW = {
   "settings.transcription.systemDefault": "系統預設",
   "settings.transcription.stopTest": "停止測試",
   "settings.transcription.testMic": "測試麥克風",
+  "settings.transcription.lockedWhileRecording": "會議錄製中，麥克風已鎖定（結束會議後才能切換或測試）。",
   "settings.transcription.help":
     "若錄音沒有聲音，多半是抓錯麥克風，換一個並用 Test 確認音量。系統音訊（對方）目前用 Core Audio tap，需簽章與授權才會有聲音。",
   "settings.evaluations.title": "評估模板",
@@ -712,6 +713,7 @@ export const en = {
   "settings.transcription.systemDefault": "System default",
   "settings.transcription.stopTest": "Stop test",
   "settings.transcription.testMic": "Test mic",
+  "settings.transcription.lockedWhileRecording": "The mic is locked while a meeting is recording — stop the meeting to switch or test it.",
   "settings.transcription.help":
     "If recording has no sound, the selected microphone is probably wrong. Pick another one and use Test to confirm level. System audio currently uses a Core Audio tap and requires signing and permission.",
   "settings.evaluations.title": "Evaluations",

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -72,6 +72,9 @@ export function SettingsApp() {
   const [cat, setCat] = useState<Category>("basic");
   const [devices, setDevices] = useState<string[]>([]);
   const [testing, setTesting] = useState(false);
+  // A meeting is recording in the main window → lock the mic test + device picker
+  // so changing the input can't disrupt the live capture.
+  const [recording, setRecording] = useState(false);
   const [newTplName, setNewTplName] = useState("");
   const [templatesPath, setTemplatesPath] = useState("");
   const [mcpInfo, setMcpInfo] = useState<McpServerInfo | null>(null);
@@ -130,7 +133,25 @@ export function SettingsApp() {
     };
   }, [mcpInfo?.running]);
 
+  // Reflect the live meeting's recording state (query once, then follow the
+  // broadcast `meeting://status`) so the mic controls lock while recording.
+  useEffect(() => {
+    if (!isTauri()) return;
+    let alive = true;
+    void invoke<boolean>("meeting_active")
+      .then((a) => alive && setRecording(a))
+      .catch(() => {});
+    const un = listen<string>("meeting://status", (e) => {
+      if (alive) setRecording(e.payload === "recording");
+    });
+    return () => {
+      alive = false;
+      void un.then((fn) => fn());
+    };
+  }, []);
+
   async function toggleTest() {
+    if (recording) return; // the mic belongs to the meeting while recording
     if (testing) {
       await invoke("stop_mic_test").catch(() => {});
       setTesting(false);
@@ -493,6 +514,7 @@ export function SettingsApp() {
               <div className="flex max-w-sm flex-col gap-2">
                 <Select
                   value={settings.inputDevice || "__default__"}
+                  disabled={recording}
                   onValueChange={async (v) => {
                     const dev = v === "__default__" ? "" : v;
                     patch({ inputDevice: dev });
@@ -509,11 +531,22 @@ export function SettingsApp() {
                   </SelectContent>
                 </Select>
                 <div className="flex items-center gap-2">
-                  <Button variant={testing ? "destructive" : "outline"} size="sm" className="h-7 px-2 text-[11px]" onClick={toggleTest}>
+                  <Button
+                    variant={testing ? "destructive" : "outline"}
+                    size="sm"
+                    className="h-7 px-2 text-[11px]"
+                    disabled={recording}
+                    onClick={toggleTest}
+                  >
                     {testing ? t("settings.transcription.stopTest") : t("settings.transcription.testMic")}
                   </Button>
                   <LevelMeter source="test" className="h-2 flex-1" />
                 </div>
+                {recording && (
+                  <p className="text-[11px] text-muted-foreground">
+                    {t("settings.transcription.lockedWhileRecording")}
+                  </p>
+                )}
               </div>
             </Field>
             <p className="max-w-md text-[11px] text-muted-foreground">


### PR DESCRIPTION
**Reported:** switching the mic input mid-meeting killed the whole transcription.

**Root cause:** the Settings "Test mic" (`start_mic_test`) — fired by the device picker or the Test button — opens a *second* input stream with no guard against an active meeting. On macOS that makes CoreAudio renegotiate the device and silently kills the meeting's capture; audio stops, transcription dies, and the stream's error callback only logs, so nothing recovers.

**Fix** (the meeting already pins its device at start and holds it — just stop anything from grabbing the mic mid-meeting):
- `start_mic_test` no-ops while a meeting is recording (reliable backstop).
- `start_meeting` tears down any running test stream so it can't contend.
- new `meeting_active` command; Settings queries it + follows the broadcast `meeting://status` to disable the device picker + Test button while recording, with a hint.

So once a meeting starts, the input device is fixed for its duration. tsc + cargo check + tests green.