### PR TITLE
[fix] preload the S→T dictionary so the first caption isn't delayed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { checkForUpdate } from "./lib/update";
 import { refreshSession } from "./lib/cloud/client";
 import { CLOUD_ENABLED } from "./lib/flags";
 import { initVoiceTyping } from "./lib/voiceTyping/host";
+import { preloadZhConverter } from "./lib/zhConvert";
 
 /**
  * Track main-window fullscreen state. Drives both the rounded corners (a
@@ -95,6 +96,9 @@ const App = () => {
         else fn();
       });
     };
+    // Warm the S→T dictionary now: paying its load on the FIRST transcript
+    // event delayed the opening caption of every meeting by the parse time.
+    preloadZhConverter();
     track(listenForTranscript());
     track(listenForProsody());
     track(listenForMeetingError());

--- a/src/lib/zhConvert.ts
+++ b/src/lib/zhConvert.ts
@@ -1,4 +1,7 @@
-// OpenCC dictionaries are large, so load them only once transcript text arrives.
+// OpenCC dictionaries are large, so they're code-split out of the main bundle
+// and loaded lazily. Loading on the FIRST transcript event delayed the first
+// caption (and the first dictation) by the whole dictionary parse — so entry
+// points that will convert soon call preloadZhConverter() at startup instead.
 let convertPromise: Promise<(s: string) => string> | null = null;
 
 async function getConverter(): Promise<(s: string) => string> {
@@ -6,6 +9,18 @@ async function getConverter(): Promise<(s: string) => string> {
     OpenCC.Converter({ from: "cn", to: "tw" })
   );
   return convertPromise;
+}
+
+/**
+ * Kick off the dictionary load in the background so the first real
+ * {@link toTraditional} call doesn't pay it on the critical path. Idempotent.
+ * A failed load is uncached so the on-demand path retries (and surfaces the
+ * error to its caller) instead of pinning a rejected promise forever.
+ */
+export function preloadZhConverter(): void {
+  getConverter().catch(() => {
+    convertPromise = null;
+  });
 }
 
 export async function toTraditional(text: string): Promise<string> {

--- a/src/voice-typing/VoiceTypingApp.tsx
+++ b/src/voice-typing/VoiceTypingApp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { listen, emit } from "@tauri-apps/api/event";
 import { Check, Loader2, Mic } from "lucide-react";
-import { toTraditional } from "../lib/zhConvert";
+import { preloadZhConverter, toTraditional } from "../lib/zhConvert";
 import { useI18n, type TranslationKey } from "../i18n";
 import { useThemePreference } from "../lib/theme";
 
@@ -120,6 +120,10 @@ export const VoiceTypingApp = () => {
 
   useEffect(() => {
     const unsubs: Array<() => void> = [];
+
+    // Warm the S→T dictionary while the overlay is prewarmed/idle, so the
+    // first dictation's publish doesn't stall on the dictionary parse.
+    preloadZhConverter();
 
     listen<SegPayload>("transcript://segment", (e) => {
       const p = e.payload;


### PR DESCRIPTION
## What

`opencc-js/cn2t` (the Simplified→Traditional dictionary, code-split and heavy) was lazily imported on the **first transcript event** — so the first caption of every meeting, and the first voice-typing publish, paid the entire dictionary load+parse (typically 200–800 ms) on the critical path. Found in the realtime-latency audit.

- `preloadZhConverter()` kicks the dynamic import off in the background; idempotent; a failed preload is uncached so the on-demand path retries and surfaces errors as before.
- Called at startup in both converting windows: the main window (App mount effect, next to the transcript listeners) and the voice-typing overlay (which is prewarmed at init, so the dictionary is ready long before the first dictation).

## Verification
Ran the app in browser dev mode: the `opencc-js_cn2t` chunk is fetched at startup with zero transcript events, and a first `toTraditional()` call afterwards completes in ~4 ms. `tsc` clean, 105 tests green.