### PR TITLE
[chore] website: download buttons → cloud edition channel

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -97,7 +97,7 @@
           <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5Z"/></svg>
           <span>GitHub</span>
         </a>
-        <a class="btn btn--primary" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">
+        <a class="btn btn--primary" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">
           <span>Get Parley</span>
         </a>
       </div>
@@ -122,7 +122,7 @@
             Live transcription, playbooks, and grounded Q&amp;A — open source, on the AI providers you choose.
           </p>
           <div class="hero__cta">
-            <a class="btn btn--primary btn--lg" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">Get Parley for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Get Parley for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">Star on GitHub</a>
           </div>
           <ul class="hero__meta">
@@ -357,7 +357,7 @@
           <h2>Build your own meeting note stack</h2>
           <p>Download Parley for macOS, add the providers you want in Settings, and start shaping it around your meetings. Free and open source.</p>
           <div class="cta__actions">
-            <a class="btn btn--primary btn--lg" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">Download for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Download for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">View on GitHub</a>
           </div>
           <p class="cta__note">Bring your preferred transcription and AI provider keys. Local model routes are supported where available.</p>


### PR DESCRIPTION
Repoints the 3 download CTAs from GitHub releases to the cloud download channel (`parley-cloud.pathors.workers.dev/download`). Repo/Star links unchanged.