### PR TITLE
[feature] re-diarize live meetings from the recording after save

### DIFF
--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -514,6 +514,7 @@ export const zhTW = {
   "speakers.voiceStageClustering": "分群中…",
   "speakers.voiceFound": "辨識出 {speakers} 位說話者，幫他們命名：",
   "speakers.voiceDone": "完成",
+  "speakers.postRefined": "已依錄音聲紋重新校正說話者",
 
   "replay.upload": "上傳錄音",
   "ingest.title": "分析錄音",
@@ -1264,6 +1265,7 @@ export const en = {
   "speakers.voiceStageClustering": "Clustering…",
   "speakers.voiceFound": "Found {speakers} speakers — name them:",
   "speakers.voiceDone": "Done",
+  "speakers.postRefined": "Speaker labels refined from the recording",
 
   "replay.upload": "Upload recording",
   "ingest.title": "Analyze recording",

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -18,6 +18,7 @@ import { CLOUD_ENABLED } from "../flags";
 import { markDirty } from "../cloud/syncState";
 import { CLOUD_URL, cloudFetch, cloudToken, syncEnabled } from "../cloud/client";
 import { listLocalFolders } from "./folders";
+import { rediarizeSegments } from "../speakers/postDiarize";
 import { translate } from "../../i18n/messages";
 import type { ReplaySession } from "../replay/types";
 import type { HistoryEntry, HistoryEntrySummary } from "./types";
@@ -236,7 +237,60 @@ export async function saveLiveToHistory(audioTempPath: string, durationMs: numbe
     speechRateHz,
   };
   await persist(entry, audioTempPath, /* compress */ false);
+  // With the recording now on disk, fix the provider's drifted speaker labels
+  // from the audio BEFORE the org copy is made, so a shared copy isn't stale.
+  // Best-effort: any failure keeps the provider labels.
+  await applyPostSaveDiarization(entry).catch((e) =>
+    log.warn("history: post-save re-diarization failed", { id: entry.id, error: String(e) }),
+  );
   await applyDefaultOrgShare(entry.id, save);
+}
+
+/**
+ * After a live save: re-derive the speakers from the recording's AUDIO and patch
+ * the just-saved entry. Provider streaming diarization drifts over long meetings
+ * (swapped labels, spurious late speakers); the on-device voice pipeline fixes
+ * that once the full recording exists, remapping the new clusters onto the
+ * provider's numbering so names assigned during the meeting stay attached (see
+ * postDiarize.ts). No-op for mic-only meetings and when nothing changes.
+ */
+async function applyPostSaveDiarization(entry: HistoryEntry): Promise<void> {
+  const { audioPath } = await invoke<HistoryReadResult>("read_history_entry", { id: entry.id });
+  if (!audioPath) return;
+  const result = await rediarizeSegments(entry.segments, audioPath);
+  if (!result) return;
+
+  const updated: HistoryEntry = { ...entry, segments: result.segments };
+  await invoke("save_history_entry", {
+    id: entry.id,
+    summaryJson: JSON.stringify(buildSummary(updated)),
+    metaJson: JSON.stringify(updated),
+    audioSourcePath: null, // leave the recording untouched
+    compress: false,
+  });
+  await emitHistoryUpdated(entry.id);
+  pushToCloud(entry.id); // refresh the cloud copy with the corrected labels
+
+  // The finished meeting is usually still on screen — retag those lines too.
+  // Live segment ids REPEAT across sessions ("mix-0", "mix-1", …), so an id
+  // match alone could hit a different meeting's lines. Only touch the store
+  // when it provably still shows THIS meeting: the just-ended live session
+  // (same start timestamp) or this very entry re-opened from history.
+  const st = useStore.getState();
+  const showsThisMeeting =
+    st.loadedHistoryId === entry.id ||
+    (st.appMode === "live" && st.loadedHistoryId === null && st.meetingStartedAt === entry.createdAt);
+  if (showsThisMeeting) {
+    const bySegId = new Map(result.segments.map((s) => [s.id, s.speaker]));
+    useStore.setState({
+      segments: st.segments.map((s) => {
+        const sp = bySegId.get(s.id);
+        return sp === undefined || sp === s.speaker ? s : { ...s, speaker: sp };
+      }),
+    });
+    toast.message(translate(st.settings.language, "speakers.postRefined"));
+  }
+  log.info("history: post-save re-diarization applied", { id: entry.id, changed: result.changed });
 }
 
 /**

--- a/src/lib/speakers/postDiarize.test.ts
+++ b/src/lib/speakers/postDiarize.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the two boundaries the module crosses: the Tauri IPC `invoke` (would run
+// the native ONNX/diarization pipeline) and the logger (touches `window` under
+// the Tauri-less path). The remap + patch logic under test is our own.
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+vi.mock("../log", () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  attachConsoleOnce: vi.fn(),
+}));
+
+import { remapToPriorSpeakers, rediarizeSegments, type PriorSeg } from "./postDiarize";
+import { seg } from "../test/fixtures";
+
+beforeEach(() => invoke.mockReset());
+
+/** Shorthand prior entry. */
+function p(id: string, speaker: number, weightMs = 1000): PriorSeg {
+  return { id, speaker, weightMs };
+}
+
+describe("remapToPriorSpeakers (cluster → prior speaker numbering)", () => {
+  it("keeps agreeing labels: each cluster claims the prior speaker it overlaps most", () => {
+    // Clustering numbered the sides opposite to the provider — the mapping must
+    // follow the overlap, not the cluster numbers.
+    const prior = [p("a", 1), p("b", 2), p("c", 1)];
+    const assigned = [
+      { id: "a", speaker: 2 },
+      { id: "b", speaker: 1 },
+      { id: "c", speaker: 2 },
+    ];
+    expect(remapToPriorSpeakers(prior, assigned)).toEqual(
+      new Map([
+        [2, 1],
+        [1, 2],
+      ]),
+    );
+  });
+
+  it("weights claims by speech duration, not line count", () => {
+    // Cluster 1 has TWO short lines labelled 2 but ONE long line labelled 1 —
+    // the long line outweighs them, so cluster 1 keeps number 1.
+    const prior = [p("a", 1, 10_000), p("b", 2, 1000), p("c", 2, 1000), p("d", 2, 9000)];
+    const assigned = [
+      { id: "a", speaker: 1 },
+      { id: "b", speaker: 1 },
+      { id: "c", speaker: 1 },
+      { id: "d", speaker: 2 },
+    ];
+    expect(remapToPriorSpeakers(prior, assigned)).toEqual(
+      new Map([
+        [1, 1],
+        [2, 2],
+      ]),
+    );
+  });
+
+  it("folds a spurious late provider speaker back into the real one", () => {
+    // The provider invented speaker 3 late in the meeting for the same voice as
+    // speaker 1; the audio puts both in one cluster, which maps to 1 (more ms).
+    const prior = [p("a", 1, 5000), p("b", 3, 2000), p("c", 2, 4000)];
+    const assigned = [
+      { id: "a", speaker: 1 },
+      { id: "b", speaker: 1 },
+      { id: "c", speaker: 2 },
+    ];
+    expect(remapToPriorSpeakers(prior, assigned)).toEqual(
+      new Map([
+        [1, 1],
+        [2, 2],
+      ]),
+    );
+  });
+
+  it("gives an unmatched cluster a fresh number above every prior number", () => {
+    // Two clusters both overlap prior speaker 1 best; the stronger claim wins
+    // and the loser gets a number no prior speaker used (here 3, above 1 and 2).
+    const prior = [p("a", 1, 5000), p("b", 1, 1000), p("c", 2, 4000)];
+    const assigned = [
+      { id: "a", speaker: 1 },
+      { id: "b", speaker: 2 },
+      { id: "c", speaker: 3 },
+    ];
+    expect(remapToPriorSpeakers(prior, assigned)).toEqual(
+      new Map([
+        [1, 1],
+        [3, 2],
+        [2, 3],
+      ]),
+    );
+  });
+
+  it("never maps a cluster to prior speaker 0 (unknown)", () => {
+    const prior = [p("a", 0), p("b", 0)];
+    const assigned = [
+      { id: "a", speaker: 1 },
+      { id: "b", speaker: 2 },
+    ];
+    // No claimable priors → both clusters get fresh numbers starting at 1.
+    expect(remapToPriorSpeakers(prior, assigned)).toEqual(
+      new Map([
+        [1, 1],
+        [2, 2],
+      ]),
+    );
+  });
+});
+
+describe("rediarizeSegments (audio-based correction of a saved live meeting)", () => {
+  it("skips mic-only meetings (no 'mix' segments) without touching the IPC", async () => {
+    const segs = [
+      seg({ id: "a", source: "me", speaker: 0, text: "hi" }),
+      seg({ id: "b", source: "them", speaker: 0, text: "yo" }),
+    ];
+    expect(await rediarizeSegments(segs, "/rec.ogg")).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("re-labels drifted lines while keeping stable ones and non-mix segments", async () => {
+    const segs = [
+      seg({ id: "a", source: "mix", speaker: 1, startMs: 0, endMs: 5000, text: "one" }),
+      seg({ id: "b", source: "mix", speaker: 2, startMs: 5000, endMs: 9000, text: "two" }),
+      // Late line the provider drifted onto speaker 1 — the audio says it's 2.
+      seg({ id: "c", source: "mix", speaker: 1, startMs: 9000, endMs: 10_000, text: "three" }),
+      // Interim + empty lines never reach the clusterer and stay untouched.
+      seg({ id: "d", source: "mix", speaker: 1, isFinal: false, text: "partial" }),
+    ];
+    invoke.mockResolvedValue([
+      { id: "a", speaker: 1, confidence: 0.9 },
+      { id: "b", speaker: 2, confidence: 0.9 },
+      { id: "c", speaker: 2, confidence: 0.8 },
+    ]);
+
+    const result = await rediarizeSegments(segs, "/rec.ogg");
+
+    expect(invoke).toHaveBeenCalledWith("diarize_audio", {
+      audioPath: "/rec.ogg",
+      segments: [
+        { id: "a", startMs: 0, endMs: 5000 },
+        { id: "b", startMs: 5000, endMs: 9000 },
+        { id: "c", startMs: 9000, endMs: 10_000 },
+      ],
+      numSpeakers: null,
+    });
+    expect(result?.changed).toBe(1);
+    expect(result?.segments.map((s) => s.speaker)).toEqual([1, 2, 2, 1]);
+    // Unchanged segments keep their identity (no needless object churn).
+    expect(result?.segments[0]).toBe(segs[0]);
+    expect(result?.segments[3]).toBe(segs[3]);
+  });
+
+  it("returns null when the audio agrees with the provider (nothing changed)", async () => {
+    const segs = [
+      seg({ id: "a", source: "mix", speaker: 1, startMs: 0, endMs: 1000, text: "one" }),
+      seg({ id: "b", source: "mix", speaker: 2, startMs: 1000, endMs: 2000, text: "two" }),
+    ];
+    invoke.mockResolvedValue([
+      { id: "a", speaker: 1, confidence: 1 },
+      { id: "b", speaker: 2, confidence: 1 },
+    ]);
+    expect(await rediarizeSegments(segs, "/rec.ogg")).toBeNull();
+  });
+});

--- a/src/lib/speakers/postDiarize.ts
+++ b/src/lib/speakers/postDiarize.ts
@@ -1,0 +1,142 @@
+// Post-save voice re-diarization for LIVE meetings.
+//
+// Live speaker labels come from the STT provider's streaming diarization, which
+// drifts over a long meeting: labels swap sides, and the same voice can be given
+// a brand-new speaker number late in the call. Once the meeting is saved we hold
+// the full recording on disk, so we re-derive the speakers from the AUDIO with
+// the same on-device pipeline the upload flow uses (`diarize_audio`: CAM++
+// embeddings + clustering), then map the new clusters back onto the provider's
+// numbering by overlap — names and colors assigned during the meeting stay put,
+// and only wrongly-labelled lines move. history.ts calls this right after the
+// entry is persisted (see saveLiveToHistory).
+
+import { invoke } from "@tauri-apps/api/core";
+import { log } from "../log";
+import type { TranscriptSegment } from "../types";
+
+/** One segment's speaker assignment from the Rust `diarize_audio` command. */
+interface RustSegSpeaker {
+  id: string;
+  /** 1-based speaker number (cluster + 1). */
+  speaker: number;
+  /** Cosine margin to the next-nearest cluster; 0 for inherited short segments. */
+  confidence: number;
+}
+
+/** A segment's PRIOR (provider-assigned) speaker and its speech duration. */
+export interface PriorSeg {
+  id: string;
+  speaker: number;
+  weightMs: number;
+}
+
+/**
+ * Map fresh cluster numbers onto the prior speaker numbering so existing names
+ * and colors survive the re-clustering. Each cluster claims the prior speaker it
+ * overlaps most (duration-weighted, one-to-one, strongest claims first); clusters
+ * with no prior match get fresh numbers ABOVE every prior number, so they can't
+ * collide with a label the meeting already used. Prior speaker 0 means "unknown"
+ * and is never a target — those lines simply adopt their cluster's mapping.
+ */
+export function remapToPriorSpeakers(
+  prior: PriorSeg[],
+  assigned: { id: string; speaker: number }[],
+): Map<number, number> {
+  const priorById = new Map(prior.map((p) => [p.id, p]));
+  // Total speech overlap (ms) between each new cluster and each prior speaker.
+  const overlap = new Map<number, Map<number, number>>();
+  const clusters = new Set<number>();
+  for (const a of assigned) {
+    clusters.add(a.speaker);
+    const p = priorById.get(a.id);
+    if (!p || p.speaker <= 0) continue;
+    const row = overlap.get(a.speaker) ?? new Map<number, number>();
+    row.set(p.speaker, (row.get(p.speaker) ?? 0) + Math.max(1, p.weightMs));
+    overlap.set(a.speaker, row);
+  }
+
+  // Greedy one-to-one matching, strongest overlap first (ties break toward the
+  // smaller prior/cluster number so the result is deterministic).
+  const pairs: { cluster: number; prior: number; w: number }[] = [];
+  for (const [cluster, row] of overlap) {
+    for (const [p, w] of row) pairs.push({ cluster, prior: p, w });
+  }
+  pairs.sort((a, b) => b.w - a.w || a.prior - b.prior || a.cluster - b.cluster);
+  const map = new Map<number, number>();
+  const taken = new Set<number>();
+  for (const { cluster, prior: p } of pairs) {
+    if (map.has(cluster) || taken.has(p)) continue;
+    map.set(cluster, p);
+    taken.add(p);
+  }
+
+  let next = Math.max(0, ...prior.map((p) => p.speaker)) + 1;
+  for (const cluster of [...clusters].sort((a, b) => a - b)) {
+    if (!map.has(cluster)) map.set(cluster, next++);
+  }
+  return map;
+}
+
+/**
+ * Re-derive speakers for a finished live meeting's segments from its recording.
+ *
+ * Only the diarized-live case qualifies: those meetings record the mic+system
+ * MIX, so the file actually contains every voice. Mic-only meetings ("me"/"them"
+ * segments) keep their channel-derived labels — the counterpart's audio isn't in
+ * the recording, so re-clustering it would be meaningless.
+ *
+ * The speaker count is auto-detected from the audio rather than seeded with the
+ * provider's count, because late-meeting over-splitting (a spurious extra
+ * speaker) is exactly the drift this pass exists to fix.
+ *
+ * Returns the full segment list with corrected speaker numbers, or null when
+ * the pass doesn't apply or nothing changed. Pure with respect to the store —
+ * persistence and UI refresh are the caller's job (history.ts).
+ */
+export async function rediarizeSegments(
+  segments: TranscriptSegment[],
+  audioPath: string,
+): Promise<{ segments: TranscriptSegment[]; changed: number } | null> {
+  const mix = segments
+    .filter((s) => s.source === "mix" && s.isFinal && s.text.trim())
+    .sort((a, b) => a.startMs - b.startMs);
+  // One line can't drift; nothing to re-cluster.
+  if (mix.length < 2) return null;
+
+  const spans = mix.map((s) => ({
+    id: s.id,
+    startMs: Math.max(0, Math.round(s.startMs)),
+    endMs: Math.max(0, Math.round(s.endMs)),
+  }));
+  const assigned = await invoke<RustSegSpeaker[]>("diarize_audio", {
+    audioPath,
+    segments: spans,
+    numSpeakers: null,
+  });
+
+  const priors: PriorSeg[] = mix.map((s) => ({
+    id: s.id,
+    speaker: s.speaker,
+    weightMs: Math.max(1, s.endMs - s.startMs),
+  }));
+  const clusterMap = remapToPriorSpeakers(priors, assigned);
+  const idToSpeaker = new Map<string, number>();
+  for (const a of assigned) {
+    const sp = clusterMap.get(a.speaker);
+    if (sp !== undefined) idToSpeaker.set(a.id, sp);
+  }
+
+  let changed = 0;
+  const patched = segments.map((s) => {
+    const sp = idToSpeaker.get(s.id);
+    if (sp === undefined || sp === s.speaker) return s;
+    changed++;
+    return { ...s, speaker: sp };
+  });
+  log.info("postDiarize: clustered", {
+    segs: mix.length,
+    changed,
+    speakers: new Set(idToSpeaker.values()).size,
+  });
+  return changed > 0 ? { segments: patched, changed } : null;
+}


### PR DESCRIPTION
## What

When a live meeting is saved, re-run speaker diarization over the full recording with the on-device voice pipeline (CAM++ + clustering — same one the upload flow uses) and patch the saved entry. Fixes the label drift that streaming provider diarization accumulates over long meetings.

## How

- **`src/lib/speakers/postDiarize.ts`** (new): re-clusters the saved `audio.ogg` by the existing segment timestamps, then maps the new clusters back onto the provider's speaker numbering by duration-weighted overlap — names/colors assigned during the meeting stay attached; only mislabelled lines move. Spurious late provider speakers fold back into the real one. Speaker count is auto-detected from the audio (over-splitting is exactly the drift being fixed).
- **`src/lib/history/history.ts`**: `saveLiveToHistory` runs the pass after `persist` and before the org auto-share, so shared copies get corrected labels. Rewrites meta/summary, re-pushes to cloud, and retags the on-screen transcript (+toast) — but only when the store provably still shows this meeting, since live segment ids (`mix-0`, `mix-1`, …) repeat across sessions.
- Skips mic-only meetings (no `mix` segments — the counterpart's audio isn't in the file). Any failure keeps the provider labels.

## Tests

- 8 new tests for the overlap remap + re-diarize gating/patching (`postDiarize.test.ts`)
- Full suite: 105/105, `tsc` clean