### PR TITLE
[fix] emit prosody ~6–7×/s and shorten the pace window

### DIFF
--- a/src-tauri/src/audio/prosody.rs
+++ b/src-tauri/src/audio/prosody.rs
@@ -3,7 +3,7 @@
 //! This is the live-coaching counterpart to [`LevelMeter`](crate::transcription::common::LevelMeter):
 //! where the level meter shows raw loudness, [`ProsodyAnalyzer`] derives *delivery*
 //! signals — pitch variation (monotony) and pausing — from the same 16 kHz mono
-//! PCM, and emits an `audio://prosody` event ~2×/s for the frontend gauges/nudges.
+//! PCM, and emits an `audio://prosody` event ~6–7×/s for the frontend gauges/nudges.
 //!
 //! HARD CONSTRAINT (issue #22): delivery is scored on the **mic ("me") stream
 //! only**, never the counterpart. The caller taps the pre-mix mic receiver
@@ -38,11 +38,16 @@ const HOP: usize = 256;
 /// Rolling window over which monotony / pause stats are computed.
 const WINDOW_MS: u64 = 7_000;
 /// Shorter rolling window for the SPEECH-RATE read specifically: the 7 s monotony
-/// window made pace lag by seconds (slow to react, slow to clear). ~3 s still holds
-/// enough syllables to be stable at a normal pace while tracking changes ~2× faster.
-const RATE_WINDOW_MS: u64 = 3_000;
-/// Emit cadence (~2 Hz), matching the level meter's "glanceable" rate.
-const EMIT_EVERY_MS: u64 = 500;
+/// window made pace lag by seconds (slow to react, slow to clear). ~2 s (6–10
+/// syllables at conversational pace) is the floor where the count still reads
+/// stable; the `< 8` frame / `< 800 ms` span guards below it keep startup sane.
+const RATE_WINDOW_MS: u64 = 2_000;
+/// Emit cadence (~6–7 Hz). Was 500 ms to match the level meter's "glanceable"
+/// rate, but that alone put up to half a second between a behavior change and
+/// the gauges/nudge logic seeing it — the single largest incidental lag in the
+/// delivery path. The DSP work per emit is trivial, so emit near-continuously
+/// and let the UI's 200 ms width transition do the visual smoothing.
+const EMIT_EVERY_MS: u64 = 150;
 /// Minimum voiced (pitched) frames in the window before monotony is meaningful
 /// (scaled to the ~16 ms hop so it still means ~0.4 s of real voicing).
 const MIN_VOICED_FRAMES: usize = 24;
@@ -105,7 +110,7 @@ const FILLED_MIN_MS: u64 = 400;
 /// real words carry more pitch movement.
 const FILLED_FLAT_SEMITONES: f32 = 1.2;
 
-/// Payload emitted to the frontend ~2×/s. Snake-case on the wire; the frontend
+/// Payload emitted to the frontend ~6–7×/s. Snake-case on the wire; the frontend
 /// maps it to camelCase (see `tauriEvents.ts`), mirroring `transcript://segment`.
 #[derive(Clone, Serialize)]
 struct ProsodyEvent {

--- a/src/lib/analysis/useDelivery.ts
+++ b/src/lib/analysis/useDelivery.ts
@@ -27,7 +27,7 @@ const NUDGE_KEY: Record<Exclude<DeliveryNudgeKind, "tone" | "filler">, Translati
  * *tone* nudge is pushed separately by the analysis engine. No-op off-air.
  *
  * The coach is rebuilt per meeting and whenever the toggles change (which resets
- * its baselines); it's driven off the `prosody` slice, which updates ~2×/s.
+ * its baselines); it's driven off the `prosody` slice, which updates ~6–7×/s.
  */
 export function useDeliveryCoach(): void {
   const meetingStatus = useStore((s) => s.meetingStatus);


### PR DESCRIPTION
## What

From the realtime-latency audit: the prosody emit cadence (`EMIT_EVERY_MS = 500`) alone put up to **half a second** between a behavior change and the delivery gauges/nudges seeing it, stacked on top of the DSP windows. Two knobs, both incidental:

- **`EMIT_EVERY_MS` 500 → 150 ms** (~6–7 Hz). Per-emit DSP cost is trivial (stats over a ≤7 s frame window + one lock). The DeliveryPanel bars keep their 200 ms width transition, so visuals stay smooth — they just track reality ~350 ms sooner. The coach's sustain/cooldown gates are wall-clock-based, so nudge frequency is unchanged; conditions are simply observed with less quantization.
- **`RATE_WINDOW_MS` 3000 → 2000 ms.** 6–10 syllables at conversational pace still gives a stable nuclei count (the existing `< 8` frames / `< 800 ms` span guards cover startup), and the pace gauge now reacts to and clears after tempo changes ~1 s sooner (median lag ~1 s, was ~1.5 s).

Intonation's 7 s window is untouched — that one is DSP-inherent for pitch-spread stability, and its post-speech lingering was already fixed by the 2 s clear in v0.8.21.

## Effect on user-visible latency
- Any gauge movement: worst-case cadence lag 500 → 150 ms.
- Pace changes: total median lag ~1.75 s → ~1.1 s; full clear after stopping ~3.5 s → ~2.15 s.
- Filled-pause count: appears up to ~350 ms sooner (400 ms hold requirement is inherent and unchanged).

## Tests
`cargo test --lib`: 15 prosody tests green (none pin the cadence). `tsc` clean, 105 frontend tests green (coach tests drive wall-clock timestamps directly, independent of cadence).