### PR TITLE
[feature] build: CLOUD_ENABLED flag for a local-only OSS edition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
 } from "./lib/history/history";
 import { checkForUpdate } from "./lib/update";
 import { refreshSession } from "./lib/cloud/client";
+import { CLOUD_ENABLED } from "./lib/flags";
 
 /**
  * Track main-window fullscreen state. Drives both the rounded corners (a
@@ -79,7 +80,7 @@ function App() {
     const unViewLogs = listenForViewLogsMenu();
     const unRecordingSaved = listenForRecordingSaved();
     const unHistoryOpen = listenForHistoryOpen();
-    const unHistoryOpenOrg = listenForHistoryOpenOrg();
+    const unHistoryOpenOrg = CLOUD_ENABLED ? listenForHistoryOpenOrg() : null;
     const unHistoryPersist = initHistoryPersistSync();
     return () => {
       unTranscript.then((fn) => fn());
@@ -93,7 +94,7 @@ function App() {
       unViewLogs.then((fn) => fn());
       unRecordingSaved.then((fn) => fn());
       unHistoryOpen.then((fn) => fn());
-      unHistoryOpenOrg.then((fn) => fn());
+      unHistoryOpenOrg?.then((fn) => fn());
       unHistoryPersist();
     };
   }, []);
@@ -104,7 +105,7 @@ function App() {
   // user-initiated, so it never interrupts a meeting. Also re-validate any stored
   // cloud sign-in on launch.
   useEffect(() => {
-    void refreshSession();
+    if (CLOUD_ENABLED) void refreshSession();
     const RECHECK_MS = 30 * 60 * 1000; // every 30 min while the app stays open
     const first = setTimeout(() => void checkForUpdate({ silent: true }), 3000);
     const recheck = setInterval(() => void checkForUpdate({ silent: true }), RECHECK_MS);

--- a/src/history/HistoryApp.tsx
+++ b/src/history/HistoryApp.tsx
@@ -48,6 +48,7 @@ import {
 import { listMyOrgs } from "../lib/cloud/orgs";
 import { listenForSettings, openSettingsWindow } from "../lib/settingsSync";
 import { useStore } from "../lib/store";
+import { CLOUD_ENABLED } from "../lib/flags";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import type { CloudOrg, CloudRecordingSummary } from "../lib/cloud/types";
@@ -139,7 +140,9 @@ export function HistoryApp() {
   useThemePreference();
   const { t, language } = useI18n();
   const locale = language === "en" ? "en-US" : "zh-TW";
-  const signedIn = useStore((s) => !!s.cloudAuth);
+  // Hooks must run unconditionally; the flag just forces cloud UI off in the OSS build.
+  const signedInRaw = useStore((s) => !!s.cloudAuth);
+  const signedIn = CLOUD_ENABLED && signedInRaw;
   const [orgs, setOrgs] = useState<CloudOrg[]>([]);
   const [selection, setSelection] = useState<Selection>({ kind: "personal" });
   const [entries, setEntries] = useState<HistoryCardItem[] | null>(null);
@@ -333,7 +336,8 @@ export function HistoryApp() {
 
   return (
     <div className="flex h-screen bg-background text-foreground">
-      {/* ── Sidebar: personal + shared (org) contexts ── */}
+      {/* ── Sidebar: personal + shared (org) contexts (cloud edition only) ── */}
+      {CLOUD_ENABLED && (
       <aside className="flex w-48 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-2">
         <SidebarItem
           icon={<FolderClosed className="size-4" />}
@@ -371,6 +375,7 @@ export function HistoryApp() {
           </>
         )}
       </aside>
+      )}
 
       {/* ── Content: the selected context's grid ── */}
       <div className="flex min-w-0 flex-1 flex-col">

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,8 @@
+// Build-time edition flag.
+//
+// The "cloud" edition (Google sign-in, history sync, organizations, and the
+// hosted account features) is compiled in by default. The pure local / OSS
+// edition is built with `VITE_PARLEY_CLOUD=false`, which makes this a compile-time
+// `false` so Vite eliminates every `CLOUD_ENABLED &&` branch — the binary then
+// ships no account/sync UI and makes no cloud calls. One codebase, two builds.
+export const CLOUD_ENABLED = import.meta.env.VITE_PARLEY_CLOUD !== "false";

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -11,6 +11,7 @@ import { useStore } from "../lib/store";
 import { LANGUAGE_OPTIONS, useI18n, type TranslationKey } from "../i18n";
 import { broadcastSettings } from "../lib/settingsSync";
 import { signInWithGoogle, signOut } from "../lib/cloud/client";
+import { CLOUD_ENABLED } from "../lib/flags";
 import {
   createOrg,
   listMyOrgs,
@@ -194,6 +195,8 @@ export function SettingsApp() {
 
         {cat === "basic" && (
           <Section title={t("settings.basic.title")}>
+            {CLOUD_ENABLED && (
+              <>
             <Field label={t("settings.nav.account")}>
               {cloudAuth ? (
                 <div className="flex max-w-sm items-center gap-3 rounded-lg border p-2.5">
@@ -251,6 +254,8 @@ export function SettingsApp() {
               <Field label={t("settings.account.org.title")}>
                 <OrgPanel />
               </Field>
+            )}
+              </>
             )}
             <Field label={t("settings.basic.name")}>
               <Input


### PR DESCRIPTION
Adds a `CLOUD_ENABLED` build flag (`src/lib/flags.ts`). Building with `VITE_PARLEY_CLOUD=false` gates out every account/sync/org touchpoint (Settings Account + OrgPanel, App's refreshSession + org listener, History sidebar/sync/share) → a clean local-only + BYOK edition with no sign-in and no cloud calls. Default build is unchanged (full cloud edition), so the current release pipeline is unaffected. Next: dual CI build + the two updater feeds (separate PR).