### PR TITLE
[fix] meeting: stop reliably tears down transcription; guard double start/stop

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -48,6 +48,11 @@ pub(crate) type RecorderBuf = Arc<Mutex<Option<Vec<i16>>>>;
 pub struct MeetingState {
     running: Arc<AtomicBool>,
     threads: Mutex<Vec<JoinHandle<()>>>,
+    /// Live transcription session tasks (the per-source Soniox/etc. WebSocket
+    /// loops). Held so `stop_meeting` can `abort()` them — a direct cancel that
+    /// closes the socket even if the capture→channel-close cascade stalls, instead
+    /// of letting the session linger and keep emitting transcript after stop.
+    tasks: Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>,
     /// Separate flag for the Settings "test mic" preview (no Soniox).
     test_running: Arc<AtomicBool>,
     /// Buffers the recorded audio of the in-progress live meeting (see RecorderBuf).
@@ -142,6 +147,8 @@ pub fn start_meeting(
     // Arm a fresh recording buffer for this meeting (the designated session below
     // tees its PCM into it; stop_meeting encodes + clears it).
     *state.recorder.lock().unwrap() = Some(Vec::new());
+    // Drop any (finished) session handles from a prior meeting before this one fills in.
+    state.tasks.lock().unwrap().clear();
     let recorder = state.recorder.clone();
     let model = model
         .filter(|m| !m.trim().is_empty())
@@ -171,19 +178,20 @@ pub fn start_meeting(
             let rx_me = spawn_capture(&state, mic, running.clone(), "me")
                 .map(|rx| spawn_mic_prosody_tap(&app, rx));
             let rx_them = spawn_capture(&state, sys, running.clone(), "them");
+            let mut tasks = state.tasks.lock().unwrap();
             match (rx_me, rx_them) {
                 (Some(a), Some(b)) => {
                     let (tx_mix, rx_mix) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
                     tauri::async_runtime::spawn(crate::audio::mixer::mix_streams(app.clone(), a, b, tx_mix));
                     // Record the mixed stream → the saved file holds both sides.
-                    run_metered_session(&app, provider, make_config(), "mix", rx_mix, Some(recorder));
+                    tasks.push(run_metered_session(&app, provider, make_config(), "mix", rx_mix, Some(recorder)));
                 }
                 // If one capture failed, transcribe + record whichever started.
                 (Some(a), None) => {
-                    run_metered_session(&app, provider, make_config(), "me", a, Some(recorder))
+                    tasks.push(run_metered_session(&app, provider, make_config(), "me", a, Some(recorder)));
                 }
                 (None, Some(b)) => {
-                    run_metered_session(&app, provider, make_config(), "them", b, Some(recorder))
+                    tasks.push(run_metered_session(&app, provider, make_config(), "them", b, Some(recorder)));
                 }
                 (None, None) => {}
             }
@@ -192,10 +200,12 @@ pub fn start_meeting(
             // un-aligned streams into one file would garble it); see plan note.
             if let Some(rx) = spawn_capture(&state, mic, running.clone(), "me") {
                 let rx = spawn_mic_prosody_tap(&app, rx);
-                run_metered_session(&app, provider, make_config(), "me", rx, Some(recorder));
+                let task = run_metered_session(&app, provider, make_config(), "me", rx, Some(recorder));
+                state.tasks.lock().unwrap().push(task);
             }
             if let Some(rx) = spawn_capture(&state, sys, running.clone(), "them") {
-                run_metered_session(&app, provider, make_config(), "them", rx, None);
+                let task = run_metered_session(&app, provider, make_config(), "them", rx, None);
+                state.tasks.lock().unwrap().push(task);
             }
         }
     }
@@ -207,7 +217,8 @@ pub fn start_meeting(
         };
         if let Some(rx) = spawn_capture(&state, mic, running.clone(), "me") {
             let rx = spawn_mic_prosody_tap(&app, rx);
-            run_metered_session(&app, provider, make_config(), "me", rx, Some(recorder));
+            let task = run_metered_session(&app, provider, make_config(), "me", rx, Some(recorder));
+            state.tasks.lock().unwrap().push(task);
         }
     }
 
@@ -218,6 +229,24 @@ pub fn start_meeting(
 #[tauri::command]
 pub fn stop_meeting(app: AppHandle, state: State<MeetingState>) -> Result<(), String> {
     state.running.store(false, Ordering::SeqCst);
+
+    // Direct-cancel safety net for the transcription sessions. Clearing `running`
+    // starts the graceful capture→channel-close cascade (which closes the socket
+    // and emits final usage); but if any link stalls, the WebSocket would linger
+    // and keep producing transcript after stop. So hand the session tasks to a
+    // watchdog that force-aborts them after a short grace — long enough for the
+    // normal path to finish first (aborting an already-finished task is a no-op).
+    let tasks: Vec<tauri::async_runtime::JoinHandle<()>> =
+        state.tasks.lock().unwrap().drain(..).collect();
+    if !tasks.is_empty() {
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            for t in tasks {
+                t.abort();
+            }
+        });
+    }
+
     // Joining lets each capture thread release its device (drops its PCM sender,
     // which in turn ends the Soniox session via channel close).
     let handles: Vec<JoinHandle<()>> = state.threads.lock().unwrap().drain(..).collect();
@@ -469,7 +498,7 @@ fn run_metered_session(
     label: &'static str,
     rx: UnboundedReceiver<Vec<i16>>,
     recorder: Option<RecorderBuf>,
-) {
+) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         // Interpose a sample counter between capture and the STT adapter: it
@@ -510,7 +539,7 @@ fn run_metered_session(
                 "seconds": seconds,
             }),
         );
-    });
+    })
 }
 
 /// Get the absolute path to the templates.json file.

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Circle, FileAudio, History, Loader2, LogOut, Mic, Minus, Settings, Square, X } from "lucide-react";
@@ -70,6 +70,12 @@ export function TitleBar({ fullscreen = false }: { fullscreen?: boolean }) {
   const replayName = useStore((s) => s.replay?.name ?? "");
   const exitReplay = useStore((s) => s.exitReplay);
   const [ingestMsg, setIngestMsg] = useState<string | null>(null);
+  // Guard the start/stop toggle so a rapid double-click can't fire two overlapping
+  // start/stop invokes (which is what could race two transcription sessions open,
+  // or interleave a stop with a start). The ref blocks re-entry synchronously
+  // (before any re-render); `toggleBusy` just disables the button visually.
+  const toggleBusyRef = useRef(false);
+  const [toggleBusy, setToggleBusy] = useState(false);
 
   const recording = status === "recording";
   const replayMode = appMode === "replay";
@@ -100,47 +106,56 @@ export function TitleBar({ fullscreen = false }: { fullscreen?: boolean }) {
   }
 
   async function toggle() {
-    if (recording) {
-      log.info("meeting: stop requested");
-      stopMeeting();
-      if (useRealPipeline) {
-        try {
-          await invoke("stop_meeting");
-        } catch (e) {
-          log.error("meeting: stop failed", { error: String(e) });
+    // Re-entrancy guard: ignore clicks while a start/stop is already in flight.
+    if (toggleBusyRef.current) return;
+    toggleBusyRef.current = true;
+    setToggleBusy(true);
+    try {
+      if (recording) {
+        log.info("meeting: stop requested");
+        stopMeeting();
+        if (useRealPipeline) {
+          try {
+            await invoke("stop_meeting");
+          } catch (e) {
+            log.error("meeting: stop failed", { error: String(e) });
+          }
+        } else {
+          stopMockStream();
         }
-      } else {
-        stopMockStream();
+        return;
       }
-      return;
-    }
-    startMeeting();
-    if (useRealPipeline) {
-      log.info("meeting: start requested", {
-        provider: transcriptionProvider,
-        model: STT_BY_ID[transcriptionProvider].label,
-        diarization: STT_BY_ID[transcriptionProvider].diarization,
-        inputDevice,
-        pipeline: "real",
-      });
-      try {
-        await invoke("start_meeting", {
+      startMeeting();
+      if (useRealPipeline) {
+        log.info("meeting: start requested", {
           provider: transcriptionProvider,
-          apiKey: sttKey,
+          model: STT_BY_ID[transcriptionProvider].label,
           diarization: STT_BY_ID[transcriptionProvider].diarization,
           inputDevice,
+          pipeline: "real",
         });
-      } catch (e) {
-        log.error("meeting: start failed", {
-          provider: transcriptionProvider,
-          inputDevice,
-          error: String(e),
-        });
-        stopMeeting();
+        try {
+          await invoke("start_meeting", {
+            provider: transcriptionProvider,
+            apiKey: sttKey,
+            diarization: STT_BY_ID[transcriptionProvider].diarization,
+            inputDevice,
+          });
+        } catch (e) {
+          log.error("meeting: start failed", {
+            provider: transcriptionProvider,
+            inputDevice,
+            error: String(e),
+          });
+          stopMeeting();
+        }
+      } else {
+        log.info("meeting: start (mock stream)");
+        startMockStream();
       }
-    } else {
-      log.info("meeting: start (mock stream)");
-      startMockStream();
+    } finally {
+      toggleBusyRef.current = false;
+      setToggleBusy(false);
     }
   }
 
@@ -274,7 +289,7 @@ export function TitleBar({ fullscreen = false }: { fullscreen?: boolean }) {
               size="sm"
               variant={recording ? "destructive" : "default"}
               onClick={toggle}
-              disabled={!!ingestMsg}
+              disabled={!!ingestMsg || toggleBusy}
               className="h-8"
             >
               {recording ? <Square className="size-3.5" /> : <Mic className="size-3.5" />}


### PR DESCRIPTION
Two meeting-lifecycle fixes, extracted from the postponed delivery branch (PR #59) so they ship independently of the (shelved) delivery detection.

## Problem
Pressing **Stop** could leave transcription running. Teardown relied entirely on the capture → channel-close cascade (clear `running` → capture threads drop their PCM senders → mixer ends → Soniox `forward` loop sees its channel close → finalizes + closes the WebSocket). If any link stalled, the socket lingered and kept emitting transcript after Stop. A rapid double-click on Start/Stop could also fire overlapping invokes.

## Fix
- **Direct cancel for the session (`commands.rs`)**: `MeetingState` now tracks the live transcription session task handles. `stop_meeting` still runs the graceful cascade first (closes the socket + emits final usage), then hands the session tasks to a watchdog that **force-aborts** them after a 1.5 s grace — so the WebSocket can't linger. `start_meeting` clears stale handles and collects the new ones; `run_metered_session` returns its `JoinHandle`.
- **Re-entrancy guard (`TitleBar.tsx`)**: the Start/Stop button blocks overlapping start/stop invokes (a ref guard, synchronous) and is disabled while one is in flight — so a double-click can't open two overlapping sessions.

## Verification
- `cargo check` ✓, `tsc` ✓, `vitest` 91 ✓
- Scope: only `src-tauri/src/commands.rs` + `src/components/TitleBar.tsx`.