### PR TITLE
[codex] Improve media permission refresh

### DIFF
--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -30,6 +30,15 @@ mod imp {
     extern "C" {
         fn CGPreflightScreenCaptureAccess() -> bool;
         fn CGRequestScreenCaptureAccess() -> bool;
+        fn CGMainDisplayID() -> u32;
+        fn CGDisplayStreamCreate(
+            display: u32,
+            output_width: usize,
+            output_height: usize,
+            pixel_format: i32,
+            properties: CFDictionaryRef,
+            handler: *const c_void,
+        ) -> CFTypeRef;
         fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
         static kCGWindowName: CFStringRef;
         static kCGWindowOwnerPID: CFStringRef;
@@ -48,6 +57,34 @@ mod imp {
     const KCG_ON_SCREEN_ONLY: u32 = 1;
     const KCG_EXCLUDE_DESKTOP: u32 = 16;
     const KCF_NUMBER_SINT32: isize = 3;
+    const PIXEL_FORMAT_BGRA: i32 = i32::from_be_bytes(*b"BGRA");
+
+    /// Screen Recording grants are ultimately about being allowed to capture the
+    /// display, not about whether any other app currently has a titled window.
+    /// Creating a tiny display stream is a stronger probe than the window-list
+    /// heuristic below and does not need the stream to be started.
+    fn can_create_display_stream() -> bool {
+        unsafe {
+            let handler = ConcreteBlock::new(
+                |_status: i32, _time: u64, _surface: *const c_void, _update: *const c_void| {},
+            );
+            let handler = handler.copy();
+            let stream = CGDisplayStreamCreate(
+                CGMainDisplayID(),
+                1,
+                1,
+                PIXEL_FORMAT_BGRA,
+                std::ptr::null(),
+                &*handler as *const _ as *const c_void,
+            );
+            if !stream.is_null() {
+                CFRelease(stream);
+                true
+            } else {
+                false
+            }
+        }
+    }
 
     /// Robust Screen-Recording check: `CGPreflightScreenCaptureAccess` is
     /// unreliable on recent macOS (returns false even when granted), so fall back
@@ -70,14 +107,19 @@ mod imp {
                 let pid_ref = CFDictionaryGetValue(dict, kCGWindowOwnerPID as *const c_void);
                 let mut pid: i32 = 0;
                 if pid_ref.is_null()
-                    || !CFNumberGetValue(pid_ref, KCF_NUMBER_SINT32, &mut pid as *mut i32 as *mut c_void)
+                    || !CFNumberGetValue(
+                        pid_ref,
+                        KCF_NUMBER_SINT32,
+                        &mut pid as *mut i32 as *mut c_void,
+                    )
                 {
                     continue;
                 }
                 if pid == our_pid {
                     continue; // our own windows always expose their title
                 }
-                let name = CFDictionaryGetValue(dict, kCGWindowName as *const c_void) as CFStringRef;
+                let name =
+                    CFDictionaryGetValue(dict, kCGWindowName as *const c_void) as CFStringRef;
                 if !name.is_null() && CFStringGetLength(name) > 0 {
                     granted = true;
                     break;
@@ -120,6 +162,9 @@ mod imp {
 
     pub fn screen_recording_authorized() -> bool {
         if unsafe { CGPreflightScreenCaptureAccess() } {
+            return true;
+        }
+        if can_create_display_stream() {
             return true;
         }
         can_read_other_window_titles()

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -54,6 +54,13 @@ export function Onboarding() {
     }
   }
 
+  function schedulePermissionRechecks() {
+    void recheck();
+    for (const delay of [500, 1500, 3000, 6000]) {
+      globalThis.setTimeout(() => void recheck(), delay);
+    }
+  }
+
   // Permissions step (4): re-check on entry AND whenever the app regains focus /
   // becomes visible, plus a slow fallback poll — so granting mic/screen access in
   // the system prompt or System Settings flips the row to ✓ on its own when the
@@ -234,7 +241,7 @@ export function Onboarding() {
                   await invoke("start_mic_test", { inputDevice: settings.inputDevice }).catch(() => {});
                   await invoke("stop_mic_test").catch(() => {});
                   await invoke("open_privacy_settings", { pane: "microphone" }).catch(() => {});
-                  void recheck();
+                  schedulePermissionRechecks();
                 }}
               />
               <PermRow
@@ -245,7 +252,7 @@ export function Onboarding() {
                 onAction={async () => {
                   await invoke("request_screen_recording").catch(() => {});
                   await invoke("open_privacy_settings", { pane: "screen" }).catch(() => {});
-                  void recheck();
+                  schedulePermissionRechecks();
                 }}
               />
               <PermRow
@@ -256,7 +263,7 @@ export function Onboarding() {
                 onAction={async () => {
                   await invoke("request_input_monitoring").catch(() => {});
                   await invoke("set_voice_typing_shortcut", { shortcut: settings.voiceTypingShortcut }).catch(() => {});
-                  void recheck();
+                  schedulePermissionRechecks();
                 }}
               />
               <PermRow
@@ -267,7 +274,8 @@ export function Onboarding() {
                 onAction={async () => {
                   // Single native prompt (it offers its own "Open System Settings").
                   await invoke("accessibility_status", { prompt: true }).catch(() => {});
-                  void recheck();
+                  await invoke("ensure_fn_listener").catch(() => {});
+                  schedulePermissionRechecks();
                 }}
               />
               <div className="flex items-center gap-2">

--- a/src/settings/PermissionsPanel.tsx
+++ b/src/settings/PermissionsPanel.tsx
@@ -57,6 +57,20 @@ export function PermissionsPanel() {
     refresh().catch(() => {});
   }, []);
 
+  useEffect(() => {
+    const refreshNow = () => {
+      refresh().catch(() => {});
+    };
+    globalThis.addEventListener("focus", refreshNow);
+    document.addEventListener("visibilitychange", refreshNow);
+    const id = globalThis.setInterval(refreshNow, 2000);
+    return () => {
+      globalThis.removeEventListener("focus", refreshNow);
+      document.removeEventListener("visibilitychange", refreshNow);
+      globalThis.clearInterval(id);
+    };
+  }, []);
+
   // The native request prompts (mic / accessibility / screen) only show once per
   // app launch. So the first click triggers the prompt (which itself offers an
   // "Open System Settings" button); every click after that opens the relevant
@@ -70,6 +84,11 @@ export function PermissionsPanel() {
       await request().catch(() => {});
     }
     await refresh();
+    for (const delay of [500, 1500, 3000, 6000]) {
+      globalThis.setTimeout(() => {
+        refresh().catch(() => {});
+      }, delay);
+    }
   }
 
   if (!isTauri()) return null;


### PR DESCRIPTION
## What changed

- Added a CoreGraphics display-stream probe before the existing window-title heuristic when checking macOS Screen Recording permission.
- Made the Settings permissions panel refresh automatically on focus, visibility changes, and a 2s mounted poll.
- Added delayed permission rechecks after grant actions in both Settings and onboarding to catch TCC updates that arrive shortly after returning from System Settings.

## Why

The Settings permissions page only refreshed on mount or manual click, so it could stay stale after the user granted microphone or Screen Recording access. Screen Recording detection also depended on reading another app window title, which can falsely report not granted when no suitable titled window is available.

## Validation

- `bun run build`
- `rustfmt --edition 2021 src/permissions.rs --check`
- `cargo check`
