### PR TITLE
[docs] highlight voice typing on the site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,9 @@ It runs in two complementary modes:
 - **Bring your own providers** — pick your transcription vendor and LLM (Claude, OpenAI, Gemini, Groq, Ollama, OpenRouter, and more).
 - **Local-first** — audio and transcripts go straight to the providers you configure; no Pathors AI proxy in between.
 - **Built-in MCP server** — connect Claude (or any MCP client) to the live meeting while the app is open: read the transcript, manage agenda TODOs, and read/add/overwrite/edit the timeline analysis, plus manage evaluation/agenda templates.
+- **Voice typing** — system-wide push-to-talk dictation in any app: hold your key, speak, release, and the text auto-pastes where your cursor is (see [Voice Typing](#-voice-typing)).
 - **Traditional Chinese** — on-the-fly conversion of transcribed text.
 - **Native macOS UI** — clean, custom window chrome.
-
-### 🎤 Voice typing — system-wide dictation
-
-Beyond meetings, Parley doubles as a push-to-talk dictation tool that works in **any** app:
-
-- **Hold to talk** — press and hold your push-to-talk key anywhere, speak, and release to transcribe.
-- **Your shortcut** — default `Option+Space` (needs no extra permission), or record any custom combo, or hold a single modifier key (`fn`/Globe, right `⌘`/`⌥`/`⌃`).
-- **Lands where your cursor is** — the result is copied to the clipboard and auto-pasted into the frontmost app.
-- **Your own provider** — the same bring-your-own transcription as meetings; audio never routes through Pathors AI.
 
 ---
 
@@ -122,9 +114,17 @@ Parley is currently unsigned, so on first launch macOS Gatekeeper may block it. 
 
 ## 🎙️ Voice Typing
 
-Parley does not use macOS Dictation. It runs its own microphone capture and realtime STT pipeline, so the output uses whichever transcription provider you configured in Settings.
+Beyond meetings, Parley doubles as a **system-wide push-to-talk dictation tool** that works in any app. It doesn't use macOS Dictation — it runs its own microphone capture and realtime STT pipeline, so the output uses whichever transcription provider you configured in Settings.
 
-On macOS, hold the push-to-talk key to record a short voice typing session and release it to finish transcription. The key is selectable in **Settings → Voice typing**: `Option+Space` (the default, no extra permission) or a hold-friendly modifier — `fn`/Globe, Right Option, Right Command, or Right Control. Parley copies the completed text to the system clipboard; if you enable auto-paste, it also sends Cmd+V to the frontmost app. The modifier keys require Input Monitoring permission, and auto-paste requires Accessibility permission.
+Hold your push-to-talk key anywhere, speak, and release to transcribe. On release, Parley copies the text to the clipboard and auto-pastes it into the frontmost app (clipboard stays the fallback when Accessibility isn't granted).
+
+Pick the trigger in **Settings → Voice typing**:
+
+- **`Option+Space`** — the default; needs no extra permission.
+- **Any recorded combo** — click the recorder and press the shortcut you want (e.g. `⌃⌥Space`, `⌘⇧D`, or an F-key). Also permission-free.
+- **A single hold-to-talk key** — `fn`/Globe or a right-side `⌘`/`⌥`/`⌃`. These need Input Monitoring (grant it, then relaunch).
+
+Auto-paste needs Accessibility; Parley requests it when you enable voice typing.
 
 ---
 
@@ -137,9 +137,3 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 ## 📄 License
 
 Licensed under the [Apache License 2.0](LICENSE). Copyright 2026 Pathors AI.
-
-## Press-And-Hold Dictation
-
-Parley does not use macOS Dictation. It uses its own microphone capture and the configured realtime STT provider. In the Tauri desktop app, hold the push-to-talk key to record a short dictation, release to transcribe, and Parley copies the completed text to the system clipboard for pasting.
-
-`Option+Space` is the default because macOS does not expose the `fn` key as a reliable official global shortcut for third-party apps. If you'd rather use `fn`/Globe or a right-side modifier, pick it in **Settings → Voice typing**; those keys are captured via a low-level event tap and need Input Monitoring permission.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,16 @@ It runs in two complementary modes:
 - **Local-first** — audio and transcripts go straight to the providers you configure; no Pathors AI proxy in between.
 - **Built-in MCP server** — connect Claude (or any MCP client) to the live meeting while the app is open: read the transcript, manage agenda TODOs, and read/add/overwrite/edit the timeline analysis, plus manage evaluation/agenda templates.
 - **Traditional Chinese** — on-the-fly conversion of transcribed text.
-- **Voice typing** — hold `fn`/Globe on macOS to dictate into the app Parley was previously focused behind; release to transcribe, copy the result, and optionally auto-paste it back into the frontmost app.
 - **Native macOS UI** — clean, custom window chrome.
+
+### 🎤 Voice typing — system-wide dictation
+
+Beyond meetings, Parley doubles as a push-to-talk dictation tool that works in **any** app:
+
+- **Hold to talk** — press and hold your push-to-talk key anywhere, speak, and release to transcribe.
+- **Your shortcut** — default `Option+Space` (needs no extra permission), or record any custom combo, or hold a single modifier key (`fn`/Globe, right `⌘`/`⌥`/`⌃`).
+- **Lands where your cursor is** — the result is copied to the clipboard and auto-pasted into the frontmost app.
+- **Your own provider** — the same bring-your-own transcription as meetings; audio never routes through Pathors AI.
 
 ---
 

--- a/website/README.md
+++ b/website/README.md
@@ -28,12 +28,13 @@ The page has marked media slots (the hero window and the three "Showcase"
 rows). **You don't need to edit any HTML** — just drop a file into `assets/`
 with the matching name and it appears automatically:
 
-| Slot                        | Drop a file named                                  |
-| --------------------------- | -------------------------------------------------- |
-| Hero window                 | `assets/showcase-hero.{gif,png,jpg,webp,mp4}`      |
-| "Every word, attributed"    | `assets/showcase-transcript.{gif,png,jpg,webp,mp4}`|
-| "Ask mid-conversation"      | `assets/showcase-qa.{gif,png,jpg,webp,mp4}`        |
-| "Insight that keeps up"     | `assets/showcase-eval.{gif,png,jpg,webp,mp4}`      |
+| Slot                        | Drop a file named                                     |
+| --------------------------- | ----------------------------------------------------- |
+| Hero window                 | `assets/showcase-hero.{gif,png,jpg,webp,mp4}`         |
+| "Every word, attributed"    | `assets/showcase-transcript.{gif,png,jpg,webp,mp4}`   |
+| "Ask mid-conversation"      | `assets/showcase-qa.{gif,png,jpg,webp,mp4}`           |
+| "Insight that keeps up"     | `assets/showcase-eval.{gif,png,jpg,webp,mp4}`         |
+| "Voice typing"              | `assets/showcase-voicetyping.{gif,png,jpg,webp,mp4}`  |
 
 Notes:
 - `.mp4` is detected too and mounts as a muted, looping, autoplaying clip — often

--- a/website/index.html
+++ b/website/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Parley is an open-source native macOS meeting copilot by Pathors AI. It captures both sides of the call, transcribes live with speaker diarization, runs configurable evaluation playbooks, and answers grounded Q&A — with your own transcription and AI providers."
     />
-    <meta name="keywords" content="meeting copilot, realtime transcription, AI meeting notes, negotiation assistant, sales call analysis, interview copilot, open source, macOS, Pathors AI" />
+    <meta name="keywords" content="meeting copilot, realtime transcription, AI meeting notes, negotiation assistant, sales call analysis, interview copilot, voice typing, dictation, push to talk, open source, macOS, Pathors AI" />
     <meta name="author" content="Pathors AI" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://parley.tw/" />
@@ -89,6 +89,7 @@
         <a href="#features">Why Parley</a>
         <a href="#how">Workflow</a>
         <a href="#showcase">Showcase</a>
+        <a href="#voice-typing">Voice typing</a>
         <a href="#stack">Open source</a>
         <a href="https://pathors.com" target="_blank" rel="noopener">Pathors AI ↗</a>
       </nav>
@@ -326,6 +327,37 @@
               <div class="media-slot__hint">
                 <p><strong>showcase-eval</strong></p>
                 <code>website/assets/showcase-eval.gif</code>
+              </div>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <!-- Voice typing: beyond the meeting -->
+      <section class="section" id="voice-typing">
+        <div class="section__head reveal">
+          <span class="eyebrow">Beyond the meeting</span>
+          <h2>Voice typing, anywhere on your Mac</h2>
+          <p>Parley isn't only for calls. Hold your push-to-talk key in any app, speak, and release — your words are transcribed with your own provider and dropped right where your cursor is.</p>
+        </div>
+
+        <div class="feature-rows">
+          <div class="feature-row reveal">
+            <div class="feature-row__copy">
+              <span class="eyebrow eyebrow--sm">Push to talk</span>
+              <h3>Hold a key. Talk. It types.</h3>
+              <p>The same fast, private transcription that powers your meetings, available system-wide — fire off a message, a note, or a prompt without touching the keyboard.</p>
+              <ul class="checklist">
+                <li>Works in any app, not just Parley</li>
+                <li>Record any shortcut — or hold a single key</li>
+                <li>Auto-pastes where your cursor is</li>
+                <li>Your own transcription provider — nothing in between</li>
+              </ul>
+            </div>
+            <figure class="media-slot media-slot--wide" data-media="showcase-voicetyping">
+              <div class="media-slot__hint">
+                <p><strong>showcase-voicetyping</strong></p>
+                <code>website/assets/showcase-voicetyping.gif</code>
               </div>
             </figure>
           </div>


### PR DESCRIPTION
Promotes voice typing — now a fully-featured system-wide dictation tool after #95 — on the landing page and README.

## Website (`website/index.html`)
- New **"Beyond the meeting"** section (`#voice-typing`) with a spotlight feature-row: "Hold a key. Talk. It types." Reuses the existing `.section` / `.feature-row` / `.checklist` / `.media-slot` classes — a `website/assets/showcase-voicetyping.{gif,mp4,…}` drops in automatically when ready.
- Nav link "Voice typing"; added voice-typing/dictation/push-to-talk to SEO keywords.

## README
- Replaced the stale "hold fn/Globe to dictate" bullet with a proper **system-wide dictation** subsection: recordable shortcut (Option+Space default / custom combo / single modifier), auto-paste into the frontmost app, bring-your-own transcription provider.
- `website/README.md`: documented the new media slot.

Deploy is automatic on merge (the Deploy website workflow runs on any push to `main` touching `website/**`).