### PR TITLE
[fix] ui: cap textarea height so pasted text can't blow up the UI

### DIFF
--- a/src/components/MeetingContextField.tsx
+++ b/src/components/MeetingContextField.tsx
@@ -30,7 +30,7 @@ export function MeetingContextField({ rows = 3, autoFocus = false }: { rows?: nu
           value={meetingContext}
           onChange={(e) => setMeetingContext(e.target.value)}
           placeholder={t("meeting.contextPlaceholder")}
-          className="resize-none text-xs"
+          className="max-h-48 overflow-y-auto resize-none text-xs"
         />
       </div>
       <div className="flex flex-col gap-2">

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -165,7 +165,7 @@ export function SettingsApp() {
             </Field>
             <Field label={t("settings.basic.background")}>
               <Textarea
-                className="max-w-sm"
+                className="max-w-sm max-h-64 overflow-y-auto resize-none"
                 rows={4}
                 placeholder={t("settings.basic.backgroundPlaceholder")}
                 value={settings.userBackground}
@@ -902,7 +902,7 @@ function EvalEditor({
         </Button>
       </div>
       <Input value={ev.description} onChange={(e) => onChange({ description: e.target.value })} placeholder={t("settings.evaluations.descriptionPlaceholder")} className="h-8 text-xs" />
-      <Textarea value={ev.prompt} onChange={(e) => onChange({ prompt: e.target.value })} placeholder={t("settings.evaluations.promptPlaceholder")} rows={3} className="resize-none text-xs" />
+      <Textarea value={ev.prompt} onChange={(e) => onChange({ prompt: e.target.value })} placeholder={t("settings.evaluations.promptPlaceholder")} rows={3} className="max-h-40 overflow-y-auto resize-none text-xs" />
     </div>
   );
 }


### PR DESCRIPTION
## Problem
The base `Textarea` uses `field-sizing-content`, so it auto-grows with its content and has **no upper bound**. Pasting a large 補充背景 / context blob stretched the field off-screen and overflowed the popovers it lives in.

## Fix
Add `max-height` + `overflow-y-auto` to the unbounded textarea instances so they scroll internally instead of growing forever:
- `MeetingContextField` — used in the analyze popover, ingest wizard, and the context button (`max-h-48`)
- Settings → meeting background (`max-h-64`) and evaluation prompt (`max-h-40`)

`AskPanel` already had `max-h-32`, so it was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)