### PR TITLE
[codex] Fix voice shortcut onboarding merge

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -274,7 +274,6 @@ export function Onboarding() {
                 onAction={async () => {
                   // Single native prompt (it offers its own "Open System Settings").
                   await invoke("accessibility_status", { prompt: true }).catch(() => {});
-                  await invoke("ensure_fn_listener").catch(() => {});
                   schedulePermissionRechecks();
                 }}
               />


### PR DESCRIPTION
## What changed

- Removes the stale `ensure_fn_listener` call from the Accessibility row in onboarding.

## Why

After PR #77 introduced a configurable voice-typing shortcut, the listener should be applied through `set_voice_typing_shortcut` from the Input Monitoring flow and settings sync. The latest main permission-refresh changes accidentally kept the old fn-specific re-arm in the Accessibility row.

## Validation

- `bun install --frozen-lockfile`
- `bun run build` (passes; existing Vite chunk warnings only)
- `git diff --check`
