### PR TITLE
fix: use supported tauri asset pattern input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           prerelease: false
           tauriScript: bun run tauri
           args: --target aarch64-apple-darwin
-          releaseAssetNamePattern: "[name]-[version]-[platform]-[arch].[ext]"
+          assetNamePattern: "[name]-[version]-[platform]-[arch].[ext]"
 
       # ── Cloud edition ──────────────────────────────────────────────────────────
       # The OSS release above is already published to GitHub. Now build the CLOUD


### PR DESCRIPTION
## Summary
- Replace the unsupported `releaseAssetNamePattern` Tauri action input with `assetNamePattern`.

## Test plan
- Not run; workflow input-only hotfix.


Made with [Cursor](https://cursor.com)