### PR TITLE
[feature] release: dual-build — OSS to GitHub, cloud to R2/website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The GitHub release is the LOCAL-ONLY OSS edition — no account/sync code.
+          VITE_PARLEY_CLOUD: "false"
           # Updater artifact signing (minisign) — lets the app verify auto-updates
           # against the pubkey in tauri.conf.json. tauri-action signs the bundle and
           # attaches `latest.json` to the release when these are present.
@@ -112,3 +114,35 @@ jobs:
           tauriScript: bun run tauri
           args: --target aarch64-apple-darwin
           releaseAssetNamePattern: "[name]-[version]-[platform]-[arch].[ext]"
+
+      # ── Cloud edition ──────────────────────────────────────────────────────────
+      # The OSS release above is already published to GitHub. Now build the CLOUD
+      # edition (account/sync/orgs compiled in, updater pointed at the website feed)
+      # and push it to R2 under `downloads/`, where the parley-cloud Worker's
+      # /download route serves it to the marketing site + the cloud app's updater.
+      # These steps run AFTER the GitHub release, so a cloud-upload failure never
+      # blocks the OSS release.
+      - name: Build cloud edition
+        env:
+          VITE_PARLEY_CLOUD: "true"
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: bun run tauri build --config src-tauri/tauri.conf.cloud.json --target aarch64-apple-darwin
+
+      - name: Upload cloud edition to R2 (website download + updater feed)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          BUNDLE="src-tauri/target/aarch64-apple-darwin/release/bundle"
+          TARGZ="${BUNDLE}/macos/Parley.app.tar.gz"
+          DMG="$(ls "${BUNDLE}"/dmg/Parley_*_aarch64.dmg | head -1)"
+          VERSION="${{ steps.release.outputs.tag }}"; VERSION="${VERSION#v}"
+          # Build the updater feed (latest.json) — signature is the .sig file, url
+          # points at the Worker download route (which streams the .app.tar.gz from R2).
+          SIG_FILE="${TARGZ}.sig" VERSION="${VERSION}" node -e 'const fs=require("fs");const sig=fs.readFileSync(process.env.SIG_FILE,"utf8").trim();fs.writeFileSync("latest.json",JSON.stringify({version:process.env.VERSION,pub_date:new Date().toISOString(),platforms:{"darwin-aarch64":{signature:sig,url:"https://parley-cloud.pathors.workers.dev/download/Parley.app.tar.gz"}}},null,2));'
+          bunx wrangler r2 object put "parley-recordings/downloads/Parley.app.tar.gz" --file "${TARGZ}" --remote
+          bunx wrangler r2 object put "parley-recordings/downloads/Parley.dmg" --file "${DMG}" --remote
+          bunx wrangler r2 object put "parley-recordings/downloads/latest.json" --file latest.json --remote

--- a/src-tauri/tauri.conf.cloud.json
+++ b/src-tauri/tauri.conf.cloud.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://parley-cloud.pathors.workers.dev/download/latest.json"
+      ]
+    }
+  }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -97,7 +97,7 @@
           <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5Z"/></svg>
           <span>GitHub</span>
         </a>
-        <a class="btn btn--primary" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">
+        <a class="btn btn--primary" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">
           <span>Get Parley</span>
         </a>
       </div>
@@ -122,7 +122,7 @@
             Live transcription, playbooks, and grounded Q&amp;A — open source, on the AI providers you choose.
           </p>
           <div class="hero__cta">
-            <a class="btn btn--primary btn--lg" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">Get Parley for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Get Parley for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">Star on GitHub</a>
           </div>
           <ul class="hero__meta">
@@ -357,7 +357,7 @@
           <h2>Build your own meeting note stack</h2>
           <p>Download Parley for macOS, add the providers you want in Settings, and start shaping it around your meetings. Free and open source.</p>
           <div class="cta__actions">
-            <a class="btn btn--primary btn--lg" href="https://github.com/pathorsAI/parley/releases/latest" target="_blank" rel="noopener">Download for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Download for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">View on GitHub</a>
           </div>
           <p class="cta__note">Bring your preferred transcription and AI provider keys. Local model routes are supported where available.</p>


### PR DESCRIPTION
Each tag ships both editions: OSS (`VITE_PARLEY_CLOUD=false`) -> GitHub release + `latest.json`; cloud (`VITE_PARLEY_CLOUD=true` + `tauri.conf.cloud.json` updater override) -> R2 `downloads/` (served by the Worker /download route to the website + the cloud updater). OSS publishes first so a cloud-upload failure can't block it. Needs CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID (set). First release flips the GitHub feed to OSS (existing cloud users reinstall from the website once).