### PR TITLE
[fix] paste voice typing on session close instead of polling for quiet

### DIFF
--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -266,5 +266,12 @@ pub fn run_metered_session(
                 "seconds": seconds,
             }),
         );
+        // The session is fully over: the socket is closed and every final
+        // token has been emitted. The voice-typing host finalizes (pastes) on
+        // this signal instead of polling for the transcript to go quiet —
+        // meetings have their own teardown and ignore it. Deliberately NOT
+        // reached when the task is aborted (a superseded session must never
+        // finalize its successor's overlay).
+        let _ = app.emit("stt://closed", serde_json::json!({ "source": label }));
     })
 }

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -90,16 +90,19 @@ export function initVoiceTyping(): () => void {
     .then((u) => (unErr = u))
     .catch(() => {});
   // The backend session is fully over — every final token has been emitted.
-  // If the key is already up, re-arm the settle loop: it sees `closedAt` and
-  // finalizes after the short CLOSE_DRAIN_MS instead of the SETTLE_MS quiet
-  // poll. Ignored while the key is still down (a server-side close mid-hold
-  // ends on the normal release path) and after a failure (endSession already
-  // finalizes failed sessions immediately).
+  // Re-arm the settle loop: it sees `closedAt` and finalizes after the short
+  // CLOSE_DRAIN_MS instead of the SETTLE_MS quiet poll. Ignored unless we're
+  // between release and finalize: while the key is DOWN the event is either a
+  // server-side close mid-hold (which then ends on the normal release path)
+  // or — after a fast re-press — a STALE close from the previous session
+  // whose delivery slipped past startSession's `closedAt = 0` reset, and
+  // honoring that one would cut the new session's flush short. Failed
+  // sessions are finalized immediately by endSession already.
   listen<{ source: string }>("stt://closed", (e) => {
     if (e.payload.source !== "voice-typing") return;
-    if (!busy) return; // stale close from a superseded/finished session
+    if (!busy || down || failed) return;
     closedAt = Date.now();
-    if (!down && !failed) waitForSettle();
+    waitForSettle();
   })
     .then((u) => (unClosed = u))
     .catch(() => {});

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -21,8 +21,13 @@ import { appendVoiceEntry } from "./history";
 const AX_BOOT_PROMPTED_KEY = "parley:ax-boot-prompted";
 
 // After the key is released we keep the session open and wait for the STT to
-// flush its final tokens — finalizing only once the text has been quiet for
-// SETTLE_MS (so the last words aren't cut off), capped at MAX_WAIT_MS.
+// flush its final tokens. FAST PATH: the backend emits `stt://closed` once the
+// session is fully over (socket closed, every final token emitted) — from
+// there we only wait CLOSE_DRAIN_MS for those last tokens to cross the
+// overlay's S→T convert-and-report hop before pasting. FALLBACK (a provider or
+// relay that never closes the socket): finalize once the text has been quiet
+// for SETTLE_MS, capped at MAX_WAIT_MS after release.
+const CLOSE_DRAIN_MS = 150;
 const SETTLE_MS = 500;
 const MAX_WAIT_MS = 3000;
 /** Keep the result visible briefly before hiding the overlay. */
@@ -31,6 +36,8 @@ const HIDE_DELAY_MS = 1100;
 let latestText = "";
 let lastTextAt = 0;
 let releasedAt = 0;
+/** When `stt://closed` arrived for the current session (0 = not yet). */
+let closedAt = 0;
 let down = false;
 let busy = false;
 /** The backend reported the STT session dead (voicetyping://error). */
@@ -48,6 +55,7 @@ export function initVoiceTyping(): () => void {
   let unPtt: UnlistenFn = () => {};
   let unText: UnlistenFn = () => {};
   let unErr: UnlistenFn = () => {};
+  let unClosed: UnlistenFn = () => {};
   // Serialize press/release handling: a quick tap used to run endSession's
   // `stop_voice_typing` while startSession's invoke was still in flight, so
   // the stop reached Rust FIRST and no-op'd — leaving a live, ownerless
@@ -80,6 +88,20 @@ export function initVoiceTyping(): () => void {
     emit("voicetyping://session", { phase: "error", message: e.payload.code }).catch(() => {});
   })
     .then((u) => (unErr = u))
+    .catch(() => {});
+  // The backend session is fully over — every final token has been emitted.
+  // If the key is already up, re-arm the settle loop: it sees `closedAt` and
+  // finalizes after the short CLOSE_DRAIN_MS instead of the SETTLE_MS quiet
+  // poll. Ignored while the key is still down (a server-side close mid-hold
+  // ends on the normal release path) and after a failure (endSession already
+  // finalizes failed sessions immediately).
+  listen<{ source: string }>("stt://closed", (e) => {
+    if (e.payload.source !== "voice-typing") return;
+    if (!busy) return; // stale close from a superseded/finished session
+    closedAt = Date.now();
+    if (!down && !failed) waitForSettle();
+  })
+    .then((u) => (unClosed = u))
     .catch(() => {});
   // Apply the saved push-to-talk key so the right trigger is live from launch
   // (registers Option+Space, or arms the HID tap for a modifier key). The
@@ -114,6 +136,7 @@ export function initVoiceTyping(): () => void {
     unPtt();
     unText();
     unErr();
+    unClosed();
   };
 }
 
@@ -150,6 +173,7 @@ async function startSession() {
   gen += 1;
   latestText = "";
   lastTextAt = Date.now();
+  closedAt = 0;
   clearTimeout(settleTimer);
   clearTimeout(hideTimer);
   await showOverlay();
@@ -192,19 +216,25 @@ async function endSession() {
   waitForSettle();
 }
 
-/** Finalize once the transcript has been quiet for SETTLE_MS (final flush done),
- *  or MAX_WAIT_MS after release as a hard stop. */
+/** Finalize as soon as the flush is provably over: CLOSE_DRAIN_MS after the
+ *  backend's `stt://closed` (fast path), else once the transcript has been
+ *  quiet for SETTLE_MS, else MAX_WAIT_MS after release as a hard stop. */
 function waitForSettle() {
   clearTimeout(settleTimer);
+  // Once closed, one short drain tick is all that's left; while still waiting
+  // on the STT flush, poll on a small interval so no path adds avoidable lag.
+  const delay = closedAt > 0 ? CLOSE_DRAIN_MS : 60;
   settleTimer = setTimeout(() => {
-    const quietFor = Date.now() - lastTextAt;
-    const elapsed = Date.now() - releasedAt;
-    if (quietFor >= SETTLE_MS || elapsed >= MAX_WAIT_MS) {
+    const now = Date.now();
+    const drained = closedAt > 0 && now - closedAt >= CLOSE_DRAIN_MS;
+    const quietFor = now - lastTextAt;
+    const elapsed = now - releasedAt;
+    if (drained || quietFor >= SETTLE_MS || elapsed >= MAX_WAIT_MS) {
       finalize().catch(() => {});
     } else {
       waitForSettle();
     }
-  }, 120);
+  }, delay);
 }
 
 async function finalize() {


### PR DESCRIPTION
## What

The realtime-latency audit flagged the release→paste path as voice typing's biggest incidental delay: after the key is released the host waited for the transcript to be **quiet for 500 ms**, sampled on a **120 ms** poll — an unconditional ~500–620 ms stall on every dictation, stretching to the 3 s hard cap when the provider flushed slowly.

Event-driven fast path:
- `run_metered_session` now emits **`stt://closed`** (`{ source }`) when the session is fully over — socket closed, every final token emitted, right after the `usage://stt` emit. Meetings ignore it. An **aborted** (superseded) session never reaches the emit, so a stale close can't finalize a newer session's overlay.
- The voice-typing host finalizes **CLOSE_DRAIN_MS (150 ms)** after that signal — just enough for the last finals to cross the overlay's S→T convert-and-report hop (`transcript://segment` → overlay converts → `voicetyping://text` → host), which is not ordering-guaranteed relative to the close event.
- The quiet-poll (500 ms quiet / 3 s cap) remains as the **fallback** for a provider or relay that never closes the socket, now polling at 60 ms so the fallback path adds less quantization too.

Guards: ignored while the key is still down (a server-side close mid-hold ends on the normal release path), after `voicetyping://error` (endSession already finalizes failed sessions immediately), and when `busy` is false. `closedAt` resets on every session start; the existing `gen` guard still protects finalize's tail.

**Expected release→paste**: ~150 ms after the provider flush, versus ~500–620 ms before — roughly 350–500 ms faster per dictation.

## Verification
`tsc` clean, 105 frontend tests green, `cargo test --lib` 17 green. The end-to-end paste path needs a real mic + STT session (not coverable headlessly); the fallback path preserves the previous behavior exactly, so a missing/late `stt://closed` degrades to today's timing.