### PR TITLE
fix: remove unused dictation state

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -68,15 +68,6 @@ pub struct MeetingState {
     recorder: RecorderBuf,
 }
 
-/// State for Typeless-style press-and-hold dictation. This is intentionally
-/// separate from meeting recording so a short dictation never touches the live
-/// meeting transcript or system-audio capture.
-#[derive(Default)]
-pub struct DictationState {
-    running: Arc<AtomicBool>,
-    threads: Mutex<Vec<JoinHandle<()>>>,
-}
-
 /// List available microphone input device names (for the Settings picker).
 #[tauri::command]
 pub fn list_input_devices() -> Vec<String> {


### PR DESCRIPTION
## Summary
- Remove the unused `DictationState` Tauri state so release builds no longer emit the dead-code warning.

## Test plan
- Attempted `cargo check --release --manifest-path src-tauri/Cargo.toml` locally, but this checkout is missing `src-tauri/onnxruntime/libonnxruntime.dylib`, so the Tauri build script stops before Rust checking completes.
- Verified the hotfix diff only removes the unused struct from `src-tauri/src/commands.rs`.

Made with [Cursor](https://cursor.com)