### PR TITLE
[fix] delivery coaching scores only the user's mic, never the counterpart

### DIFF
--- a/src-tauri/src/audio/prosody.rs
+++ b/src-tauri/src/audio/prosody.rs
@@ -5,10 +5,13 @@
 //! signals — pitch variation (monotony) and pausing — from the same 16 kHz mono
 //! PCM, and emits an `audio://prosody` event ~2×/s for the frontend gauges/nudges.
 //!
-//! HARD CONSTRAINT (issue #22): this runs on the **mic ("me") stream only**, never
-//! the counterpart. The caller taps the pre-mix mic receiver *before* the mixer
-//! (see `spawn_mic_prosody_tap` in `commands.rs`), so with diarization on we still
-//! analyze raw mic, not the mixed/diarized stream.
+//! HARD CONSTRAINT (issue #22): delivery is scored on the **mic ("me") stream
+//! only**, never the counterpart. The caller taps the pre-mix mic receiver
+//! *before* the mixer (see `spawn_mic_prosody_tap` in `commands.rs`), so with
+//! diarization on we still analyze raw mic, not the mixed/diarized stream. The
+//! system-audio stream IS analyzed too ([`FarEndAnalyzer`]) — but only as a
+//! reference for rejecting the far voice bleeding through the speakers into the
+//! mic; it feeds no user-facing stat of its own.
 //!
 //! F0 is estimated with a self-contained YIN detector (no extra crates, in keeping
 //! with the project's no-native-deps posture). Monotony is the spread of F0 *in
@@ -16,6 +19,8 @@
 //! the reference pitch, so it calibrates to the speaker rather than to absolute Hz.
 
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -56,6 +61,39 @@ const F0_MAX_HZ: f32 = 400.0;
 /// thing monotony uses) is invariant to it.
 const SEMITONE_REF_HZ: f32 = 100.0;
 
+/// Far-end ("them") bleed rejection: with the counterpart played over SPEAKERS,
+/// the mic physically hears them, and their speech would otherwise pollute every
+/// "me" statistic (pace baseline, pitch spread, filled pauses). The system-audio
+/// stream gives us the clean far-end signal, so a mic frame is rejected as bleed
+/// when it is pitch-matched to a recent far-end frame — a purely acoustic test
+/// (never STT). Headphone users are unaffected: without bleed the mic only ever
+/// carries the user's own pitch.
+///
+/// How long a far-end frame stays queryable. Covers capture/chunking skew between
+/// the two streams plus the match window below.
+const FAR_RETAIN_MS: u64 = 600;
+/// A mic frame is compared against far-end frames at most this much older. Wide
+/// enough to absorb the ~100 ms chunk cadence + speaker→mic acoustic delay.
+const FAR_MATCH_WINDOW_MS: u64 = 350;
+/// "The counterpart is (still) talking" for the dead-air gate — wider than the
+/// match window so brief inter-word gaps don't read as the far side going quiet.
+const FAR_ACTIVE_WINDOW_MS: u64 = 800;
+/// Max pitch distance (semitones, octave-tolerant) for a mic frame to count as
+/// the far voice leaking through the speakers. YIN octave errors on the
+/// reverberant bleed path are common, hence the octave folding.
+const BLEED_SEMITONE_TOL: f32 = 1.0;
+/// Bleed must not be dramatically LOUDER than the far-end digital signal; direct
+/// speech into the mic usually is. Loose (mic AGC makes levels incomparable) —
+/// the pitch match is the primary discriminator, this only rescues the case of
+/// the user talking over the far side at a coincidentally matching pitch.
+const BLEED_LEVEL_CEIL: f32 = 1.5;
+
+/// Trailing silence (ms) after which the emitted pitch-spread reads as "no
+/// signal" (0) instead of lingering on the rolling window's stale frames — the
+/// intonation gauge should clear promptly once the user stops talking, not ~7 s
+/// later when the window drains.
+const PITCH_CLEAR_SILENCE_MS: u64 = 2_000;
+
 /// Filled-pause ("um/uh/呃/痾/嗯") detection. A filled pause is one sustained,
 /// flat, vowel-like sound — distinct from connected speech (which has syllable
 /// structure) and from a normal syllable (which is short). STT drops these and the
@@ -86,6 +124,12 @@ struct ProsodyEvent {
     /// pace estimate that (unlike transcript WPM) works in diarized mode too, and
     /// is "me"-only by construction. The frontend baselines it per session.
     speech_rate_hz: f32,
+    /// Whole-session articulation rate (nuclei per *voiced* second) accumulated
+    /// over the mic stream — the streaming twin of [`measure_speech_rate_hz`].
+    /// The retro's measured-pace read uses the last value of this instead of
+    /// measuring the saved recording, which in diarized meetings is the MIX of
+    /// both sides and would score the counterpart's pace too (issue #22).
+    session_rate_hz: f32,
     /// Fraction of frames in the window that were voiced (0..1).
     voiced_ratio: f32,
     /// Current trailing silence in ms (0 while speaking).
@@ -98,6 +142,10 @@ struct ProsodyEvent {
     /// just been recognized (a sustained, flat, single held vowel). The frontend
     /// counts these + nudges; STT can't see them so this is the only source.
     filled_pause: bool,
+    /// Whether the counterpart's (system-audio) stream is currently audible —
+    /// the dead-air nudge must not fire while the other side is talking. Always
+    /// false when there is no system capture (non-macOS / capture failed).
+    farend_active: bool,
 }
 
 /// One analyzed frame's contribution to the rolling stats.
@@ -130,10 +178,15 @@ pub struct ProsodyAnalyzer {
     /// True while the current trailing voiced run already qualifies as a filled
     /// pause, so it's reported once (rising edge) rather than every emit it's held.
     in_filled_pause: bool,
+    /// Cumulative whole-session articulation rate over this (mic-only) stream.
+    session_rate: SessionRateMeter,
+    /// The counterpart's recent acoustic state, for speaker-bleed rejection.
+    /// `None` when there is no system-audio capture to compare against.
+    far: Option<Arc<FarEndState>>,
 }
 
 impl ProsodyAnalyzer {
-    pub fn new(app: AppHandle, source: &'static str) -> Self {
+    pub fn new(app: AppHandle, source: &'static str, far: Option<Arc<FarEndState>>) -> Self {
         Self {
             app,
             source,
@@ -143,6 +196,8 @@ impl ProsodyAnalyzer {
             last_emit_ms: 0,
             last_voiced_ms: None,
             in_filled_pause: false,
+            session_rate: SessionRateMeter::new(),
+            far,
         }
     }
 
@@ -160,10 +215,21 @@ impl ProsodyAnalyzer {
             } else {
                 None
             };
+            // Speaker-bleed rejection: a voiced frame that is really the far
+            // side leaking through the speakers is dropped from EVERY "me"
+            // statistic — zeroed rms so it can't seed syllable nuclei or raise
+            // the per-window loudness floor, and unvoiced so it can't feed the
+            // pitch/pace/filled-pause stats or reset the silence clock.
+            let bleed = self
+                .far
+                .as_ref()
+                .is_some_and(|f| f.is_bleed_at(Instant::now(), rms, semitones));
+            let (rms, semitones) = if bleed { (0.0, None) } else { (rms, semitones) };
             let voiced = semitones.is_some();
             if voiced {
                 self.last_voiced_ms = Some(t_ms);
             }
+            self.session_rate.push(rms);
             self.frames.push_back(FrameStat {
                 t_ms,
                 voiced,
@@ -203,20 +269,6 @@ impl ProsodyAnalyzer {
         let total = self.frames.len().max(1);
         let voiced_ratio = voiced_semitones.len() as f32 / total as f32;
 
-        let (pitch_var_semitones, monotony_score) = if voiced_semitones.len() >= MIN_VOICED_FRAMES {
-            let mean = voiced_semitones.iter().sum::<f32>() / voiced_semitones.len() as f32;
-            let var = voiced_semitones
-                .iter()
-                .map(|x| (x - mean) * (x - mean))
-                .sum::<f32>()
-                / voiced_semitones.len() as f32;
-            let sd = var.sqrt();
-            // Expressive speech varies ~2.5+ semitones; < ~1 reads as monotone.
-            (sd, (1.0 - sd / 2.5).clamp(0.0, 1.0))
-        } else {
-            (0.0, 0.0)
-        };
-
         let speaking = self.frames.back().is_some_and(|f| f.voiced);
         let f0_hz = self
             .frames
@@ -231,6 +283,25 @@ impl ProsodyAnalyzer {
             None => 0,
         };
 
+        // Once the user has been quiet for a bit, the intonation read is over —
+        // report "no signal" instead of letting the rolling window's stale
+        // frames hold the gauge at its last value for ~WINDOW_MS.
+        let pitch_done = silence_ms >= PITCH_CLEAR_SILENCE_MS;
+        let (pitch_var_semitones, monotony_score) =
+            if !pitch_done && voiced_semitones.len() >= MIN_VOICED_FRAMES {
+                let mean = voiced_semitones.iter().sum::<f32>() / voiced_semitones.len() as f32;
+                let var = voiced_semitones
+                    .iter()
+                    .map(|x| (x - mean) * (x - mean))
+                    .sum::<f32>()
+                    / voiced_semitones.len() as f32;
+                let sd = var.sqrt();
+                // Expressive speech varies ~2.5+ semitones; < ~1 reads as monotone.
+                (sd, (1.0 - sd / 2.5).clamp(0.0, 1.0))
+            } else {
+                (0.0, 0.0)
+            };
+
         let _ = self.app.emit(
             PROSODY_EVENT,
             ProsodyEvent {
@@ -239,11 +310,16 @@ impl ProsodyAnalyzer {
                 pitch_var_semitones,
                 monotony_score,
                 speech_rate_hz: self.speech_rate_hz(),
+                session_rate_hz: self.session_rate.rate_hz(),
                 voiced_ratio,
                 silence_ms,
                 longest_pause_ms: self.longest_pause(now_ms),
                 speaking,
                 filled_pause,
+                farend_active: self
+                    .far
+                    .as_ref()
+                    .is_some_and(|f| f.is_active_at(Instant::now())),
             },
         );
     }
@@ -464,6 +540,171 @@ pub fn measure_speech_rate_hz(pcm: &[f32], sample_rate: u32) -> f32 {
     nuclei as f32 / voiced_sec
 }
 
+/// Streaming twin of [`measure_speech_rate_hz`]: accumulates the whole-session
+/// articulation rate frame-by-frame as the live mic is analyzed, so the retro can
+/// report the USER'S pace without ever decoding the saved recording — which in
+/// diarized meetings is the mic+system MIX and would fold the counterpart's speech
+/// into the number. Framing, per-`WINDOW_MS`-block loudness floor, RMS-based
+/// voicing, and the voiced-time denominator all mirror the batch function, so the
+/// two quantities stay comparable (upload entries still use the batch measure).
+struct SessionRateMeter {
+    /// Frames per nuclei-counting block (~`WINDOW_MS`), matching the batch fn.
+    block: usize,
+    /// Current (partial) block's per-frame RMS envelope + voicing flags.
+    rms: Vec<f32>,
+    voiced: Vec<bool>,
+    /// Totals over all completed blocks.
+    nuclei: usize,
+    voiced_frames: u64,
+}
+
+impl SessionRateMeter {
+    fn new() -> Self {
+        let hop_sec = HOP as f32 / TARGET_SAMPLE_RATE as f32;
+        Self {
+            block: (((WINDOW_MS as f32 / 1000.0) / hop_sec).round() as usize).max(8),
+            rms: Vec::new(),
+            voiced: Vec::new(),
+            nuclei: 0,
+            voiced_frames: 0,
+        }
+    }
+
+    /// Feed one analysis frame's RMS. Voicing is RMS-based like the batch measure
+    /// (not YIN-gated like the live windowed rate) to keep the quantities aligned.
+    fn push(&mut self, rms: f32) {
+        self.rms.push(rms);
+        self.voiced.push(rms >= VOICING_RMS_FLOOR);
+        if self.rms.len() >= self.block {
+            self.nuclei += count_syllable_nuclei(&self.rms, &self.voiced);
+            self.voiced_frames += self.voiced.iter().filter(|&&v| v).count() as u64;
+            self.rms.clear();
+            self.voiced.clear();
+        }
+    }
+
+    /// Articulation rate (nuclei per voiced second) over everything seen so far,
+    /// including the current partial block; 0.0 until any voiced speech.
+    fn rate_hz(&self) -> f32 {
+        let partial_voiced = self.voiced.iter().filter(|&&v| v).count() as u64;
+        let voiced_sec =
+            (self.voiced_frames + partial_voiced) as f32 * HOP as f32 / TARGET_SAMPLE_RATE as f32;
+        if voiced_sec <= 0.0 {
+            return 0.0;
+        }
+        (self.nuclei + count_syllable_nuclei(&self.rms, &self.voiced)) as f32 / voiced_sec
+    }
+}
+
+/// One analyzed far-end frame, timestamped at analysis time. Wall-clock (not
+/// sample-clock) because the mic and system streams are captured by independent
+/// tasks whose sample counters aren't aligned.
+struct FarFrame {
+    at: Instant,
+    rms: f32,
+    semitones: Option<f32>,
+}
+
+/// Shared view of the counterpart's ("them") recent acoustic state. Written by
+/// [`FarEndAnalyzer`] on the system-audio task, read by [`ProsodyAnalyzer`] on
+/// the mic task to reject speaker bleed — see the `FAR_*`/`BLEED_*` constants.
+pub struct FarEndState {
+    frames: Mutex<VecDeque<FarFrame>>,
+}
+
+impl FarEndState {
+    pub fn new() -> Self {
+        Self {
+            frames: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    fn push_frame_at(&self, at: Instant, rms: f32, semitones: Option<f32>) {
+        let mut frames = self.frames.lock().unwrap();
+        frames.push_back(FarFrame { at, rms, semitones });
+        while frames
+            .front()
+            .is_some_and(|f| at.duration_since(f.at).as_millis() as u64 > FAR_RETAIN_MS)
+        {
+            frames.pop_front();
+        }
+    }
+
+    /// Whether a VOICED mic frame is the far voice leaking through the speakers:
+    /// a recent far-end frame is pitch-matched (octave-tolerant) and the mic
+    /// level is plausibly bleed rather than direct speech. Unvoiced mic frames
+    /// are never bleed — they carry no pitch and are excluded from stats anyway.
+    fn is_bleed_at(&self, now: Instant, mic_rms: f32, mic_semitones: Option<f32>) -> bool {
+        let Some(mic_st) = mic_semitones else {
+            return false;
+        };
+        let frames = self.frames.lock().unwrap();
+        let mut far_max_rms = 0.0f32;
+        let mut pitch_match = false;
+        for f in frames.iter().rev() {
+            if now.duration_since(f.at).as_millis() as u64 > FAR_MATCH_WINDOW_MS {
+                break;
+            }
+            if f.rms < VOICING_RMS_FLOOR {
+                continue;
+            }
+            far_max_rms = far_max_rms.max(f.rms);
+            if let Some(far_st) = f.semitones {
+                let d = (far_st - mic_st).abs();
+                // Octave-fold: bleed through a speaker+room often YIN-detects an
+                // octave off; treat ±12 st as the same voice.
+                let d = d.min((d - 12.0).abs());
+                if d <= BLEED_SEMITONE_TOL {
+                    pitch_match = true;
+                }
+            }
+        }
+        pitch_match && mic_rms < far_max_rms * BLEED_LEVEL_CEIL
+    }
+
+    /// Whether the far side has produced audible signal within
+    /// [`FAR_ACTIVE_WINDOW_MS`] — gates the dead-air nudge ("nobody talking"),
+    /// which must not fire in the middle of the counterpart's monologue.
+    fn is_active_at(&self, now: Instant) -> bool {
+        self.frames.lock().unwrap().iter().rev().any(|f| {
+            now.duration_since(f.at).as_millis() as u64 <= FAR_ACTIVE_WINDOW_MS
+                && f.rms >= VOICING_RMS_FLOOR
+        })
+    }
+}
+
+/// Streaming analyzer for the SYSTEM-AUDIO ("them") stream: same FRAME/HOP
+/// framing and YIN pitch as the mic analyzer, but it only feeds the shared
+/// [`FarEndState`] — it emits no events and keeps no windows of its own.
+pub struct FarEndAnalyzer {
+    buf: Vec<f32>,
+    state: Arc<FarEndState>,
+}
+
+impl FarEndAnalyzer {
+    pub fn new(state: Arc<FarEndState>) -> Self {
+        Self {
+            buf: Vec::with_capacity(FRAME * 2),
+            state,
+        }
+    }
+
+    /// Feed one PCM chunk (16 kHz mono i16) of the counterpart's audio.
+    pub fn push(&mut self, chunk: &[i16]) {
+        self.buf.extend(chunk.iter().map(|&s| s as f32 / 32768.0));
+        while self.buf.len() >= FRAME {
+            let rms = rms_of(&self.buf[..FRAME]);
+            let semitones = if rms >= VOICING_RMS_FLOOR {
+                yin_f0(&self.buf[..FRAME], TARGET_SAMPLE_RATE as f32).map(hz_to_semitones)
+            } else {
+                None
+            };
+            self.state.push_frame_at(Instant::now(), rms, semitones);
+            self.buf.drain(..HOP);
+        }
+    }
+}
+
 /// Root-mean-square amplitude of a frame (samples already in −1..1).
 fn rms_of(frame: &[f32]) -> f32 {
     if frame.is_empty() {
@@ -672,6 +913,84 @@ mod tests {
         assert!(!ProsodyAnalyzer::is_filled_pause_run(
             &varied.iter().collect::<Vec<_>>()
         ));
+    }
+
+    #[test]
+    fn session_rate_meter_matches_batch_measure() {
+        // The streaming meter must report the same articulation rate the batch
+        // function measures over identical audio — it replaces the batch measure
+        // for live meetings (where the saved file may be a mix of both sides).
+        let rate = TARGET_SAMPLE_RATE;
+        let dur_s = 9.0f32; // spans >1 block (~7 s) so completed + partial paths run
+        let bumps = 27.0f32; // 3 syllables/s
+        let n = (rate as f32 * dur_s) as usize;
+        let mut pcm = vec![0f32; n];
+        for (k, s) in pcm.iter_mut().enumerate() {
+            let t = k as f32 / rate as f32;
+            let carrier = (2.0 * PI * 150.0 * t).sin();
+            let frac = ((t / dur_s) * bumps).fract();
+            let env = 0.5 - 0.5 * (2.0 * PI * frac).cos();
+            *s = carrier * (0.05 + 0.5 * env);
+        }
+
+        let mut meter = SessionRateMeter::new();
+        let mut i = 0;
+        while i + FRAME <= pcm.len() {
+            meter.push(rms_of(&pcm[i..i + FRAME]));
+            i += HOP;
+        }
+
+        let batch = measure_speech_rate_hz(&pcm, rate);
+        let streaming = meter.rate_hz();
+        assert!(batch > 0.0, "batch measure should see the bumps");
+        assert!(
+            (streaming - batch).abs() < 0.3,
+            "streaming {streaming} should match batch {batch}"
+        );
+    }
+
+    #[test]
+    fn farend_pitch_match_rejects_bleed() {
+        let far = FarEndState::new();
+        let now = Instant::now();
+        // Far side spoke ~100 ms ago at 10 st, moderately loud.
+        far.push_frame_at(now - std::time::Duration::from_millis(100), 0.2, Some(10.0));
+
+        // Mic frame at the same pitch, quieter → speaker bleed.
+        assert!(far.is_bleed_at(now, 0.05, Some(10.3)));
+        // Octave-folded match (10 + 12 = 22 st) is still the same voice.
+        assert!(far.is_bleed_at(now, 0.05, Some(22.0)));
+        // Same pitch but mic much LOUDER than the far signal → the user talking.
+        assert!(!far.is_bleed_at(now, 0.5, Some(10.0)));
+        // Clearly different pitch → the user talking over the far side.
+        assert!(!far.is_bleed_at(now, 0.05, Some(4.0)));
+        // Unvoiced mic frames are never bleed.
+        assert!(!far.is_bleed_at(now, 0.05, None));
+    }
+
+    #[test]
+    fn farend_stale_frames_do_not_match() {
+        let far = FarEndState::new();
+        let now = Instant::now();
+        far.push_frame_at(now - std::time::Duration::from_millis(500), 0.2, Some(10.0));
+        // Outside FAR_MATCH_WINDOW_MS → no bleed verdict…
+        assert!(!far.is_bleed_at(now, 0.05, Some(10.0)));
+        // …but still inside FAR_ACTIVE_WINDOW_MS → the far side counts as talking.
+        assert!(far.is_active_at(now));
+        // And silence far frames never make it active.
+        let quiet = FarEndState::new();
+        quiet.push_frame_at(now, 0.001, None);
+        assert!(!quiet.is_active_at(now));
+    }
+
+    #[test]
+    fn session_rate_meter_zero_on_silence() {
+        let mut meter = SessionRateMeter::new();
+        assert_eq!(meter.rate_hz(), 0.0);
+        for _ in 0..1000 {
+            meter.push(0.0);
+        }
+        assert_eq!(meter.rate_hz(), 0.0);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -203,13 +203,19 @@ pub fn start_meeting(
             device_name: input_device,
         };
         let sys = crate::audio::system_macos::SystemAudio { app: app.clone() };
+        // Shared far-end state: the system-audio tap feeds it, the mic prosody
+        // tap reads it to reject the counterpart's voice bleeding through the
+        // speakers into the mic (pace/intonation must score "me" only).
+        let far = std::sync::Arc::new(crate::audio::prosody::FarEndState::new());
         if diarization {
             // Tap the PRE-MIX mic for delivery coaching (issue #22): the prosody
             // analyzer must see raw mic, never the mixed/diarized stream.
             let rx_me = spawn_capture(&coord, MicUser::Meeting, mic, gate.clone(), "me")
                 .ok()
-                .map(|rx| spawn_mic_prosody_tap(&app, rx));
-            let rx_them = spawn_capture(&coord, MicUser::Meeting, sys, gate.clone(), "them").ok();
+                .map(|rx| spawn_mic_prosody_tap(&app, rx, Some(far.clone())));
+            let rx_them = spawn_capture(&coord, MicUser::Meeting, sys, gate.clone(), "them")
+                .ok()
+                .map(|rx| spawn_farend_tap(rx, far));
             let mut tasks = state.tasks.lock().unwrap();
             log::info!(
                 "meeting: capture started (mic: {}, system: {})",
@@ -282,7 +288,7 @@ pub fn start_meeting(
             // un-aligned streams into one file would garble it); see plan note.
             let mut tasks = state.tasks.lock().unwrap();
             if let Ok(rx) = spawn_capture(&coord, MicUser::Meeting, mic, gate.clone(), "me") {
-                let rx = spawn_mic_prosody_tap(&app, rx);
+                let rx = spawn_mic_prosody_tap(&app, rx, Some(far.clone()));
                 tasks.push(run_metered_session(
                     &app,
                     provider,
@@ -294,6 +300,7 @@ pub fn start_meeting(
                 ));
             }
             if let Ok(rx) = spawn_capture(&coord, MicUser::Meeting, sys, gate.clone(), "them") {
+                let rx = spawn_farend_tap(rx, far);
                 tasks.push(run_metered_session(
                     &app,
                     provider,
@@ -313,7 +320,8 @@ pub fn start_meeting(
             device_name: input_device,
         };
         if let Ok(rx) = spawn_capture(&coord, MicUser::Meeting, mic, gate.clone(), "me") {
-            let rx = spawn_mic_prosody_tap(&app, rx);
+            // No system capture on this platform → no far-end reference to gate on.
+            let rx = spawn_mic_prosody_tap(&app, rx, None);
             let task = run_metered_session(
                 &app,
                 provider,
@@ -558,15 +566,41 @@ pub fn start_oauth_loopback(app: AppHandle) -> Result<u16, String> {
 ///
 /// This is the single mic tap point and it sits BEFORE the mixer, so with
 /// diarization on we analyze raw mic — never the mixed/diarized stream (the
-/// issue #22 hard constraint: delivery is scored on "me" only).
+/// issue #22 hard constraint: delivery is scored on "me" only). `far` is the
+/// counterpart's shared acoustic state (from [`spawn_farend_tap`]) used to
+/// reject the far voice leaking through the SPEAKERS into the mic — without it,
+/// a speakers-only setup scores the other side's pace/intonation as the user's.
 fn spawn_mic_prosody_tap(
     app: &AppHandle,
     mut rx: UnboundedReceiver<Vec<i16>>,
+    far: Option<std::sync::Arc<crate::audio::prosody::FarEndState>>,
 ) -> UnboundedReceiver<Vec<i16>> {
     let (tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let mut analyzer = crate::audio::prosody::ProsodyAnalyzer::new(app, "me");
+        let mut analyzer = crate::audio::prosody::ProsodyAnalyzer::new(app, "me", far);
+        while let Some(chunk) = rx.recv().await {
+            analyzer.push(&chunk);
+            if tx.send(chunk).is_err() {
+                break;
+            }
+        }
+    });
+    out_rx
+}
+
+/// Tee the system-audio ("them") PCM through a
+/// [`FarEndAnalyzer`](crate::audio::prosody::FarEndAnalyzer) that feeds the
+/// shared far-end state for speaker-bleed rejection, forwarding every chunk
+/// untouched downstream. Counterpart of [`spawn_mic_prosody_tap`].
+#[cfg(target_os = "macos")]
+fn spawn_farend_tap(
+    mut rx: UnboundedReceiver<Vec<i16>>,
+    far: std::sync::Arc<crate::audio::prosody::FarEndState>,
+) -> UnboundedReceiver<Vec<i16>> {
+    let (tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+    tauri::async_runtime::spawn(async move {
+        let mut analyzer = crate::audio::prosody::FarEndAnalyzer::new(far);
         while let Some(chunk) = rx.recv().await {
             analyzer.push(&chunk);
             if tx.send(chunk).is_err() {

--- a/src/lib/ai/delivery.ts
+++ b/src/lib/ai/delivery.ts
@@ -105,7 +105,7 @@ export async function analyzeDelivery(opts: {
     ? `Your delivery signals: ~${prosody.speechRateHz.toFixed(1)} syllables/sec, ` +
       `pitch variation ${prosody.pitchVarSemitones.toFixed(1)} semitones.\n\n`
     : measuredRateHz
-      ? `Measured speaking rate over this recording: ~${measuredRateHz.toFixed(1)} ` +
+      ? `Acoustically measured speaking rate for this session: ~${measuredRateHz.toFixed(1)} ` +
         `syllables/sec (≈ ${Math.round(measuredRateHz * 60)} syllables/min). ` +
         `Use this for the pace read rather than guessing from the text.\n\n`
       : "";

--- a/src/lib/analysis/delivery.test.ts
+++ b/src/lib/analysis/delivery.test.ts
@@ -17,11 +17,13 @@ function sample(over: Partial<ProsodyMetrics> = {}): ProsodyMetrics {
     pitchVarSemitones: 3,
     monotonyScore: 0,
     speechRateHz: 3,
+    sessionRateHz: 3,
     voicedRatio: 0.7,
     silenceMs: 0,
     longestPauseMs: 400,
     speaking: true,
     filledPause: false,
+    farendActive: false,
     ...over,
   };
 }
@@ -106,6 +108,34 @@ describe("DeliveryCoach", () => {
     expect(
       coach.observe(sample({ filledPause: true }), 1000 + DEFAULT_THRESHOLDS.cooldownMs + 1)?.kind
     ).toBe("filledpause");
+  });
+
+  it("does NOT flag dead air while the counterpart is talking", () => {
+    const coach = new DeliveryCoach(ALL_ON);
+    for (let t = 0; t <= 3000; t += 500) {
+      coach.observe(sample({ speaking: true, speechRateHz: 3 }), t);
+    }
+    // The user goes quiet but the far side keeps talking: with speaker-bleed
+    // rejection the mic reads silent, yet this is a monologue — not dead air.
+    let fired = false;
+    for (let t = 3500; t <= 30000; t += 500) {
+      const r = coach.observe(
+        sample({ speaking: false, silenceMs: t - 3000, voicedRatio: 0, farendActive: true }),
+        t
+      );
+      if (r?.kind === "deadair") fired = true;
+    }
+    expect(fired).toBe(false);
+    // Once the far side also goes quiet, dead air resumes firing.
+    let kind: string | null = null;
+    for (let t = 30500; t <= 45000; t += 500) {
+      const r = coach.observe(
+        sample({ speaking: false, silenceMs: t - 3000, voicedRatio: 0, farendActive: false }),
+        t
+      );
+      if (r) kind = r.kind;
+    }
+    expect(kind).toBe("deadair");
   });
 
   it("does NOT flag dead air on opening silence before any speech", () => {

--- a/src/lib/analysis/delivery.ts
+++ b/src/lib/analysis/delivery.ts
@@ -131,8 +131,15 @@ export class DeliveryCoach {
 
     // Evaluate every candidate; the first that is allowed to fire wins. Order is
     // priority: dead air and steamrolling are the most actionable mid-call.
+    // Dead air means NOBODY is talking: the mic is silent AND the counterpart's
+    // stream is quiet — with speaker-bleed rejection the mic no longer "hears"
+    // the far side, so their monologue must not read as dead air.
     const deadAir =
-      this.toggles.pauses && this.hasSpoken && !m.speaking && m.silenceMs >= this.th.deadAirMs;
+      this.toggles.pauses &&
+      this.hasSpoken &&
+      !m.speaking &&
+      !m.farendActive &&
+      m.silenceMs >= this.th.deadAirMs;
     if (this.gate("deadair", deadAir, nowMs)) return { kind: "deadair", severity: "info" };
 
     const steamroll =

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -82,9 +82,9 @@ function snapshotAnalysis() {
 }
 
 /** Measure a recording's articulation rate (syllables/sec) via Rust; null on any
- *  failure. Lets the live-save path produce the SAME measured-pace quantity the
- *  upload path does (both run the DSP over the stored 16 kHz audio), instead of an
- *  LLM guess or the live windowed rate (which includes pauses). */
+ *  failure. Same DSP quantity the upload path computes. For live saves this is
+ *  only a FALLBACK for mic-only recordings — the primary source is the mic-derived
+ *  session rate (store.micSessionRateHz), which never includes the other side. */
 async function measureRecordingRate(path: string): Promise<number | null> {
   if (!isTauri()) return null;
   try {
@@ -215,9 +215,14 @@ export async function saveLiveToHistory(audioTempPath: string, durationMs: numbe
   const s = useStore.getState();
   const createdAt = s.meetingStartedAt ?? Date.now();
   const dateLabel = new Date(createdAt).toLocaleString(localeOf());
-  // Measure the captured recording's pace with the same DSP the upload path uses,
-  // so a reopened live meeting shows a real (comparable) measured pace.
-  const speechRateHz = await measureRecordingRate(audioTempPath);
+  // Mic-only measured pace (issue #22): prefer the whole-session articulation rate
+  // the live prosody tap accumulated from the user's OWN mic. Only fall back to
+  // measuring the saved file when the mic rate is missing AND the file can't
+  // contain the other side — in diarized meetings the recording is the mic+system
+  // MIX, and measuring it would fold the counterpart's pace into the number.
+  const micOnlyRecording = !s.segments.some((seg) => seg.source === "mix");
+  const speechRateHz =
+    s.micSessionRateHz ?? (micOnlyRecording ? await measureRecordingRate(audioTempPath) : null);
   const save = resolveDefaultSave();
   const entry: HistoryEntry = {
     id: crypto.randomUUID(),

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -241,6 +241,11 @@ interface ParleyState {
   /** Latest prosody metrics from the backend; null until the first event. */
   prosody: ProsodyMetrics | null;
   setProsody: (m: ProsodyMetrics | null) => void;
+  /** Whole-session articulation rate of the USER'S MIC (last `sessionRateHz`
+   *  seen). Unlike `prosody`, this survives stop so the history save can record
+   *  a mic-only measured pace — never the counterpart's (issue #22). Reset on
+   *  meeting start. */
+  micSessionRateHz: number | null;
   /** Running count of filled pauses ("um/uh/呃/痾") detected acoustically this
    *  meeting (STT drops them, so this is the only tally). Reset on meeting start. */
   filledPauseCount: number;
@@ -352,6 +357,7 @@ export const useStore = create<ParleyState>()(
       autoAnalyze: false,
       autoAnalyzeSec: 45,
       prosody: null,
+      micSessionRateHz: null,
       filledPauseCount: 0,
       deliveryNudge: null,
       deliveryAssessment: null,
@@ -612,6 +618,9 @@ export const useStore = create<ParleyState>()(
       if (state.meetingStatus !== "recording") return {};
       return {
         prosody: m,
+        // Kept outside `prosody` so it survives the stop-time reset: the history
+        // save reads it as the mic-only measured pace (issue #22).
+        micSessionRateHz: m.sessionRateHz > 0 ? m.sessionRateHz : state.micSessionRateHz,
         filledPauseCount: m.filledPause ? state.filledPauseCount + 1 : state.filledPauseCount,
       };
     }),
@@ -671,6 +680,7 @@ export const useStore = create<ParleyState>()(
       solutionFindingId: null,
       findingSolutions: {},
       prosody: null,
+      micSessionRateHz: null,
       filledPauseCount: 0,
       deliveryNudge: null,
       deliveryAssessment: null,

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -52,11 +52,13 @@ interface ProsodyEventPayload {
   pitch_var_semitones: number;
   monotony_score: number;
   speech_rate_hz: number;
+  session_rate_hz: number;
   voiced_ratio: number;
   silence_ms: number;
   longest_pause_ms: number;
   speaking: boolean;
   filled_pause: boolean;
+  farend_active: boolean;
 }
 
 /**
@@ -76,11 +78,13 @@ export async function listenForProsody(): Promise<UnlistenFn> {
       pitchVarSemitones: p.pitch_var_semitones,
       monotonyScore: p.monotony_score,
       speechRateHz: p.speech_rate_hz,
+      sessionRateHz: p.session_rate_hz,
       voicedRatio: p.voiced_ratio,
       silenceMs: p.silence_ms,
       longestPauseMs: p.longest_pause_ms,
       speaking: p.speaking,
       filledPause: p.filled_pause,
+      farendActive: p.farend_active,
     });
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -347,6 +347,10 @@ export interface ProsodyMetrics {
   monotonyScore: number;
   /** Mic-anchored speech rate (syllable nuclei per second) over the window. */
   speechRateHz: number;
+  /** Whole-session articulation rate (nuclei per voiced second) over the mic so
+   *  far — the mic-only stand-in for measuring the saved recording, which in
+   *  diarized meetings is a mix of both sides. 0 until any voiced speech. */
+  sessionRateHz: number;
   /** Fraction of the window that was voiced (0..1). */
   voicedRatio: number;
   /** Current trailing silence in ms (0 while speaking). */
@@ -358,6 +362,10 @@ export interface ProsodyMetrics {
   /** One-shot edge: a filled pause ("um/uh/呃/痾") was just detected acoustically
    *  (STT drops these, so this mic-derived flag is the only source). */
   filledPause: boolean;
+  /** Whether the counterpart's (system-audio) stream is currently audible —
+   *  dead air means NOBODY is talking, so the nudge must hold while they speak.
+   *  Always false when there's no system capture. */
+  farendActive: boolean;
 }
 
 /** Kind of live delivery nudge surfaced to the speaker (see DeliveryNudge). */


### PR DESCRIPTION
## What

Three mic-isolation fixes for the live delivery coach's pace/intonation detection (extends the issue #22 hard constraint):

### 1. Speaker-bleed rejection (acoustic, no STT)
When the counterpart plays over **speakers**, the mic physically hears them, and their speech polluted every "me" statistic (pace baseline, pitch spread, filled pauses, dead-air clock). Now the system-audio stream is analyzed as a far-end reference (`FarEndAnalyzer`: same FRAME/HOP framing + YIN pitch), and a voiced mic frame is rejected as bleed when it pitch-matches a recent far-end frame (±1 st, octave-tolerant) at a plausible level. Rejected frames are zeroed out of the envelope and treated as unvoiced, so they can't seed syllable nuclei, feed the pitch stats, or reset the silence clock.

- Purely acoustic — never relies on STT, per the product constraint.
- Headphone users are unaffected (no bleed → no pitch match on their own speech).
- The dead-air nudge now requires the far side to be quiet too (`farend_active` on the prosody event) — with bleed rejection the mic reads silent during the counterpart's monologue, and that must not count as dead air.

### 2. Mic-only measured pace for the retro
The post-call "measured pace" was computed over the saved recording — which in diarized meetings is the **mic+system mix**, folding the counterpart's pace into the number and into the LLM's pace verdict. The live prosody tap now accumulates a whole-session articulation rate (`SessionRateMeter`, the streaming twin of `measure_speech_rate_hz` — same framing, block loudness floor, and voiced-time denominator, verified equivalent in tests). The history save prefers it; measuring the file remains only as a fallback for mic-only recordings, and uploads keep the whole-file measure (there is no mic there).

### 3. Intonation clears promptly
The pitch-spread gauge lingered up to ~7 s after speech stopped (rolling-window drain). It now reports no-signal after 2 s of trailing silence.

## Tests
- `cargo test --lib`: 17 passed — includes new tests for pitch-match bleed rejection, octave folding, stale-frame windows, and streaming≈batch session-rate equivalence.
- `vitest`: 97 passed — includes a new coach test that dead air holds while `farendActive` and resumes after.
- `tsc --noEmit` clean, `cargo fmt` clean on touched files.