### PR TITLE
[fix] meter mixed output so system audio shows a level; enlarge PTT waveform

### DIFF
--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -25,17 +25,18 @@ const STALL: Duration = Duration::from_millis(600);
 
 /// Sum `rx_a` and `rx_b` sample-by-sample into `tx_out` until both close.
 /// Mixes where both sides have data; a side that ends (or stalls — see [STALL])
-/// stops gating the other, whose audio then passes through untouched. The mic
-/// side (`rx_a`) is metered and emitted as the "me" input level so the header
-/// mic meter still moves even though mic + system are merged into a single
-/// (diarized) transcription session.
+/// stops gating the other, whose audio then passes through untouched. The mixed
+/// OUTPUT is metered and emitted as the "me" input level, so the header meter
+/// reflects everything being captured (mic + system) rather than the mic alone
+/// — otherwise system audio playing with no mic input would leave the meter
+/// flat even though it is being recorded and transcribed.
 pub async fn mix_streams(
     app: AppHandle,
     mut rx_a: UnboundedReceiver<Vec<i16>>,
     mut rx_b: UnboundedReceiver<Vec<i16>>,
     tx_out: UnboundedSender<Vec<i16>>,
 ) {
-    let mut mic_meter = LevelMeter::new(app, "me", LEVEL_EVENT);
+    let mut meter = LevelMeter::new(app, "me", LEVEL_EVENT);
     let mut a: VecDeque<i16> = VecDeque::new();
     let mut b: VecDeque<i16> = VecDeque::new();
     let mut a_open = true;
@@ -48,11 +49,18 @@ pub async fn mix_streams(
     let mut tick = tokio::time::interval(Duration::from_millis(200));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // Meter then forward one output chunk. Every send routes through here so the
+    // "me" level reflects the exact mixed audio and no emit path is missed.
+    // Returns `false` once the consumer is gone, so the caller can stop.
+    let mut emit = |out: Vec<i16>| -> bool {
+        meter.push(&out);
+        tx_out.send(out).is_ok()
+    };
+
     while a_open || b_open {
         tokio::select! {
             chunk = rx_a.recv(), if a_open => match chunk {
                 Some(c) => {
-                    mic_meter.push(&c);
                     a.extend(c);
                     last_a = Instant::now();
                 }
@@ -76,7 +84,7 @@ pub async fn mix_streams(
                 let s = a.pop_front().unwrap() as i32 + b.pop_front().unwrap() as i32;
                 out.push(s.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
             }
-            if tx_out.send(out).is_err() {
+            if !emit(out) {
                 return;
             }
         }
@@ -87,12 +95,12 @@ pub async fn mix_streams(
         if a_open && b_open {
             if !a.is_empty() && b.is_empty() && last_b.elapsed() >= STALL {
                 let out: Vec<i16> = a.drain(..).collect();
-                if tx_out.send(out).is_err() {
+                if !emit(out) {
                     return;
                 }
             } else if !b.is_empty() && a.is_empty() && last_a.elapsed() >= STALL {
                 let out: Vec<i16> = b.drain(..).collect();
-                if tx_out.send(out).is_err() {
+                if !emit(out) {
                     return;
                 }
             }
@@ -101,13 +109,13 @@ pub async fn mix_streams(
         // When one side has permanently ended, flush the other directly.
         if !a_open && !b.is_empty() {
             let out: Vec<i16> = b.drain(..).collect();
-            if tx_out.send(out).is_err() {
+            if !emit(out) {
                 return;
             }
         }
         if !b_open && !a.is_empty() {
             let out: Vec<i16> = a.drain(..).collect();
-            if tx_out.send(out).is_err() {
+            if !emit(out) {
                 return;
             }
         }

--- a/src/voice-typing/VoiceTypingApp.tsx
+++ b/src/voice-typing/VoiceTypingApp.tsx
@@ -7,6 +7,12 @@ import { useThemePreference } from "../lib/theme";
 
 const BAR_COUNT = 20;
 const BAR_FLOOR = 0.05;
+/** Perceptual gain on the mic level before it drives the bars. `level` is a raw
+ *  peak ratio (peak / 32767) that sits low for normal speech, so without a lift
+ *  the bars barely leave the floor. Applied on top of the sqrt curve. */
+const LEVEL_GAIN = 1.7;
+/** Tallest a bar can draw, in px (the pill grows to fit — see the bars row). */
+const BAR_MAX_PX = 22;
 const WAVE_PROFILE = [
   0.28, 0.44, 0.62, 0.38, 0.72, 0.5, 0.86, 0.64, 0.95, 0.74, 0.74, 0.95, 0.64, 0.86, 0.5, 0.72,
   0.38, 0.62, 0.44, 0.28,
@@ -54,7 +60,7 @@ function decayBars(bars: number[]): number[] {
 
 /** Convert the current mic level into a full instantaneous waveform, not history. */
 function instantWaveform(level: number): number[] {
-  const energy = Math.min(1, Math.sqrt(Math.max(0, level)));
+  const energy = Math.min(1, Math.sqrt(Math.max(0, level)) * LEVEL_GAIN);
   const lift = BAR_FLOOR + energy * (1 - BAR_FLOOR);
 
   return WAVE_PROFILE.map((shape, index) => {
@@ -200,12 +206,12 @@ export const VoiceTypingApp = () => {
         >
           {phaseIcon}
         </div>
-        <div className="flex h-4 items-center gap-[2px]">
+        <div className="flex h-6 items-center gap-[2px]">
           {bars.map((b, i) => (
             <span
               key={barKeys.current[i]}
               className="w-[2px] rounded-full bg-sky-500"
-              style={{ height: `${Math.max(2, Math.round(b * 16))}px` }}
+              style={{ height: `${Math.max(2, Math.round(b * BAR_MAX_PX))}px` }}
             />
           ))}
         </div>


### PR DESCRIPTION
Two audio **level-meter / waveform display** bugs (capture + transcription were already fine).

## 1. System (Mac internal) audio drove no meter

In a diarized meeting the mixer metered only the **mic** side (`rx_a` → `"me"`), and the meeting header meter ([TitleBar.tsx](src/components/TitleBar.tsx)) is wired to `source="me"`. So audio playing **inside the Mac** with no mic input left the meter flat — even though it was being recorded and transcribed the whole time.

**Fix:** the mixer now meters the **mixed output** as `"me"`, routed through a single `emit` helper so every send path (main mix, stall-guard passthrough ×2, end-of-side flush ×2) is metered and none is missed. The header meter now reflects everything captured — mic **+** system. Per the chosen single-combined-meter design; the You/Them distinction still comes from diarization on the transcript side.

## 2. Push-to-talk overlay waveform too small

The raw level is a peak ratio (`peak / 32767`) that sits low for normal speech, and the overlay bars were capped at 16 px, so the waveform barely left the floor. Added a perceptual `LEVEL_GAIN` on top of the existing `sqrt` curve and raised the bar ceiling to 22 px (the pill row grows to fit). Typical speech now fills the bars.

## Scope note

Non-diarized BYOK meetings run two separate `me`/`them` sessions with no mixer, so their header still shows mic-only — a minor residual gap. The hosted / diarized path fixed here is the common case (and the reporter's).

## Testing

- `cargo clippy --all-targets` clean
- `tsc --noEmit` clean
- `vitest` 96/96
- Visual sizing/gain are simple constants, easy to tune further.

Follow-up to the transcription fixes in #104 / #105.