### PR TITLE
[fix] history: enable webview drag-and-drop in the History window

### DIFF
--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -430,6 +430,12 @@ export async function openHistoryWindow(): Promise<void> {
     minWidth: 720,
     minHeight: 480,
     resizable: true,
+    // The folder sidebar uses HTML5 drag-and-drop (drag a card onto a folder). Tauri's
+    // native OS drag-drop handler is ON by default and SWALLOWS the webview's dragover/
+    // drop events, so without this the drop zones never highlight and nothing moves.
+    // This window has no OS file-drop needs (uploads happen in the main window), so it's
+    // safe to hand drag-drop to the webview.
+    dragDropEnabled: false,
   });
   win.once("tauri://error", (e) => log.error("history: window error", { error: String(e) }));
 }


### PR DESCRIPTION
## Problem
In the History window, dragging a recording card onto a personal or org folder showed **no hover/drop-target highlight and never actually moved or copied** the recording (reported after v0.8.5).

## Root cause
Tauri's native OS drag-drop handler (`dragDropEnabled`) is **on by default** and intercepts the webview's HTML5 `dragover`/`drop` events before React's drop zones can receive them. So the handlers (which are correct) simply never fired.

## Fix
Set `dragDropEnabled: false` on the History `WebviewWindow` (one line). This window has no OS file-drop needs — uploads happen in the main window — so handing drag-drop to the webview is safe.

This restores all the drag-and-drop paths:
- personal ↔ personal folder (move)
- personal → org (copy / move dialog)
- **moving recordings between folders inside an org** (the in-org organization the report asked for)

## Notes
- Takes effect when the History window is next created (fresh app launch / reopen).
- Frontend ships in the next app release (not auto-deployed).

`tsc` + `vite build` clean. The DnD handler logic was already correct; this only unblocks the events.