### PR TITLE
[fix] history: discard recording for an empty (no-transcript) meeting

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -261,6 +261,33 @@ pub fn stop_meeting(app: AppHandle, state: State<MeetingState>) -> Result<(), St
     Ok(())
 }
 
+/// Delete a freshly-encoded live recording the frontend decided NOT to save —
+/// e.g. an empty meeting with no transcript (likely an accidental Start/Stop).
+/// `save_history_entry` removes the temp source when it moves it into an entry
+/// folder; this is the matching cleanup for the skip path so the `.ogg` doesn't
+/// orphan in the temp dir.
+///
+/// Guarded: only removes a file under the OS temp dir whose name matches our own
+/// `parley-recording-*.ogg`, so it can never be coerced into deleting an
+/// arbitrary path.
+#[tauri::command]
+pub fn discard_recording(path: String) {
+    let p = std::path::Path::new(&path);
+    let in_temp = p.starts_with(std::env::temp_dir());
+    let looks_like_ours = p
+        .file_name()
+        .and_then(|f| f.to_str())
+        .is_some_and(|f| f.starts_with("parley-recording-") && f.ends_with(".ogg"));
+    if in_temp && looks_like_ours {
+        match std::fs::remove_file(p) {
+            Ok(()) => log::info!("recording: discarded unsaved {path}"),
+            Err(e) => log::warn!("recording: discard failed for {path}: {e}"),
+        }
+    } else {
+        log::warn!("recording: refused to discard non-recording path {path}");
+    }
+}
+
 /// Save a meeting transcript (markdown) to ~/Documents/Parley and return the
 /// absolute path written. Creates the folder if needed.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::start_meeting,
             commands::stop_meeting,
+            commands::discard_recording,
             commands::list_input_devices,
             commands::start_mic_test,
             commands::stop_mic_test,

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -126,7 +126,11 @@ let uploadSaveInFlight: Promise<unknown> | null = null;
 export async function saveLiveToHistory(audioTempPath: string, durationMs: number): Promise<void> {
   if (!isTauri()) return;
   if (!hasSpokenTranscript()) {
+    // Nothing was transcribed — almost certainly an accidental Start/Stop. Don't
+    // save a history entry, and discard the encoded temp recording so it doesn't
+    // orphan in the temp dir (an entry would normally consume it on save).
     log.info("history: live save skipped (no transcript)");
+    await invoke("discard_recording", { path: audioTempPath }).catch(() => {});
     return;
   }
   const s = useStore.getState();


### PR DESCRIPTION
An accidental **Start → Stop** with nothing said shouldn't leave anything behind.

The frontend already skips writing a history entry when there's no spoken transcript (`hasSpokenTranscript`), so empty meetings don't clutter History. But the backend had, by then, encoded the audio to a temp `.ogg` and emitted `recording-saved` — and since no entry consumes that file (an entry save is what moves + deletes it), it **orphaned in the OS temp dir**.

## Change
- New guarded **`discard_recording`** command — only removes a `parley-recording-*.ogg` under the OS temp dir, so it can't be coerced into deleting an arbitrary path.
- `saveLiveToHistory`'s skip path now calls it, so an empty meeting cleans up its own temp recording.

Net effect: a no-transcript meeting leaves **no history entry and no leftover audio**.

## Verification
- `cargo check` clean (new command compiles); `tsc` clean; **91** vitest tests pass.
- Independent of the open delivery PR (#59) — based on current `main` (v0.8.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)