### PR TITLE
[fix] ui: pointer cursor on buttons, tabs and dropdowns

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -175,8 +175,14 @@ textarea,
   }
 }
 
-/* Native-app cursor behaviour: controls use the default arrow, not the web
-   pointing-hand. Real text hyperlinks keep the pointer. */
-a[href] {
+/* Cursor behaviour: interactive controls (buttons, tabs, dropdown triggers
+   and items, links, and custom role="button" elements) use the pointing-hand
+   cursor. Text inputs keep their default I-beam; disabled controls do not. */
+a[href],
+button:not(:disabled),
+[role="button"]:not([aria-disabled="true"]),
+[role="tab"]:not([aria-disabled="true"]),
+[role="option"]:not([aria-disabled="true"]),
+[role="menuitem"]:not([aria-disabled="true"]) {
   cursor: pointer;
 }


### PR DESCRIPTION
## What

Restore the pointing-hand cursor on interactive controls.

Tailwind v4's Preflight stopped applying `cursor: pointer` to `<button>`, so every shadcn control (Button, Tabs triggers, Select/dropdown triggers) showed the default arrow. The previous rule only kept the pointer on real `a[href]` links.

## Change

One global CSS rule in `src/index.css` now covers:

- `button:not(:disabled)` — shadcn Button, Tabs and Select triggers (all render `<button>`)
- `[role="button"]` — custom clickable elements (FindingRow, ReplayTranscript, HistoryApp)
- `[role="tab"]`, `[role="option"]`, `[role="menuitem"]` — Radix tab/dropdown items

Disabled controls are excluded (`:not(:disabled)` / `:not([aria-disabled="true"])`) and text inputs keep their I-beam. The rule is intentionally unlayered so it overrides shadcn's `cursor-default` on Select items.

CSS-only, no component changes.