### PR TITLE
[docs] add Apple logo to the macOS download buttons

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -99,6 +99,7 @@
           <span>GitHub</span>
         </a>
         <a class="btn btn--primary" href="https://api.parley.tw/download" target="_blank" rel="noopener">
+          <svg class="apple" viewBox="0 0 384 512" width="13" height="16" aria-hidden="true" fill="currentColor"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
           <span>Get Parley</span>
         </a>
       </div>
@@ -123,7 +124,10 @@
             Live transcription, playbooks, and grounded Q&amp;A — open source, on the AI providers you choose.
           </p>
           <div class="hero__cta">
-            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">Get Parley for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">
+              <svg class="apple" viewBox="0 0 384 512" width="15" height="18" aria-hidden="true" fill="currentColor"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
+              <span>Get Parley for macOS</span>
+            </a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">Star on GitHub</a>
           </div>
           <ul class="hero__meta">
@@ -389,7 +393,10 @@
           <h2>Build your own meeting note stack</h2>
           <p>Download Parley for macOS, add the providers you want in Settings, and start shaping it around your meetings. Free and open source.</p>
           <div class="cta__actions">
-            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">Download for macOS</a>
+            <a class="btn btn--primary btn--lg" href="https://api.parley.tw/download" target="_blank" rel="noopener">
+              <svg class="apple" viewBox="0 0 384 512" width="15" height="18" aria-hidden="true" fill="currentColor"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
+              <span>Download for macOS</span>
+            </a>
             <a class="btn btn--ghost btn--lg" href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">View on GitHub</a>
           </div>
           <p class="cta__note">Bring your preferred transcription and AI provider keys. Local model routes are supported where available.</p>


### PR DESCRIPTION
Adds the Apple mark to the download CTAs — nav "Get Parley", hero "Get Parley for macOS", and the bottom "Download for macOS". Inline SVG using `currentColor` so it inherits each button's text colour (dark on the gradient), matching the existing GitHub-button icon. No CSS needed — the buttons already flex their icon + label.

Deploys automatically on merge.