### PR TITLE
Fix timeline analysis prompt behavior

### DIFF
--- a/src/lib/ai/findingSolution.test.ts
+++ b/src/lib/ai/findingSolution.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineEvent } from "../types";
+import { seg } from "../test/fixtures";
+import { buildFindingSolutionPrompt, segmentsKnownAtFinding } from "./findingSolution";
+
+const finding: TimelineEvent = {
+  id: "f1",
+  atMs: 10_000,
+  side: "them",
+  severity: "critical",
+  source: "extra",
+  title: "Price objection",
+  detail: "THEM challenged the price and ME needs to explore before moving.",
+};
+
+const transcript = [
+  seg({ id: "before", source: "me", text: "Our price is 6000.", startMs: 5_000, endMs: 6_000 }),
+  seg({ id: "moment", source: "them", text: "6000 is too high.", startMs: 10_000, endMs: 12_000 }),
+  seg({ id: "future", source: "me", text: "Then I can do 4500.", startMs: 20_000, endMs: 21_000 }),
+];
+
+describe("finding solution prompt context", () => {
+  it("keeps live advice bounded to the selected finding turn", () => {
+    expect(segmentsKnownAtFinding(transcript, finding).map((s) => s.id)).toEqual(["before", "moment"]);
+
+    const prompt = buildFindingSolutionPrompt({
+      context: "",
+      finding,
+      segments: transcript,
+      mode: "live",
+    });
+
+    expect(prompt).toContain("MODE: REALTIME ADVICE");
+    expect(prompt).toContain("6000 is too high.");
+    expect(prompt).not.toContain("Then I can do 4500.");
+    expect(prompt).not.toContain("Full transcript for HINDSIGHT only");
+  });
+
+  it("labels future transcript as hindsight for replay coaching", () => {
+    const prompt = buildFindingSolutionPrompt({
+      context: "",
+      finding,
+      segments: transcript,
+      mode: "replay",
+    });
+
+    expect(prompt).toContain("MODE: POST-EVALUATION COACHING");
+    expect(prompt).toContain("Transcript known at this moment");
+    expect(prompt).toContain("Full transcript for HINDSIGHT only");
+    expect(prompt).toContain("Then I can do 4500.");
+  });
+});

--- a/src/lib/ai/findingSolution.ts
+++ b/src/lib/ai/findingSolution.ts
@@ -6,6 +6,8 @@ import { recordLlmUsage } from "../usage/log";
 import { profileContext, outputLanguageInstruction } from "./profile";
 import type { FindingSolution, Settings, TimelineEvent, TranscriptSegment } from "../types";
 
+export type FindingSolutionMode = "live" | "replay";
+
 const replySchema = z.object({
   kind: z
     .enum(["rebut", "reframe", "trade", "concede_redirect"])
@@ -32,11 +34,11 @@ const schema = z.object({
     .describe("2-3 distinct ready-to-use reply options, spanning angles (rebut/reframe/trade/concede_redirect) where sensible."),
 });
 
-const SYSTEM = `You are the reply coach for Parley. The user ("ME") is in a negotiation/interview against the other party ("THEM"). You are given ONE notable moment plus the FULL conversation transcript.
+const SYSTEM = `You are the reply coach for Parley. The user ("ME") is in a negotiation/interview against the other party ("THEM"). You are given ONE notable moment plus timestamped transcript context.
 
 WHOSE REPLY — CRITICAL: every "reply" is the next line MY SIDE ("ME") says, in MY voice and serving MY interest. You are coaching ME, NOT THEM — NEVER write what THEM would say, and NEVER continue, defend, or strengthen THEM's argument. The self-profile and meeting context tell you which speaker is ME; everyone else is THEM. If the moment's side is "them", ME is RESPONDING TO / countering what THEM did there; if the side is "me", ME is fixing MY OWN misstep — what ME should have said instead. If it's ever unclear who is who, infer ME from the profile + meeting context (and which side each speaker argues for) and ALWAYS reply from MY side.
 
-Think about the WHOLE negotiation — the overall stakes, leverage, and where the deal is heading — not just this one local exchange. A reply that wins this point but weakens ME's position in the bigger picture is a bad reply. Then hand ME ready-to-use ways to reply at this moment.
+Think about the overall stakes, leverage, and where the deal is heading — not just this one local exchange. A reply that wins this point but weakens ME's position in the bigger picture is a bad reply. Then hand ME ready-to-use ways to reply at this moment.
 
 Ground the replies in PRINCIPLED NEGOTIATION: focus on INTERESTS not positions, appeal to OBJECTIVE CRITERIA rather than raw pressure, look for OPTIONS that create mutual gain, and account for MY BATNA / target / bottom line (given in the context, if any) and the ZOPA. Never invent facts, numbers, or a BATNA that wasn't given.
 
@@ -44,13 +46,76 @@ Output ONLY:
 - 2-3 distinct "reply" options, each a VERBATIM line ME can say right now. Span different strategic angles where it helps (rebut / reframe / trade / concede_redirect) — don't force angles that don't fit.
 - For each, ONE short "consideration": the key trade-off, or what the reply does for ME's position in the overall negotiation.
 
-Be terse. Do NOT explain at length what went wrong, summarize, or narrate the situation — ME already knows the moment. Ground every reply in what was actually said across the whole transcript; never invent quotes or facts. Respond ENTIRELY in the language of the transcript.`;
+Be terse. Do NOT explain at length what went wrong, summarize, or narrate the situation — ME already knows the moment. Ground every reply in what was actually knowable at the moment unless a section is explicitly labeled HINDSIGHT; never invent quotes or facts. Respond ENTIRELY in the language of the transcript.`;
+
+function findingCutoffMs(finding: TimelineEvent, segments: TranscriptSegment[]): number {
+  const spoken = segments
+    .filter((s) => s.isFinal && s.text.trim())
+    .sort((a, b) => a.startMs - b.startMs);
+  const containing = spoken.find((s) => s.startMs <= finding.atMs && finding.atMs <= s.endMs);
+  if (containing) return containing.endMs;
+  const sameSecond = spoken.find((s) => s.startMs >= finding.atMs && s.startMs < finding.atMs + 1000);
+  if (sameSecond) return sameSecond.endMs;
+  let nearestBefore: TranscriptSegment | null = null;
+  for (const s of spoken) {
+    if (s.startMs <= finding.atMs) nearestBefore = s;
+  }
+  return nearestBefore?.endMs ?? finding.atMs;
+}
+
+export function segmentsKnownAtFinding(segments: TranscriptSegment[], finding: TimelineEvent): TranscriptSegment[] {
+  const cutoffMs = findingCutoffMs(finding, segments);
+  return segments.filter((s) => s.isFinal && s.text.trim() && s.startMs <= cutoffMs);
+}
+
+export function buildFindingSolutionPrompt(opts: {
+  context: string;
+  finding: TimelineEvent;
+  segments: TranscriptSegment[];
+  names?: Record<string, string>;
+  mode?: FindingSolutionMode;
+}): string {
+  const { context, finding, segments, names, mode = "replay" } = opts;
+  // At-moment context must stop at the selected turn; otherwise an old live
+  // finding opened later can leak future negotiation content into the advice.
+  const knownTranscript = transcriptWithTimestamps(segmentsKnownAtFinding(segments, finding), names);
+  const fullTranscript = transcriptWithTimestamps(segments, names);
+
+  // The moment is anchored by its timestamp; the model locates the surrounding
+  // exchange in the timestamped transcript below (no quotes are stored).
+  const moment =
+    `The moment to reply to (at ${formatClock(finding.atMs)} in the transcript below, side = ${finding.side}):\n` +
+    `- ${finding.title}: ${finding.detail}`;
+
+  // If the retro already found ME defused this moment, hand the model MY actual
+  // response so the suggestions build on it without treating later facts as
+  // knowledge available at the moment.
+  const resolvedBlock =
+    finding.resolved && finding.resolution?.trim()
+      ? `\n\nME ALREADY RESPONDED to this moment later in the conversation:\n- ${finding.resolution.trim()}\n` +
+        `This is hindsight context from after the moment. If it worked, you may give replies that reinforce or extend the same move; if it was weak or incomplete, give a stronger version. Do NOT imply ME knew later facts at the moment.`
+      : "";
+
+  const modeBlock =
+    mode === "live"
+      ? `MODE: REALTIME ADVICE.
+Use ONLY the "Transcript known at this moment" below when drafting reply lines and considerations. Do not use any content after ${formatClock(finding.atMs)}; it is not provided because ME would not know it yet. Make the options actionable next steps: ask, clarify, test criteria, protect leverage, or trade.`
+      : `MODE: POST-EVALUATION COACHING.
+Draft what ME should have said using the "Transcript known at this moment" as the factual boundary for the reply itself. You may use the full transcript only as HINDSIGHT to improve coaching. If a consideration relies on later behavior, explicitly start it with "Hindsight:" (or the equivalent in the transcript language). Never make a reply line depend on facts ME learned only later.`;
+
+  const hindsightBlock =
+    mode === "replay" && fullTranscript !== knownTranscript
+      ? `\n\nFull transcript for HINDSIGHT only:\n${fullTranscript || "(no transcript)"}`
+      : "";
+
+  return `${context}${modeBlock}\n\n${moment}${resolvedBlock}\n\nTranscript known at this moment:\n${knownTranscript || "(no transcript)"}${hindsightBlock}\n\nGive ME the reply options — each a line MY side would say next, never THEM's.`;
+}
 
 /**
- * Generate the "how should I reply" solution for ONE finding. Reads the FULL
- * transcript (global — the model weighs the whole negotiation, not just the
- * local exchange) plus the finding fields. Mode-agnostic: works for LIVE
- * (transcript so far) and REPLAY (whole recording) alike.
+ * Generate the "how should I reply" solution for ONE finding. LIVE uses only
+ * context available at that moment; REPLAY also provides the full transcript as
+ * explicitly labeled hindsight so coaching can learn from later behavior without
+ * pretending ME knew it in the moment.
  */
 export async function generateFindingSolution(opts: {
   settings: Settings;
@@ -58,38 +123,20 @@ export async function generateFindingSolution(opts: {
   segments: TranscriptSegment[];
   meetingContext?: string;
   names?: Record<string, string>;
+  mode?: FindingSolutionMode;
 }): Promise<FindingSolution> {
-  const { settings, finding, segments, meetingContext, names } = opts;
-
-  // Global: hand the model the entire conversation so its reply accounts for the
-  // whole negotiation, not just a 1-2 minute window around the moment.
-  const fullTranscript = transcriptWithTimestamps(segments, names);
+  const { settings, finding, segments, meetingContext, names, mode = "replay" } = opts;
 
   const ctx =
     profileContext(settings) +
     (meetingContext?.trim() ? `Meeting context: ${meetingContext.trim()}\n\n` : "");
-
-  // The moment is anchored by its timestamp; the model locates the surrounding
-  // exchange in the full timestamped transcript below (no quotes are stored).
-  const moment =
-    `The moment to reply to (at ${formatClock(finding.atMs)} in the transcript below, side = ${finding.side}):\n` +
-    `- ${finding.title}: ${finding.detail}`;
-
-  // If the retro already found ME defused this moment, hand the model MY actual
-  // response so the suggestions BUILD ON it (reinforce / strengthen) instead of
-  // ignoring what ME already said.
-  const resolvedBlock =
-    finding.resolved && finding.resolution?.trim()
-      ? `\n\nME ALREADY RESPONDED to this moment later in the conversation:\n- ${finding.resolution.trim()}\n` +
-        `Treat that as MY starting point: if it worked, give replies that REINFORCE or EXTEND it; if it was weak or incomplete, give a STRONGER version of the same move. Do NOT ignore it, repeat it verbatim, or contradict MY own line.`
-      : "";
 
   const { object, usage } = await generateObjectResilient({
     settings,
     kind: "eval",
     schema,
     system: SYSTEM + JSON_MODE_INSTRUCTION + outputLanguageInstruction(settings),
-    prompt: `${ctx}${moment}${resolvedBlock}\n\nFull transcript:\n${fullTranscript || "(no transcript)"}\n\nWeigh the whole negotiation, then give ME the reply options — each a line MY side would say next, never THEM's.`,
+    prompt: buildFindingSolutionPrompt({ context: ctx, finding, segments, names, mode }),
   });
   void recordLlmUsage(settings, "eval", "eval", usage);
 

--- a/src/lib/ai/timeline.ts
+++ b/src/lib/ai/timeline.ts
@@ -42,9 +42,9 @@ const eventSchema = z.object({
   resolved: z
     .boolean()
     .describe(
-      "true when, LATER in the conversation, ME actually responded to / addressed this moment — answered the " +
-        "question, countered the pressure, corrected the misstep, or defused the risk. (Whether ME did it WELL is " +
-        "judged elsewhere; here only whether ME took it on.) false if it was left unaddressed or you are unsure."
+      "true ONLY when ME meaningfully mitigated / repaired this moment — explored the concern, protected leverage, " +
+        "traded for value, corrected the misstep, or otherwise reduced the risk. A reply by itself is NOT resolution; " +
+        "a weak answer, unexplored concession, or ignored concern stays unresolved."
     ),
   resolution: z
     .string()
@@ -65,7 +65,7 @@ const SYSTEM_BODY = `
 
 You are given the user's ACTIVE EVALUATIONS (each with an id, a name, and what to look for) and the full timestamped transcript (every line is prefixed with its [m:ss] start time).
 
-Work at the level of MEANINGFUL EXCHANGES, not individual sentences. Read the WHOLE conversation, then surface only the handful of moments that genuinely shaped the negotiation — a position taken, leverage, a constraint or concern raised, a concession, a real risk, a mistake/missed move by ME, OR a real challenge/objection/pressure/risk from THEM that ME then TOOK ON and handled (a WIN worth recording — surface it as a resolved moment; see RESOLVED MOMENTS). A win counts ONLY when there was genuine tension for ME to defuse — never ME merely answering a neutral question, being agreeable, or saying something pleasant. GROUP a back-and-forth on one topic into ONE moment, anchored at its most representative timestamp; do NOT emit a separate finding for each sentence or minor turn — a mistake by ME and ME's own later correction of it are ONE resolved moment, never two. Prefer a few high-signal findings over many granular ones, and surface open/unresolved problems and risks FIRST: wins are ADDITIONAL, never a substitute for an open problem and never take its slot.
+Work at the level of MEANINGFUL EXCHANGES, not individual sentences. Read the conversation, then surface only the handful of moments that genuinely shaped the negotiation — a position taken, leverage, a constraint or concern raised, a concession, a real risk, a mistake/missed move by ME, OR a real challenge/objection/pressure/risk from THEM that ME meaningfully handled (a WIN worth recording — surface it as a resolved moment; see RESOLVED MOMENTS). A win counts ONLY when there was genuine tension for ME to defuse AND ME actually reduced the risk — never ME merely replying, answering a neutral question, being agreeable, or saying something pleasant. GROUP a back-and-forth on one topic into ONE moment, anchored at its most representative timestamp; do NOT emit a separate finding for each sentence or minor turn — a mistake by ME and ME's own later meaningful repair are ONE resolved moment, never two. Prefer a few high-signal findings over many granular ones, and surface open/unresolved problems and risks FIRST: wins are ADDITIONAL, never a substitute for an open problem and never take its slot.
 
 For EACH moment provide:
 - time: the [m:ss] it is best anchored to — copy a REAL timestamp EXACTLY from the transcript line it refers to. This is the ONLY anchor (there are no quotes), so it must be accurate enough for ME to jump straight to that line.
@@ -74,8 +74,8 @@ For EACH moment provide:
 - source: "eval" when the moment matches one OR MORE configured evaluations — also set evalIds to EVERY eval id it genuinely matches. A single moment can match SEVERAL (e.g. a grand over-promise can be both "pushback" and "deception"). Do NOT force-fit: if it doesn't clearly fit any eval, use "extra" with evalIds [].
 - evalIds: the matching evaluation ids (array — one, several, or [] for "extra").
 - title: a short label for the dynamic (not a quote).
-- detail: 1-2 sentences on the STRATEGIC substance — what is really going on (the underlying interest, leverage, risk, or move) and why it matters — so ME knows how to think about and negotiate it, not merely what was said.
-- resolved: true ONLY when, LATER in the transcript, ME actually responded to / addressed this moment — answered the question, countered the pressure, corrected MY own misstep, or defused the risk. false if it was left hanging, ignored, or you are unsure. (Mainly a "them" pressure/objection/risk that ME took on, but also a "me" misstep ME later fixed.)
+- detail: 1-2 sentences on the STRATEGIC substance — what is really going on (the underlying interest, leverage, risk, missed exploration, or move) and why it matters — so ME knows how to think about and negotiate it, not merely what was said.
+- resolved: true ONLY when ME meaningfully mitigated / repaired this moment — explored the concern, protected leverage, traded for value, corrected MY own misstep, or otherwise reduced the risk. false if ME merely replied, gave an unexplored concession, accepted the premise, left it hanging, ignored it, or you are unsure. (Mainly a "them" pressure/objection/risk that ME handled well enough to reduce, but also a "me" misstep ME later fixed.)
 - resolution: when resolved, ONE short line naming MY actual move and quoting/paraphrasing MY key words; "" when not resolved.
 
 INTERPRET IN FULL CONTEXT — accuracy matters more than coverage:
@@ -84,9 +84,23 @@ INTERPRET IN FULL CONTEXT — accuracy matters more than coverage:
 - When THEM makes a strong point or a good proposal, surface it as a "them" moment so ME can think about how to respond — even if no eval targets it.
 - If MY negotiation setup (BATNA / target / bottom line) is provided in the context, USE it: judge leverage and the ZOPA (zone of possible agreement) against it, separate interests from positions, prefer objective criteria over pressure, and flag when ME is being pushed toward MY bottom line.
 
-RESOLVED MOMENTS — record what ME handled, do NOT drop it. A real challenge ME took on is a WIN worth showing precisely BECAUSE handling it is what ME should see; when ME later answers, counters, corrects, or defuses a moment, set resolved + resolution and it renders GREEN. Keep its side by WHOSE move it was, never by who came out ahead: a THEM objection/pressure/risk ME rebutted stays "them" + resolved; a ME misstep ME later fixed stays "me" + resolved. Be honest — mark resolved ONLY when the transcript really shows ME addressing it; you need NOT judge whether the response was strong (that is judged separately), but you DO need a concrete "how": if you cannot name MY actual move in the resolution line, it is not a win — omit the moment, do NOT emit it as an unresolved warn/critical instead. In a still-in-progress meeting, mark resolved ONLY once ME has clearly finished addressing it; a reply still unfolding stays unresolved. A moment ME ignored or never came back to stays unresolved.
+RESOLVED MOMENTS — record what ME meaningfully handled, do NOT drop it. A real challenge ME reduced is a WIN worth showing precisely BECAUSE handling it is what ME should see; when ME later explores, counters with substance, trades for value, corrects, repairs, or defuses a moment, set resolved + resolution and it renders GREEN. Keep its side by WHOSE move it was, never by who came out ahead: a THEM objection/pressure/risk ME mitigated stays "them" + resolved; a ME misstep ME repaired stays "me" + resolved. Be strict — a reply alone is NOT resolution. Do NOT mark resolved when ME simply answered, changed the number/position, conceded, accepted pressure, or moved on without exploring the other side's interest/rationale. You MUST judge whether MY response meaningfully reduced the risk; if it did not, keep the underlying problem unresolved and set severity by its stakes. For example, if THEM says "6000 is too high" and ME immediately drops to 4500 without probing budget, criteria, priorities, or a trade, that is likely a serious unresolved ME concession/missed-exploration issue, NOT resolved. If you cannot name MY meaningful mitigating move in the resolution line, it is not resolved. In a still-in-progress meeting, mark resolved ONLY once ME has clearly finished a meaningful mitigation; a reply still unfolding stays unresolved. A moment ME ignored or never came back to stays unresolved.
 
 Be selective and ACCURATE. A short list of well-judged, strategic findings is far better than many literal ones. Ground everything in what was actually said; never fabricate timestamps — every time must be copied from a real transcript line.`;
+
+const LIVE_MODE_INSTRUCTIONS = `
+
+MODE: REALTIME / IN-PROGRESS ANALYSIS.
+- Treat this as coaching while ME can still change the conversation. Highlight red/critical risks when warranted, but write detail so it points to the NEXT useful move: what ME should ask, clarify, slow down, protect, or trade next.
+- Prefer open, actionable findings over retrospective praise. A severe live issue should remain visible until ME has meaningfully mitigated it.
+- Do not use hindsight language; this transcript contains only what has been said so far.`;
+
+const REPLAY_MODE_INSTRUCTIONS = `
+
+MODE: POST-EVALUATION / RETROSPECTIVE ANALYSIS.
+- The conversation is over. Be direct about what went wrong, where MY response was weak, what leverage or information ME failed to explore, and what ME should learn for next time.
+- You may use later counterparty behavior as hindsight evidence, but label it as hindsight in the detail when it matters (for example: "In hindsight, their later budget comment suggests this should have been probed here.").
+- Do not convert a bad response into a green/resolved card merely because ME replied; unresolved mistakes and weak concessions should stay warn/critical.`;
 
 /** Parse a model-supplied "[m:ss]" / "m:ss" / "h:mm:ss" time into milliseconds. */
 export function parseClockMs(raw: string | undefined): number | null {
@@ -215,7 +229,10 @@ export async function analyzeTimeline(opts: {
   const list = evals.length
     ? evals.map((e) => `### id: ${e.id}\nname: ${e.name}\nwatch for: ${e.prompt}`).join("\n\n")
     : "(none configured)";
-  const system = (mode === "live" ? SYSTEM_INTRO_LIVE : SYSTEM_INTRO_REPLAY) + SYSTEM_BODY;
+  const system =
+    (mode === "live" ? SYSTEM_INTRO_LIVE : SYSTEM_INTRO_REPLAY) +
+    SYSTEM_BODY +
+    (mode === "live" ? LIVE_MODE_INSTRUCTIONS : REPLAY_MODE_INSTRUCTIONS);
   const transcriptLabel = mode === "live" ? "Transcript so far" : "Full transcript";
 
   const provider = settings.provider;

--- a/src/lib/analysis/engine.ts
+++ b/src/lib/analysis/engine.ts
@@ -10,7 +10,7 @@ import type { EvalDef, Settings, TimelineEvent, TranscriptSegment } from "../typ
 let analysisBusy = false;
 
 /** Bump when the analysis prompt/output shape changes, to invalidate caches. */
-const ANALYSIS_CACHE_VERSION = "6";
+const ANALYSIS_CACHE_VERSION = "7";
 
 /** Deterministic 32-bit FNV-1a hash → hex; good enough for a content cache key. */
 function fnv1a(s: string): string {

--- a/src/lib/analysis/solution.ts
+++ b/src/lib/analysis/solution.ts
@@ -6,12 +6,12 @@ import { generateFindingSolution } from "../ai/findingSolution";
  * Lazily generate the "how it should have been done" solution for one finding
  * and cache it in the store keyed by finding id. No-ops if the finding is gone,
  * already running/done, or there's no LLM key (the UI guards the no-key case).
- * Reads the FULL transcript (no playhead masking), so it behaves identically in
- * LIVE and REPLAY.
+ * LIVE advice is generated from the transcript known at the finding's turn;
+ * REPLAY additionally gets full-transcript hindsight, explicitly labeled.
  */
 export async function runFindingSolution(findingId: string): Promise<void> {
   const state = useStore.getState();
-  const { settings, segments, speakerNames, findings, findingSolutions, setFindingSolution } = state;
+  const { settings, segments, speakerNames, findings, findingSolutions, setFindingSolution, appMode } = state;
   const meetingContext = meetingBriefText(state);
 
   const entry = findingSolutions[findingId];
@@ -28,6 +28,7 @@ export async function runFindingSolution(findingId: string): Promise<void> {
       segments,
       meetingContext,
       names: speakerNames,
+      mode: appMode,
     });
     useStore.getState().setFindingSolution(findingId, { status: "done", solution, error: null });
   } catch (err) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,9 +86,9 @@ export type WargameStrategyKind = "rebut" | "reframe" | "trade" | "concede_redir
 
 /**
  * A per-finding "how should I reply" solution. Given ONE notable moment, the
- * engine reasons over the WHOLE negotiation (global, not just the local
- * exchange) and returns a few ready-to-use reply options — minimal prose, no
- * diagnosis of what went wrong.
+ * engine returns a few ready-to-use reply options — minimal prose, no diagnosis
+ * of what went wrong. LIVE advice is bounded to what ME knew at that moment;
+ * REPLAY may include explicitly labeled hindsight in the consideration.
  */
 
 /** One concrete way ME could reply at this moment, with a one-line consideration. */
@@ -136,10 +136,10 @@ export interface TimelineEvent {
   title: string;
   /** One or two sentences explaining the moment. */
   detail: string;
-  /** REPLAY/post-eval: true when ME LATER addressed / defused / answered this
-   *  moment elsewhere in the conversation. Rendered GREEN ("resolved") instead of
-   *  the severity colour, and its {@link resolution} is fed to the reply coach so
-   *  suggestions build on what ME already said rather than ignoring it. */
+  /** REPLAY/post-eval: true when ME meaningfully mitigated / repaired this
+   *  moment elsewhere in the conversation. A mere reply or weak concession is not
+   *  enough. Rendered GREEN ("resolved") instead of the severity colour, and its
+   *  {@link resolution} is fed to the reply coach as labeled hindsight. */
   resolved?: boolean;
   /** One short line on HOW ME handled it — present only when {@link resolved}. */
   resolution?: string;


### PR DESCRIPTION
## Summary
- Tighten timeline resolution criteria so a reply or weak concession is not treated as resolved.
- Split realtime and retrospective timeline prompting so live findings focus on actionable next moves while replay findings capture mistakes and hindsight coaching.
- Bound "how to reply" advice to transcript content known at the selected moment, with full transcript only labeled as hindsight in replay mode.

## Test plan
- npm test -- src/lib/ai/findingSolution.test.ts
- npm test
- npm run build


Made with [Cursor](https://cursor.com)