### PR TITLE
[fix] mute a stopped meeting's late errors; fix listener-leak race

### DIFF
--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -186,6 +186,16 @@ pub type RecorderBuf = Arc<Mutex<Option<Vec<i16>>>>;
 /// `{ source, code, message }`: meetings pass `meeting://error` (the meeting UI
 /// tears down on it), voice typing passes `voicetyping://error` (the host
 /// forwards it to the overlay's error state).
+///
+/// `error_mute`: session tasks outlive `stop_meeting` by up to the flush/abort
+/// grace, and the meeting UI tears down on `meeting://error` unconditionally —
+/// so a failure inside that window (it belongs to a meeting the user already
+/// ended) would kill the NEXT meeting the user just started, or toast a
+/// spurious failure for one that completed fine. `stop_meeting` sets the flag
+/// when it releases its tasks; a muted failure is logged only. Voice typing
+/// passes `None` — its stale-error guards are abort-on-restart plus the
+/// host-side busy/generation checks.
+#[allow(clippy::too_many_arguments)]
 pub fn run_metered_session(
     app: &AppHandle,
     provider: SttProvider,
@@ -194,6 +204,7 @@ pub fn run_metered_session(
     rx: UnboundedReceiver<Vec<i16>>,
     recorder: Option<RecorderBuf>,
     error_event: &'static str,
+    error_mute: Option<Arc<AtomicBool>>,
 ) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -250,10 +261,20 @@ pub fn run_metered_session(
             } else {
                 "connect"
             };
-            let _ = app.emit(
-                error_event,
-                serde_json::json!({ "source": label, "code": code, "message": msg }),
-            );
+            if error_mute
+                .as_ref()
+                .is_some_and(|m| m.load(Ordering::SeqCst))
+            {
+                // The owning meeting was already stopped: the failure has no
+                // actionable surface and the teardown it triggers would hit
+                // whatever meeting is CURRENTLY running instead.
+                log::info!("[stt:{label}] failure after stop — suppressing {error_event}");
+            } else {
+                let _ = app.emit(
+                    error_event,
+                    serde_json::json!({ "source": label, "code": code, "message": msg }),
+                );
+            }
         }
 
         let samples = counter.await.unwrap_or(0);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -65,6 +65,11 @@ pub struct MeetingState {
     /// closes the socket even if the capture→channel-close cascade stalls, instead
     /// of letting the session linger and keep emitting transcript after stop.
     tasks: Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>,
+    /// This meeting's `meeting://error` mute (fresh per start, set on stop).
+    /// Session tasks outlive `stop_meeting` by the flush/abort grace; a failure
+    /// in that window must not tear down whatever meeting runs NEXT — see
+    /// `run_metered_session`.
+    error_mute: Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
     /// Buffers the recorded audio of the in-progress live meeting (see RecorderBuf).
     recorder: RecorderBuf,
 }
@@ -179,6 +184,10 @@ pub fn start_meeting(
     *state.recorder.lock().unwrap() = Some(Vec::new());
     // Drop any (finished) session handles from a prior meeting before this one fills in.
     state.tasks.lock().unwrap().clear();
+    // Arm THIS meeting's error mute (unset). The previous meeting's sessions
+    // hold the previous Arc — already muted by its stop.
+    let error_mute = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    *state.error_mute.lock().unwrap() = Some(error_mute.clone());
     let recorder = state.recorder.clone();
     let model = model
         .filter(|m| !m.trim().is_empty())
@@ -240,6 +249,7 @@ pub fn start_meeting(
                         rx_mix,
                         Some(recorder),
                         "meeting://error",
+                        Some(error_mute.clone()),
                     ));
                 }
                 // If one capture failed, transcribe + record whichever started.
@@ -252,6 +262,7 @@ pub fn start_meeting(
                         a,
                         Some(recorder),
                         "meeting://error",
+                        Some(error_mute.clone()),
                     ));
                 }
                 (None, Some(b)) => {
@@ -263,6 +274,7 @@ pub fn start_meeting(
                         b,
                         Some(recorder),
                         "meeting://error",
+                        Some(error_mute.clone()),
                     ));
                 }
                 (None, None) => {
@@ -297,6 +309,7 @@ pub fn start_meeting(
                     rx,
                     Some(recorder),
                     "meeting://error",
+                    Some(error_mute.clone()),
                 ));
             }
             if let Ok(rx) = spawn_capture(&coord, MicUser::Meeting, sys, gate.clone(), "them") {
@@ -309,6 +322,7 @@ pub fn start_meeting(
                     rx,
                     None,
                     "meeting://error",
+                    Some(error_mute.clone()),
                 ));
             }
         }
@@ -330,6 +344,7 @@ pub fn start_meeting(
                 rx,
                 Some(recorder),
                 "meeting://error",
+                Some(error_mute.clone()),
             );
             state.tasks.lock().unwrap().push(task);
         }
@@ -355,6 +370,13 @@ pub fn stop_meeting(
     // lose the last segment + usage event.)
     let tasks: Vec<tauri::async_runtime::JoinHandle<()>> =
         state.tasks.lock().unwrap().drain(..).collect();
+    // From this point the meeting is over: a failure inside the flush/abort
+    // grace below belongs to THIS (ended) meeting, and raising meeting://error
+    // for it would tear down whatever meeting the user starts next (or toast a
+    // spurious failure). Mute it — run_metered_session logs instead.
+    if let Some(mute) = state.error_mute.lock().unwrap().as_ref() {
+        mute.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
     if !tasks.is_empty() {
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(8000)).await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -368,15 +368,16 @@ pub fn stop_meeting(
     // is a no-op, and after stop no new audio flows, so the extra idle wait
     // produces no new transcript. (A short grace would cut a slow finalize and
     // lose the last segment + usage event.)
-    let tasks: Vec<tauri::async_runtime::JoinHandle<()>> =
-        state.tasks.lock().unwrap().drain(..).collect();
     // From this point the meeting is over: a failure inside the flush/abort
     // grace below belongs to THIS (ended) meeting, and raising meeting://error
     // for it would tear down whatever meeting the user starts next (or toast a
-    // spurious failure). Mute it — run_metered_session logs instead.
+    // spurious failure). Mute FIRST — before anything below can make a session
+    // fail — then release the tasks; run_metered_session logs instead.
     if let Some(mute) = state.error_mute.lock().unwrap().as_ref() {
         mute.store(true, std::sync::atomic::Ordering::SeqCst);
     }
+    let tasks: Vec<tauri::async_runtime::JoinHandle<()>> =
+        state.tasks.lock().unwrap().drain(..).collect();
     if !tasks.is_empty() {
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(8000)).await;

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -138,6 +138,7 @@ pub fn start_voice_typing(
         rx,
         None,
         "voicetyping://error",
+        None,
     );
     // Pin the session task so the next start (or stop's backstop) can abort
     // it. If a newer start won the race while we were spawning, ours is the

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -52,28 +52,35 @@ let hideTimer: ReturnType<typeof setTimeout> | undefined;
 /** Wire up the host. Returns a cleanup function. No-op outside Tauri. */
 export function initVoiceTyping(): () => void {
   if (!isTauri()) return () => {};
-  let unPtt: UnlistenFn = () => {};
-  let unText: UnlistenFn = () => {};
-  let unErr: UnlistenFn = () => {};
-  let unClosed: UnlistenFn = () => {};
+  // listen() resolves asynchronously — a cleanup that runs before it resolves
+  // (StrictMode's dev double-mount of App) must still unlisten the late
+  // arrival, or the second init's handlers double up for the app's lifetime.
+  let cancelled = false;
+  const unsubs: UnlistenFn[] = [];
+  const track = (p: Promise<UnlistenFn>) => {
+    p.then((u) => {
+      if (cancelled) u();
+      else unsubs.push(u);
+    }).catch(() => {});
+  };
   // Serialize press/release handling: a quick tap used to run endSession's
   // `stop_voice_typing` while startSession's invoke was still in flight, so
   // the stop reached Rust FIRST and no-op'd — leaving a live, ownerless
   // backend session (mic claimed, socket open) behind. Chaining guarantees
   // start has resolved before its matching stop is issued.
   let pttChain: Promise<void> = Promise.resolve();
-  listen<{ down: boolean }>("voicetyping://ptt", (e) => {
-    const isDown = e.payload.down;
-    pttChain = pttChain.then(() => onPtt(isDown)).catch(() => {});
-  })
-    .then((u) => (unPtt = u))
-    .catch(() => {});
-  listen<{ text: string }>("voicetyping://text", (e) => {
-    latestText = e.payload.text;
-    lastTextAt = Date.now();
-  })
-    .then((u) => (unText = u))
-    .catch(() => {});
+  track(
+    listen<{ down: boolean }>("voicetyping://ptt", (e) => {
+      const isDown = e.payload.down;
+      pttChain = pttChain.then(() => onPtt(isDown)).catch(() => {});
+    }),
+  );
+  track(
+    listen<{ text: string }>("voicetyping://text", (e) => {
+      latestText = e.payload.text;
+      lastTextAt = Date.now();
+    }),
+  );
   // Backend STT failure (rejected key, expired hosted session, out of
   // credits). The host owns the session lifecycle, so it bridges the event
   // into the overlay's one error surface (`voicetyping://session`) — the code
@@ -81,14 +88,14 @@ export function initVoiceTyping(): () => void {
   // looks like successful silence: frozen waveform, no transcript, no
   // explanation. The mic stays claimed until release; endSession still stops
   // it, and finalize still delivers whatever text arrived before the death.
-  listen<{ code: string }>("voicetyping://error", (e) => {
-    if (!busy) return; // stale event from an already-finished session
-    failed = true;
-    log.warn("voice-typing: session failed", { code: e.payload.code });
-    emit("voicetyping://session", { phase: "error", message: e.payload.code }).catch(() => {});
-  })
-    .then((u) => (unErr = u))
-    .catch(() => {});
+  track(
+    listen<{ code: string }>("voicetyping://error", (e) => {
+      if (!busy) return; // stale event from an already-finished session
+      failed = true;
+      log.warn("voice-typing: session failed", { code: e.payload.code });
+      emit("voicetyping://session", { phase: "error", message: e.payload.code }).catch(() => {});
+    }),
+  );
   // The backend session is fully over — every final token has been emitted.
   // Re-arm the settle loop: it sees `closedAt` and finalizes after the short
   // CLOSE_DRAIN_MS instead of the SETTLE_MS quiet poll. Ignored unless we're
@@ -98,14 +105,14 @@ export function initVoiceTyping(): () => void {
   // whose delivery slipped past startSession's `closedAt = 0` reset, and
   // honoring that one would cut the new session's flush short. Failed
   // sessions are finalized immediately by endSession already.
-  listen<{ source: string }>("stt://closed", (e) => {
-    if (e.payload.source !== "voice-typing") return;
-    if (!busy || down || failed) return;
-    closedAt = Date.now();
-    waitForSettle();
-  })
-    .then((u) => (unClosed = u))
-    .catch(() => {});
+  track(
+    listen<{ source: string }>("stt://closed", (e) => {
+      if (e.payload.source !== "voice-typing") return;
+      if (!busy || down || failed) return;
+      closedAt = Date.now();
+      waitForSettle();
+    }),
+  );
   // Apply the saved push-to-talk key so the right trigger is live from launch
   // (registers Option+Space, or arms the HID tap for a modifier key). The
   // Settings panel re-applies it whenever the user changes the selection.
@@ -136,10 +143,8 @@ export function initVoiceTyping(): () => void {
   // Warm the overlay window so it's listening before the first key press.
   prewarmOverlay().catch(() => {});
   return () => {
-    unPtt();
-    unText();
-    unErr();
-    unClosed();
+    cancelled = true;
+    unsubs.forEach((u) => u());
   };
 }
 

--- a/src/voice-typing/VoiceTypingApp.tsx
+++ b/src/voice-typing/VoiceTypingApp.tsx
@@ -120,53 +120,69 @@ export const VoiceTypingApp = () => {
 
   useEffect(() => {
     const unsubs: Array<() => void> = [];
+    // listen() resolves asynchronously, so an unmount that lands before it
+    // resolves (StrictMode's dev double-mount, any overlay remount) would push
+    // the unlisten into an already-drained array — a leaked duplicate listener
+    // that double-fires setState for the lifetime of this long-lived window.
+    // Track through a cancellation flag instead: late arrivals unlisten
+    // themselves immediately.
+    let cancelled = false;
+    const track = (p: Promise<() => void>) => {
+      p.then((u) => {
+        if (cancelled) u();
+        else unsubs.push(u);
+      }).catch(() => {});
+    };
 
     // Warm the S→T dictionary while the overlay is prewarmed/idle, so the
     // first dictation's publish doesn't stall on the dictionary parse.
     preloadZhConverter();
 
-    listen<SegPayload>("transcript://segment", (e) => {
-      const p = e.payload;
-      if (p.source !== "voice-typing") return;
-      if (p.is_final) {
-        finalsRef.current.set(p.id, p.text);
-        interimRef.current = ""; // the committed run supersedes the tail
-      } else {
-        interimRef.current = p.text;
-      }
-      publish.current().catch(() => {});
-    })
-      .then((u) => unsubs.push(u))
-      .catch(() => {});
+    track(
+      listen<SegPayload>("transcript://segment", (e) => {
+        const p = e.payload;
+        if (p.source !== "voice-typing") return;
+        if (p.is_final) {
+          finalsRef.current.set(p.id, p.text);
+          interimRef.current = ""; // the committed run supersedes the tail
+        } else {
+          interimRef.current = p.text;
+        }
+        publish.current().catch(() => {});
+      }),
+    );
 
-    listen<LevelPayload>("audio://level", (e) => {
-      if (e.payload.source !== "voice-typing") return;
-      setBars(instantWaveform(e.payload.level));
-    })
-      .then((u) => unsubs.push(u))
-      .catch(() => {});
+    track(
+      listen<LevelPayload>("audio://level", (e) => {
+        if (e.payload.source !== "voice-typing") return;
+        setBars(instantWaveform(e.payload.level));
+      }),
+    );
 
-    listen<SessionPayload>("voicetyping://session", (e) => {
-      const { phase: p, message } = e.payload;
-      if (p === "start") {
-        finalsRef.current.clear();
-        interimRef.current = "";
-        setText("");
-        setError(null);
-        setPhase("listening");
-      } else if (p === "stop") {
-        setPhase("finalizing");
-      } else if (p === "done") {
-        setPhase("done");
-      } else if (p === "error") {
-        setError(message || "error");
-        setPhase("done");
-      }
-    })
-      .then((u) => unsubs.push(u))
-      .catch(() => {});
+    track(
+      listen<SessionPayload>("voicetyping://session", (e) => {
+        const { phase: p, message } = e.payload;
+        if (p === "start") {
+          finalsRef.current.clear();
+          interimRef.current = "";
+          setText("");
+          setError(null);
+          setPhase("listening");
+        } else if (p === "stop") {
+          setPhase("finalizing");
+        } else if (p === "done") {
+          setPhase("done");
+        } else if (p === "error") {
+          setError(message || "error");
+          setPhase("done");
+        }
+      }),
+    );
 
-    return () => unsubs.forEach((u) => u());
+    return () => {
+      cancelled = true;
+      unsubs.forEach((u) => u());
+    };
   }, []);
 
   // Let the waveform settle back to the floor when not actively listening.


### PR DESCRIPTION
The last two hardening items from the #104/#108 independent reviews, re-implemented against current main (the original background attempts died mid-flight, and their partial work predated the #116 host.ts rewrite — it was discarded).

## 1. A stopped meeting's late failure could tear down the next meeting

Session tasks outlive `stop_meeting` by up to the 8 s flush/abort grace, and `listenForMeetingError` runs `stopMeeting()` + `invoke("stop_meeting")` + a toast on **any** `meeting://error`. A failure inside that window belongs to a meeting the user already **ended** (e.g. hosted quota hit exactly at the finalize flush) — raising it killed the next meeting the user had just started, or toasted a spurious failure for one that completed and saved fine.

**Fix:** each `start_meeting` arms a fresh per-meeting mute (`Arc<AtomicBool>` in `MeetingState`, passed to every `run_metered_session` of that meeting); `stop_meeting` flips it when it releases its tasks. A post-stop failure is now logged, never emitted. Voice typing passes `None` (its stale-error story is #107's abort-on-restart + host-side guards).

Chosen over threading a session id through the event payload and frontend: same protection, no payload/listener/frontend changes, and it also covers the spurious-toast case by construction.

## 2. Unmount-before-resolve listener leak (overlay + host)

`listen(...).then((u) => unsubs.push(u))` with a cleanup that drains `unsubs` leaks the listener whenever cleanup runs before `listen()` resolves (StrictMode's dev double-mount; any remount of the long-lived overlay window) — the late-resolved handler stays live and double-fires every subsequent event. Both `VoiceTypingApp`'s effect and `initVoiceTyping` now track registrations through a cancellation flag; late arrivals unlisten themselves immediately.

## Testing

- `cargo clippy --all-targets` clean
- `tsc --noEmit` clean
- `vitest` 105/105

Also housekeeping (outside this diff): the two stale agent worktrees/branches holding the abandoned partial attempts were removed.