### PR TITLE
[docs] add MCP section to the landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -90,6 +90,7 @@
         <a href="#how">Workflow</a>
         <a href="#showcase">Showcase</a>
         <a href="#voice-typing">Voice typing</a>
+        <a href="#mcp">MCP</a>
         <a href="#stack">Open source</a>
         <a href="https://pathors.com" target="_blank" rel="noopener">Pathors AI ↗</a>
       </nav>
@@ -366,6 +367,37 @@
             </figure>
           </div>
         </div>
+      </section>
+
+      <!-- MCP: connect your own AI client to the live meeting -->
+      <section class="section" id="mcp">
+        <div class="section__head reveal">
+          <span class="eyebrow">Built-in MCP server</span>
+          <h2>Ask the meeting from your own AI</h2>
+          <p>Parley runs a local Model Context Protocol server. Point Claude — or any MCP client — at it and query the live call as it happens, with the AI app you already use.</p>
+        </div>
+
+        <div class="feature-rows">
+          <div class="feature-row reveal">
+            <div class="feature-row__copy">
+              <span class="eyebrow eyebrow--sm">Model Context Protocol</span>
+              <h3>Your AI, wired into the live call</h3>
+              <p>No extra key inside Parley — connect the assistant you already pay for and let it read the running transcript, then ask <em>"what did they commit to?"</em> or <em>"what haven't I asked yet?"</em> grounded in the meeting.</p>
+              <ul class="checklist">
+                <li>Reads the live, speaker-labelled transcript</li>
+                <li>Can drive the agenda, evaluations, and timeline</li>
+                <li>Works with Claude, Cursor, and any MCP client</li>
+              </ul>
+            </div>
+            <div class="codeblock reveal">
+              <button class="copy" data-copy="claude mcp add --transport http parley http://127.0.0.1:3011/mcp">Copy</button>
+              <pre><code><span class="c-cmt"># Connect your MCP client — keep Parley open</span>
+claude mcp add --transport http parley \
+  http://127.0.0.1:3011/mcp</code></pre>
+            </div>
+          </div>
+        </div>
+        <p class="mcp-note">The exact endpoint (and a ready-to-paste command) lives in <strong>Settings → MCP Server</strong>.</p>
       </section>
 
       <!-- Impact / provider support -->

--- a/website/styles.css
+++ b/website/styles.css
@@ -485,6 +485,10 @@ img { max-width: 100%; display: block; }
 }
 .copy:hover { color: var(--text); border-color: var(--line-2); }
 .copy.is-done { color: var(--teal); border-color: rgba(94,234,212,0.4); }
+.mcp-note { text-align: center; color: var(--muted-2); font-size: 13px; margin-top: 30px; }
+.mcp-note strong { color: var(--muted); font-weight: 600; }
+/* In the MCP feature-row the codeblock is the right-hand element, not a centred block. */
+.feature-row .codeblock { margin: 0; max-width: 100%; }
 .cta__actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-top: 30px; }
 .cta__note { color: var(--muted-2); font-size: 13px; margin-top: 22px; }
 


### PR DESCRIPTION
Highlights a differentiator that wasn't on the site: Parley's **built-in MCP server**.

During a live meeting you can point Claude — or any MCP client (Cursor, etc.) — at Parley's local HTTP MCP endpoint and query the meeting from the AI app you already use, instead of only the in-app provider key. The client can read the live, speaker-labelled transcript (`get_transcript`) and drive the agenda / evaluations / timeline.

New section **"Ask the meeting from your own AI"** (after Voice typing): a feature-row with the value prop + a copy-able one-line setup command, plus an `#mcp` nav link. Reuses the existing `.section` / `.feature-row` / `.checklist` / `.codeblock` / `.copy` styles.

Kept the client claims accurate — leads with Claude/Cursor and "any MCP client" rather than promising specific ChatGPT support. Verified responsive (2-col desktop, stacks on mobile, no overflow).

Deploys automatically on merge.