### PR TITLE
[fix] ingest: save transcript-only when analysis is skipped or cancelled

### DIFF
--- a/src/components/IngestWizard.tsx
+++ b/src/components/IngestWizard.tsx
@@ -5,6 +5,7 @@ import { useStore, speakerKey, defaultSpeakerLabel, formatClock, type ReplayTrim
 import { speakerDotClass } from "../lib/speakerColors";
 import { hasProviderKey } from "../lib/ai/settings";
 import { runAnalysis } from "../lib/analysis/engine";
+import { saveUploadToHistory } from "../lib/history/history";
 import { useI18n } from "../i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,7 +55,6 @@ export function IngestWizard() {
   const setStep = useStore((s) => s.setIngestWizardStep);
   const close = useStore((s) => s.closeIngestWizard);
   const enterReplay = useStore((s) => s.enterReplay);
-  const exitReplay = useStore((s) => s.exitReplay);
   const segments = useStore((s) => s.segments);
   const speakerNames = useStore((s) => s.speakerNames);
   const setSpeakerName = useStore((s) => s.setSpeakerName);
@@ -189,10 +189,33 @@ export function IngestWizard() {
     setTemplateId(id);
   }
 
+  /**
+   * Land on the results page WITHOUT running analysis, keeping the transcribed
+   * recording as a transcript-only history entry so the upload is never lost.
+   * Used by "analyze later", the no-LLM-key path, and Cancel once a transcript
+   * exists. Skips the save when the analysis pipeline is already running/done (it
+   * auto-saves WITH findings via useReplayAnalysis) or when the session was
+   * already persisted.
+   */
+  function finishTranscriptOnly() {
+    const st = useStore.getState();
+    const { replay, loadedHistoryId, analysisStatus } = st;
+    const hasSpoken = st.segments.some((s) => s.isFinal && s.text.trim());
+    if (replay && hasSpoken && !loadedHistoryId && analysisStatus !== "running" && analysisStatus !== "done") {
+      // Fire-and-forget: saveUploadToHistory marks the entry loaded before its slow
+      // Opus compress, so a later manual re-analysis overwrites it in place.
+      void saveUploadToHistory(replay).catch((e) =>
+        console.error("[ingest] transcript-only save failed", e),
+      );
+    }
+    close();
+  }
+
   function confirmAnalyze() {
-    // No LLM key → skip analysis, just land on the (diarized) results page.
+    // No LLM key → can't analyze; keep the transcript-only recording and land on
+    // the (diarized) results page.
     if (!hasProviderKey(useStore.getState().settings)) {
-      close();
+      finishTranscriptOnly();
       return;
     }
     setStep("analyzing");
@@ -219,15 +242,17 @@ export function IngestWizard() {
   function cancel() {
     startedRef.current = null;
     failedRef.current = null;
-    // Only tear down replay if we actually entered it (transcription step done).
-    // On count/transcribing the app is still LIVE — exitReplay would wipe a
-    // stopped live meeting's transcript/findings. Just disarm the gate instead.
+    // Once a transcript exists (we entered replay after transcription), NEVER
+    // discard it — persist it transcript-only and land on the results page so the
+    // upload isn't lost. Before that (count/transcribing, app still LIVE) there's
+    // nothing to save; exitReplay would wipe a stopped live meeting's transcript,
+    // so just disarm the deferred gate and close.
     if (useStore.getState().appMode === "replay") {
-      exitReplay();
+      finishTranscriptOnly();
     } else {
       useStore.setState({ analysisGate: "open" });
+      close();
     }
-    close();
   }
 
   const wide = step === "review" || step === "trim";
@@ -521,9 +546,9 @@ export function IngestWizard() {
                 {t("ingest.confirm")}
               </Button>
             ) : (
-              // No template picked → don't force analysis; land on the results
-              // page and let them analyze later from the timeline.
-              <Button size="sm" variant="outline" className="h-8" onClick={() => close()}>
+              // No template picked → don't force analysis; save transcript-only and
+              // land on the results page, letting them analyze later from the timeline.
+              <Button size="sm" variant="outline" className="h-8" onClick={finishTranscriptOnly}>
                 {t("ingest.skipAnalysis")}
               </Button>
             ))}

--- a/src/components/replay/useReplayAnalysis.ts
+++ b/src/components/replay/useReplayAnalysis.ts
@@ -97,6 +97,13 @@ export function useReplayAnalysis(): void {
 
     const session = useStore.getState().replay;
     if (!session) return;
+    // Already persisted (the ingest wizard saved it transcript-only when analysis
+    // was skipped/cancelled) — creating a second entry here would duplicate it.
+    // A manual re-analysis overwrites the existing one via initHistoryPersistSync.
+    if (useStore.getState().loadedHistoryId) {
+      savedFor.current = replayId;
+      return;
+    }
     savedFor.current = replayId;
     // saveUploadToHistory marks the new entry as loaded BEFORE its slow compress,
     // so a re-analysis during that window overwrites it (initHistoryPersistSync)


### PR DESCRIPTION
## Problem

After uploading a recording, the ingest wizard runs a pipeline (count → transcribe → trim → diarize → review → analyze). At the **analyze** step, dismissing the wizard lost the whole recording:

- **Cancel (取消)** called `exitReplay()`, tearing down the transcribed session and discarding everything — the upload was gone with nothing saved.
- **"稍後分析" (analyze later)** and the **no-LLM-key** path just `close()`d without ever persisting the recording. Auto-save is gated on the analysis pipeline actually running (`useReplayAnalysis`), so skipping analysis meant the transcript was never written to history.

Expected: cancelling/skipping analysis should keep the recording as a **transcript-only** history entry.

## Fix

- Added `finishTranscriptOnly()` in `IngestWizard`: once a transcript exists (we've entered replay), persist a transcript-only entry via `saveUploadToHistory` and land on the results page instead of discarding. Routed **Cancel**, **analyze later**, and the **no-key** path through it. Skips the save when analysis is already running/done (it auto-saves with findings) or when the session was already persisted; skips empty (silent) transcripts, matching `saveLiveToHistory`.
- Guarded the auto-save in `useReplayAnalysis` so a later manual re-analysis of an already-saved (transcript-only) entry overwrites it in place (via `loadedHistoryId` + `initHistoryPersistSync`) rather than creating a duplicate.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 119/119 pass
- Traced all dismissal paths (cancel / skip / no-key / post-error) and the transcript-only → manual-reanalyze flow (confirmed no duplicate entry).