### PR TITLE
[fix] meeting: dev-only listener double-subscribe + orphan-session hardening

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -248,10 +248,21 @@ pub fn stop_meeting(app: AppHandle, state: State<MeetingState>) -> Result<(), St
     }
 
     // Joining lets each capture thread release its device (drops its PCM sender,
-    // which in turn ends the Soniox session via channel close).
+    // which in turn ends the Soniox session via channel close). Capture threads
+    // self-exit within ~100 ms of `running` clearing, but bound the wait so a wedged
+    // thread (e.g. a stuck CoreAudio teardown) can't hang the stop command itself;
+    // the session WebSocket is force-closed separately by the watchdog above.
     let handles: Vec<JoinHandle<()>> = state.threads.lock().unwrap().drain(..).collect();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
     for h in handles {
-        let _ = h.join();
+        while !h.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        if h.is_finished() {
+            let _ = h.join();
+        } else {
+            log::warn!("stop_meeting: capture thread didn't exit within grace; detaching");
+        }
     }
     let _ = app.emit("meeting://status", "stopped");
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TitleBar } from "./components/TitleBar";
 import { LiveScreen } from "./components/live/LiveScreen";
 import { ReplayScreen } from "./components/replay/ReplayScreen";
@@ -71,34 +73,43 @@ function App() {
   const rounded = isTauri() && !fullscreen;
 
   useEffect(() => {
-    const unTranscript = listenForTranscript();
-    const unProsody = listenForProsody();
-    const unSettings = listenForSettings();
+    // StrictMode (dev) double-invokes this effect (mount→cleanup→mount) and Vite
+    // HMR re-runs it on edits. The Tauri `listen()` calls resolve their UnlistenFn
+    // on a LATER tick, so a naive `unX.then(fn => fn())` cleanup can fire its
+    // unlisten AFTER the re-mount has already re-subscribed — leaving two live
+    // handlers for `transcript://segment` / `audio://prosody` (the dev-only
+    // "double" symptom). Guard with an `active` flag: collect each unlisten as it
+    // resolves; if the effect is already torn down by then, unlisten immediately.
+    let active = true;
+    const live: Array<() => void> = [];
+    const track = (p: Promise<() => void>) => {
+      void p.then((fn) => {
+        if (active) live.push(fn);
+        else fn();
+      });
+    };
+    track(listenForTranscript());
+    track(listenForProsody());
+    track(listenForSettings());
+    track(listenForSttUsage());
+    track(listenForCacheClear());
+    track(listenForSpeakerCacheClear());
+    track(listenForViewLogsMenu());
+    track(listenForRecordingSaved());
+    track(listenForHistoryOpen());
+    if (CLOUD_ENABLED) track(listenForHistoryOpenOrg());
+    // These return a synchronous UnlistenFn.
     const unTemplates = initTemplatesSync();
     const unSession = initSessionSync();
     const unSessionCmds = initSessionCommands();
-    const unSttUsage = listenForSttUsage();
-    const unCacheClear = listenForCacheClear();
-    const unSpeakerCacheClear = listenForSpeakerCacheClear();
-    const unViewLogs = listenForViewLogsMenu();
-    const unRecordingSaved = listenForRecordingSaved();
-    const unHistoryOpen = listenForHistoryOpen();
-    const unHistoryOpenOrg = CLOUD_ENABLED ? listenForHistoryOpenOrg() : null;
     const unHistoryPersist = initHistoryPersistSync();
     return () => {
-      unTranscript.then((fn) => fn());
-      unProsody.then((fn) => fn());
-      unSettings.then((fn) => fn());
+      active = false;
+      live.forEach((fn) => fn());
+      live.length = 0;
       unTemplates();
       unSession();
       unSessionCmds();
-      unSttUsage.then((fn) => fn());
-      unCacheClear.then((fn) => fn());
-      unSpeakerCacheClear.then((fn) => fn());
-      unViewLogs.then((fn) => fn());
-      unRecordingSaved.then((fn) => fn());
-      unHistoryOpen.then((fn) => fn());
-      unHistoryOpenOrg?.then((fn) => fn());
       unHistoryPersist();
     };
   }, []);
@@ -116,6 +127,31 @@ function App() {
     return () => {
       clearTimeout(first);
       clearInterval(recheck);
+    };
+  }, []);
+
+  // If the window is closed (or dev-reloaded via HMR) mid-meeting, tell Rust to
+  // stop so the native capture/transcription session can't be orphaned. The only
+  // other stop_meeting caller is the toolbar toggle, so without this a reload/close
+  // leaves the backend recording. Best-effort: the IPC is dispatched even as the
+  // webview tears down; stop_meeting is idempotent.
+  useEffect(() => {
+    if (!isTauri()) return;
+    let active = true;
+    let unlisten: (() => void) | undefined;
+    const stopIfRecording = () => {
+      if (useStore.getState().meetingStatus === "recording") {
+        void invoke("stop_meeting").catch(() => {});
+      }
+    };
+    window.addEventListener("beforeunload", stopIfRecording);
+    void getCurrentWindow()
+      .onCloseRequested(stopIfRecording)
+      .then((fn) => (active ? (unlisten = fn) : fn()));
+    return () => {
+      active = false;
+      window.removeEventListener("beforeunload", stopIfRecording);
+      unlisten?.();
     };
   }, []);
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -560,7 +560,12 @@ export const useStore = create<ParleyState>()(
   setAutoAnalyze: (on) => set({ autoAnalyze: on }),
   setAutoAnalyzeSec: (sec) => set({ autoAnalyzeSec: Math.max(20, sec || 45) }),
 
-  setProsody: (m) => set({ prosody: m }),
+  // Prosody is a live-only signal. Ignore non-null updates outside a recording so a
+  // leaked/duplicate listener (e.g. a dev StrictMode re-subscribe, or a backend
+  // frame slipping through stop_meeting's teardown grace) can't move the gauges
+  // after stop. A null reset always applies.
+  setProsody: (m) =>
+    set((state) => (m && state.meetingStatus !== "recording" ? {} : { prosody: m })),
   pushDeliveryNudge: (n) => set({ deliveryNudge: n }),
   clearDeliveryNudge: () => set({ deliveryNudge: null }),
 
@@ -641,6 +646,10 @@ export const useStore = create<ParleyState>()(
 
   upsertSegment: (segment) =>
     set((state) => {
+      // Live transcript events must never mutate a loaded REPLAY recording — drop a
+      // stray live event (e.g. a leaked listener) while viewing a saved session.
+      // (Live finalize after stop is appMode "live"/"stopped", so it's unaffected.)
+      if (state.appMode === "replay") return {};
       const idx = state.segments.findIndex((s) => s.id === segment.id);
       if (idx === -1) {
         return { segments: [...state.segments, segment] };


### PR DESCRIPTION
Follow-up to the investigation of the transcription "double-trigger" report. **Root cause is the React/Vite dev layer, not Tauri** — and it's dev-only, which is why it was never seen in shipped builds.

## What was happening
`<React.StrictMode>` (dev-only; compiled out in prod) double-invokes App's single Tauri-listener `useEffect`, and Vite HMR re-runs it on edits. That effect's async unlisten cleanup (`unX.then(fn => fn())`) wasn't race-safe: `listen()` resolves on a later tick, so a deferred unlisten could fire *after* the re-mount had already re-subscribed — leaving two live `transcript://segment` / `audio://prosody` handlers. Amplified in dev because the keyless demo path uses a JS-only mock stream that bypasses Rust's idempotency guard. The Start/Stop button itself cannot double-fire (plain `onClick`; StrictMode doesn't double DOM handlers; Rust `running.swap(true)` is idempotent).

## Fixes
- **A — `App.tsx`**: listener effect is now StrictMode/HMR-safe. An `active` flag collects each async `UnlistenFn` as it resolves and unlistens immediately if the effect was already torn down, so a deferred unlisten can never race a re-subscribe. All 14 subscriptions preserved; sync vs async cleanups classified correctly.
- **B — `store.ts`**: defense-in-depth ingress guards. `setProsody` ignores non-null updates outside `recording` (null reset still applies); `upsertSegment` ignores stray live events while in `replay`. The live finalize-tail after Stop (`live`/`stopped`) is unaffected.
- **C — `App.tsx`**: stop the meeting on window close / dev reload (`beforeunload` + Tauri `onCloseRequested`) so the native capture session can't be orphaned — previously only the toolbar toggle ever called `stop_meeting`.
- **D — `commands.rs`**: bound `stop_meeting`'s capture-thread join (poll `is_finished()` to a 1.5 s deadline, then detach + warn) so a wedged thread can't hang the stop command. Complements PR #66's async-session watchdog.

## Verification
- `tsc` ✓, `vitest` 91 ✓, `cargo check` ✓. Scope: `src/App.tsx`, `src/lib/store.ts`, `src-tauri/src/commands.rs`.
- Adversarial diff review: ship (no blockers; verified no dropped/doubled listeners, no broken reset/replay/finalize paths, strictly-safer Rust join).