### PR TITLE
[chore] domains: migrate website + cloud API to parley.tw

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           VERSION="${{ steps.release.outputs.tag }}"; VERSION="${VERSION#v}"
           # Build the updater feed (latest.json) — signature is the .sig file, url
           # points at the Worker download route (which streams the .app.tar.gz from R2).
-          SIG_FILE="${TARGZ}.sig" VERSION="${VERSION}" node -e 'const fs=require("fs");const sig=fs.readFileSync(process.env.SIG_FILE,"utf8").trim();fs.writeFileSync("latest.json",JSON.stringify({version:process.env.VERSION,pub_date:new Date().toISOString(),platforms:{"darwin-aarch64":{signature:sig,url:"https://parley-cloud.pathors.workers.dev/download/Parley.app.tar.gz"}}},null,2));'
+          SIG_FILE="${TARGZ}.sig" VERSION="${VERSION}" node -e 'const fs=require("fs");const sig=fs.readFileSync(process.env.SIG_FILE,"utf8").trim();fs.writeFileSync("latest.json",JSON.stringify({version:process.env.VERSION,pub_date:new Date().toISOString(),platforms:{"darwin-aarch64":{signature:sig,url:"https://api.parley.tw/download/Parley.app.tar.gz"}}},null,2));'
           bunx wrangler r2 object put "parley-recordings/downloads/Parley.app.tar.gz" --file "${TARGZ}" --remote
           bunx wrangler r2 object put "parley-recordings/downloads/Parley.dmg" --file "${DMG}" --remote
           bunx wrangler r2 object put "parley-recordings/downloads/latest.json" --file latest.json --remote

--- a/src-tauri/tauri.conf.cloud.json
+++ b/src-tauri/tauri.conf.cloud.json
@@ -3,7 +3,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://parley-cloud.pathors.workers.dev/download/latest.json"
+        "https://api.parley.tw/download/latest.json"
       ]
     }
   }

--- a/src/lib/cloud/client.ts
+++ b/src/lib/cloud/client.ts
@@ -10,7 +10,7 @@ import type { CloudUser } from "./types";
  */
 export const CLOUD_URL =
   (import.meta.env.VITE_PARLEY_CLOUD_URL as string | undefined)?.replace(/\/$/, "") ||
-  "https://parley-cloud.pathors.workers.dev";
+  "https://api.parley.tw";
 
 type Me = { user: CloudUser | null; activeOrganizationId: string | null };
 

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,1 @@
-parley.pathors.com
+parley.tw

--- a/website/README.md
+++ b/website/README.md
@@ -58,23 +58,24 @@ publishes this folder automatically.
 
 ## Custom domain with Cloudflare
 
-To serve the site at your own domain (e.g. `parley.pathors.com`) using GitHub
-Pages + Cloudflare DNS:
+The site is served at **`parley.tw`** (apex) via GitHub Pages + Cloudflare DNS.
+To reproduce or move it:
 
 1. **Tell GitHub the domain.** Create `website/CNAME` containing just the
    hostname, e.g.:
    ```
-   parley.pathors.com
+   parley.tw
    ```
    (Or set it under Settings → Pages → Custom domain, which creates the same
    file. Keeping it in `website/` means the Actions deploy preserves it.)
 
 2. **Add the DNS record in Cloudflare** (DNS → Records):
-   - **Subdomain** (recommended, e.g. `parley`): add a `CNAME` record
+   - **Apex/root** (`parley.tw`, current setup): add `CNAME` `@` →
+     `pathorsai.github.io` (Cloudflare flattens this automatically), or use
+     GitHub's four A records: `185.199.108.153`, `185.199.109.153`,
+     `185.199.110.153`, `185.199.111.153`.
+   - **Subdomain** (e.g. `parley`): add a `CNAME` record
      `parley` → `pathorsai.github.io`.
-   - **Apex/root** (`pathors.com`): add `CNAME` `@` → `pathorsai.github.io`
-     (Cloudflare flattens this automatically), or use GitHub's four A records:
-     `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`.
 
 3. **Proxy + SSL.** You can leave the record **Proxied** (orange cloud). Set
    Cloudflare **SSL/TLS → Overview → Full** (not Flexible — Flexible causes

--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,7 @@
     <meta name="keywords" content="meeting copilot, realtime transcription, AI meeting notes, negotiation assistant, sales call analysis, interview copilot, open source, macOS, Pathors AI" />
     <meta name="author" content="Pathors AI" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://parley.pathors.com/" />
+    <link rel="canonical" href="https://parley.tw/" />
 
     <!-- Open Graph -->
     <meta property="og:site_name" content="Parley by Pathors AI" />
@@ -21,14 +21,14 @@
       content="Live transcription, configurable evaluation playbooks, and a grounded Q&A sidebar for negotiations, sales, and interviews. Native macOS. Open source. By Pathors AI."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://parley.pathors.com/" />
-    <meta property="og:image" content="https://parley.pathors.com/assets/og.png" />
+    <meta property="og:url" content="https://parley.tw/" />
+    <meta property="og:image" content="https://parley.tw/assets/og.png" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Parley — Open-source realtime meeting copilot" />
     <meta name="twitter:description" content="Live transcription, configurable playbooks, and grounded Q&A for high-stakes calls. Native macOS. Open source. By Pathors AI." />
-    <meta name="twitter:image" content="https://parley.pathors.com/assets/og.png" />
+    <meta name="twitter:image" content="https://parley.tw/assets/og.png" />
 
     <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
 
@@ -42,7 +42,7 @@
             "@id": "https://pathors.com/#org",
             "name": "Pathors AI",
             "url": "https://pathors.com",
-            "logo": "https://parley.pathors.com/assets/og.png",
+            "logo": "https://parley.tw/assets/og.png",
             "sameAs": ["https://github.com/pathorsAI"]
           },
           {
@@ -50,7 +50,7 @@
             "name": "Parley",
             "applicationCategory": "BusinessApplication",
             "operatingSystem": "macOS",
-            "url": "https://parley.pathors.com/",
+            "url": "https://parley.tw/",
             "description": "Open-source realtime meeting copilot for negotiations, sales, interviews, and diligence calls. Live transcription, configurable evaluation playbooks, and grounded Q&A with your own AI and transcription providers.",
             "license": "https://www.apache.org/licenses/LICENSE-2.0",
             "isAccessibleForFree": true,
@@ -97,7 +97,7 @@
           <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5Z"/></svg>
           <span>GitHub</span>
         </a>
-        <a class="btn btn--primary" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">
+        <a class="btn btn--primary" href="https://api.parley.tw/download" target="_blank" rel="noopener">
           <span>Get Parley</span>
         </a>
       </div>
@@ -122,7 +122,7 @@
             Live transcription, playbooks, and grounded Q&amp;A — open source, on the AI providers you choose.
           </p>
           <div class="hero__cta">
-            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Get Parley for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">Get Parley for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">Star on GitHub</a>
           </div>
           <ul class="hero__meta">
@@ -357,7 +357,7 @@
           <h2>Build your own meeting note stack</h2>
           <p>Download Parley for macOS, add the providers you want in Settings, and start shaping it around your meetings. Free and open source.</p>
           <div class="cta__actions">
-            <a class="btn btn--primary btn--lg" href="https://parley-cloud.pathors.workers.dev/download" target="_blank" rel="noopener">Download for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">Download for macOS</a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">View on GitHub</a>
           </div>
           <p class="cta__note">Bring your preferred transcription and AI provider keys. Local model routes are supported where available.</p>

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://parley.pathors.com/sitemap.xml
+Sitemap: https://parley.tw/sitemap.xml

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://parley.pathors.com/</loc>
+    <loc>https://parley.tw/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Migrate Parley's own domains to **parley.tw**. Pathors AI org links/schema (bare `pathors.com`) are intentionally kept.

## Changes
- `website/`: `CNAME` → `parley.tw`; canonical / og:url / og:image / twitter:image / JSON-LD `url`+`logo` → `parley.tw`; `sitemap.xml`, `robots.txt`; the 3 download buttons → `https://api.parley.tw/download`.
- `src/lib/cloud/client.ts`: default `CLOUD_URL` fallback → `https://api.parley.tw` (only affects new builds / dev).
- `src-tauri/tauri.conf.cloud.json`: cloud updater feed → `https://api.parley.tw/download/latest.json`.

## ⚠️ Draft — do not merge until DNS is ready
Merging triggers `deploy-website.yml`, which republishes GitHub Pages with the new `CNAME`. That is the website's cutover to `parley.tw`. Before merging:
1. In Cloudflare, point `parley.tw` apex at GitHub Pages (`@` → A records `185.199.108–111.153`, or CNAME-flatten to `pathorsai.github.io`), SSL/TLS = **Full**.
2. Let GitHub provision the cert, tick **Enforce HTTPS** in repo Settings → Pages.

The project site serves at the apex **root** (`parley.tw/`, not `parley.tw/parley/`) — all asset paths are relative, so nothing breaks.

Backend counterpart: pathorsAI/parley-internal `chore/migrate-parley-tw`.