### PR TITLE
[fix] enforce a single voice-typing session (abort stale task/socket)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,9 @@ pub fn run() {
         // voice typing) — guarantees at most one live capture session.
         .manage(MicCoordinator::default())
         .manage(MeetingState::default())
+        // Singleton guard for the voice-typing session task (abort-on-restart
+        // + bounded post-release flush) — see voice_typing::VoiceTypingState.
+        .manage(voice_typing::VoiceTypingState::default())
         // Native menu-bar "Diagnostics" submenu (View Logs + Clear Cache).
         .menu(menu::build)
         .on_menu_event(|app, event| menu::on_event(app, event.id().as_ref()))

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -12,12 +12,40 @@
 // The `objc` 0.2 macros emit `cfg(cargo-clippy)` checks newer compilers warn on.
 #![allow(unexpected_cfgs)]
 
+use std::sync::{Arc, Mutex};
+
 use tauri::{AppHandle, State};
 
 use crate::audio::microphone::Microphone;
 use crate::capture::{run_metered_session, spawn_capture, Begin, MicCoordinator, MicUser};
 use crate::commands::{read_config_file, write_config_file};
 use crate::transcription::{SttProvider, TranscribeConfig};
+
+/// Grace for the post-release final flush before a lingering session task is
+/// force-aborted (mirrors `stop_meeting`'s backstop). The frontend waits at
+/// most ~3 s for the flush, so 8 s cuts only genuine zombies.
+const FLUSH_ABORT_GRACE: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// Singleton guard for the voice-typing STT session task. [`MicCoordinator`]
+/// already guarantees at most one CAPTURE, but the session task it feeds (the
+/// provider WebSocket) used to be fire-and-forget: after release it lingers to
+/// flush the final tokens, and a server that never closes leaves it parked
+/// forever with an open socket. Each new press then opened ANOTHER socket
+/// while the old session kept emitting into the same `voice-typing-{n}` /
+/// `voice-typing-tail` segment-id namespace — the overlay showed both
+/// sessions' tokens interleaved (transcript "stacking"). This state pins the
+/// one live task so a new start aborts the old socket first and a stop bounds
+/// its flush.
+#[derive(Default)]
+pub struct VoiceTypingState(Arc<Mutex<VtInner>>);
+
+#[derive(Default)]
+struct VtInner {
+    /// Bumped on every start; stale backstops/starts compare against it so
+    /// they can never abort a NEWER session than the one they belong to.
+    seq: u64,
+    task: Option<tauri::async_runtime::JoinHandle<()>>,
+}
 
 /// Start a mic-only streaming transcription. Idempotent while already running;
 /// refused while a meeting owns the mic (a second input stream could kill the
@@ -34,6 +62,7 @@ use crate::transcription::{SttProvider, TranscribeConfig};
 pub fn start_voice_typing(
     app: AppHandle,
     coord: State<MicCoordinator>,
+    state: State<VoiceTypingState>,
     provider: String,
     api_key: String,
     model: Option<String>,
@@ -54,8 +83,24 @@ pub fn start_voice_typing(
     if provider == SttProvider::Parley && relay_endpoint.is_none() {
         return Err("hosted transcription requires the cloud relay URL".into());
     }
+    // A press must always yield a FRESH session. Release any voice-typing mic
+    // claim left by a desynced frontend (no-op when idle), and abort the
+    // previous session task outright — if it is still flushing, its late
+    // tokens would interleave with the new session's in the overlay, and its
+    // socket must close before we open the next one. Aborting a finished task
+    // is a no-op.
+    coord.stop(MicUser::VoiceTyping);
+    let my_seq = {
+        let mut vt = state.0.lock().unwrap();
+        vt.seq += 1;
+        if let Some(task) = vt.task.take() {
+            task.abort();
+        }
+        vt.seq
+    };
     let gate = match coord.begin(MicUser::VoiceTyping) {
         Begin::Started(gate) => gate,
+        // Unreachable (we just released the claim), kept for safety.
         Begin::AlreadyActive => return Ok(()),
         Begin::Busy(_) => return Err("microphone is in use by the meeting".into()),
     };
@@ -80,7 +125,7 @@ pub fn start_voice_typing(
             return Err(format!("microphone failed to start: {e}"));
         }
     };
-    run_metered_session(
+    let task = run_metered_session(
         &app,
         provider,
         config,
@@ -89,6 +134,16 @@ pub fn start_voice_typing(
         None,
         "voicetyping://error",
     );
+    // Pin the session task so the next start (or stop's backstop) can abort
+    // it. If a newer start won the race while we were spawning, ours is the
+    // stale one — kill our own task instead of clobbering the newer handle
+    // (the newer start already stopped our capture and owns the mic claim).
+    let mut vt = state.0.lock().unwrap();
+    if vt.seq == my_seq {
+        vt.task = Some(task);
+    } else {
+        task.abort();
+    }
     Ok(())
 }
 
@@ -126,11 +181,29 @@ pub fn write_voice_history(app: AppHandle, content: String) -> Result<(), String
 }
 
 /// Stop the session: clear its gate and join the mic thread with a bounded
-/// grace (which drops its PCM sender, closing the STT session cleanly). No-op
-/// if voice typing doesn't own the mic.
+/// grace (which drops its PCM sender, closing the STT session cleanly — the
+/// graceful path that lets the provider flush its final tokens). No-op if
+/// voice typing doesn't own the mic.
+///
+/// Backstop: a provider/relay that never closes the socket would leave the
+/// session task parked on its read half forever. Mirror `stop_meeting`'s
+/// direct-cancel safety net — abort the task once the flush window has long
+/// passed. Guarded by `seq` so a backstop from THIS session can never abort a
+/// newer one started during the grace.
 #[tauri::command]
-pub fn stop_voice_typing(coord: State<MicCoordinator>) {
+pub fn stop_voice_typing(coord: State<MicCoordinator>, state: State<VoiceTypingState>) {
     coord.stop(MicUser::VoiceTyping);
+    let my_seq = state.0.lock().unwrap().seq;
+    let inner = state.0.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(FLUSH_ABORT_GRACE).await;
+        let mut vt = inner.lock().unwrap();
+        if vt.seq == my_seq {
+            if let Some(task) = vt.task.take() {
+                task.abort();
+            }
+        }
+    });
 }
 
 /// Copy text to the system clipboard via the native pasteboard. Needed because

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -88,7 +88,10 @@ pub fn start_voice_typing(
     // previous session task outright — if it is still flushing, its late
     // tokens would interleave with the new session's in the overlay, and its
     // socket must close before we open the next one. Aborting a finished task
-    // is a no-op.
+    // is a no-op. Trade-off: aborting a mid-flush session also drops its
+    // `usage://stt` emit, undercounting the local cost display for that
+    // session's last seconds — acceptable (relay billing is server-side, and
+    // the alternative is the transcript stacking this fixes).
     coord.stop(MicUser::VoiceTyping);
     let my_seq = {
         let mut vt = state.0.lock().unwrap();
@@ -100,7 +103,9 @@ pub fn start_voice_typing(
     };
     let gate = match coord.begin(MicUser::VoiceTyping) {
         Begin::Started(gate) => gate,
-        // Unreachable (we just released the claim), kept for safety.
+        // Unreachable in practice: the host serializes press/release, so no
+        // second voice-typing start can land between the stop above and this
+        // begin. Kept for safety.
         Begin::AlreadyActive => return Ok(()),
         Begin::Busy(_) => return Err("microphone is in use by the meeting".into()),
     };

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -40,8 +40,15 @@ export function initVoiceTyping(): () => void {
   let unPtt: UnlistenFn = () => {};
   let unText: UnlistenFn = () => {};
   let unErr: UnlistenFn = () => {};
+  // Serialize press/release handling: a quick tap used to run endSession's
+  // `stop_voice_typing` while startSession's invoke was still in flight, so
+  // the stop reached Rust FIRST and no-op'd — leaving a live, ownerless
+  // backend session (mic claimed, socket open) behind. Chaining guarantees
+  // start has resolved before its matching stop is issued.
+  let pttChain: Promise<void> = Promise.resolve();
   listen<{ down: boolean }>("voicetyping://ptt", (e) => {
-    onPtt(e.payload.down).catch(() => {});
+    const isDown = e.payload.down;
+    pttChain = pttChain.then(() => onPtt(isDown)).catch(() => {});
   })
     .then((u) => (unPtt = u))
     .catch(() => {});
@@ -100,7 +107,15 @@ async function onPtt(isDown: boolean) {
 }
 
 async function startSession() {
-  if (busy) return;
+  if (busy) {
+    // A press during the previous dictation's settle window. Swallowing it
+    // (the old behavior) left the user talking into nothing — instead deliver
+    // the pending text now and fall through to a fresh session. The backend
+    // start also aborts any session task still flushing, so the old session
+    // cannot leak tokens into the new overlay.
+    clearTimeout(settleTimer);
+    await finalize().catch(() => {});
+  }
   const { settings } = useStore.getState();
   if (!settings.voiceTypingEnabled) return;
   const provider = settings.transcriptionProvider;

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -31,6 +31,10 @@ let down = false;
 let busy = false;
 /** The backend reported the STT session dead (voicetyping://error). */
 let failed = false;
+/** Session generation. A finalize that was still awaiting its copy/paste when
+ *  a NEW session started must not run its tail (emit "done" + schedule hide)
+ *  against the new session's overlay. */
+let gen = 0;
 let settleTimer: ReturnType<typeof setTimeout> | undefined;
 let hideTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -129,6 +133,7 @@ async function startSession() {
   }
   busy = true;
   failed = false;
+  gen += 1;
   latestText = "";
   lastTextAt = Date.now();
   clearTimeout(settleTimer);
@@ -189,6 +194,7 @@ function waitForSettle() {
 }
 
 async function finalize() {
+  const myGen = gen;
   busy = false;
   const text = latestText.trim();
   if (text) {
@@ -204,6 +210,11 @@ async function finalize() {
     }
     appendVoiceEntry(text).catch(() => {});
   }
+  // A new press may have started a session while the copy/paste above was in
+  // flight — its overlay is live, and this finalize's tail must not flip it to
+  // "done" or hide it. The text above was still delivered (it predates the
+  // new session).
+  if (gen !== myGen) return;
   await emit("voicetyping://session", { phase: "done", message: text ? "ok" : "empty" });
   scheduleHide();
 }


### PR DESCRIPTION
## Problem

Rapid push-to-talk presses could **stack transcripts**: old tokens interleaving with the new dictation in the overlay.

`MicCoordinator` guarantees at most one **capture**, but the STT session task it feeds (the provider WebSocket) was fire-and-forget — never tracked, never aborted. After release the session lingers to flush its final tokens (by design), but a provider/relay that never closes the socket leaves the task parked on its read half **forever**, with the socket open. Every session also reuses the same `voice-typing-{n}` / `voice-typing-tail` segment-id namespace, so when a new press opened a second socket while a zombie was still emitting, the overlay rendered both sessions' tokens interleaved. Each additional press could add another socket.

## Fix — make the session a singleton

**Backend** — new `VoiceTypingState` managed state pins the one live session task:

- `start_voice_typing` releases any stale voice-typing mic claim and **aborts the previous session task** (closing its socket) before opening a fresh one. Keydown now always yields a fresh session. The new handle is stored under a `seq` counter so a racing start can never clobber — or kill — a newer session than its own.
- `stop_voice_typing` keeps the graceful gate-based stop (final-token flush preserved) and adds the same direct-cancel safety net `stop_meeting` already has: an **8s abort backstop** (seq-guarded), so a stalled provider can no longer leave a zombie session + open socket behind.

**Frontend** (`host.ts`) — two rapid-press races with the same smell, both pre-existing (the first was flagged by #104's independent review):

- Press/release events are now **serialized through a promise chain**. A quick tap used to race `stop_voice_typing` ahead of its still-in-flight `start_voice_typing`, so the stop no-op'd in Rust and the session it meant to end stayed alive, ownerless (mic claimed, socket open, hosted seconds billed).
- A press during the previous dictation's **settle window** used to be swallowed by the `busy` guard — the user talked into nothing. It now cuts the settle short, delivers the pending text, and starts fresh (the backend abort guarantees the old session can't leak tokens into the new overlay).

## Testing

- `cargo clippy --all-targets` clean
- `tsc --noEmit` clean
- `vitest` 96/96

Follow-up to #104/#105/#106.