### PR TITLE
[feature] settings: eye toggle to reveal/hide API key inputs

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -12,6 +12,7 @@ import { STT_PROVIDERS, STT_BY_ID } from "../lib/transcription/providers";
 import { useI18n, LANGUAGE_OPTIONS } from "../i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import {
   Select,
   SelectContent,
@@ -202,8 +203,7 @@ export function Onboarding() {
                   {llm.id === "parley" ? t("onboarding.login.signedIn") : t("onboarding.llm.noKey")}
                 </p>
               ) : (
-                <Input
-                  type="password"
+                <PasswordInput
                   autoComplete="off"
                   placeholder={llm.keyPlaceholder}
                   value={(settings[llm.apiKeyField] as string) ?? ""}
@@ -249,8 +249,7 @@ export function Onboarding() {
               {stt.id === "parley" ? (
                 <p className="text-[11px] text-muted-foreground">{t("onboarding.login.signedIn")}</p>
               ) : (
-                <Input
-                  type="password"
+                <PasswordInput
                   autoComplete="off"
                   placeholder={stt.keyPlaceholder}
                   value={(settings[stt.apiKeyField] as string) ?? ""}

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Input } from "./input";
+import { translate } from "../../i18n/messages";
+import { useStore } from "../../lib/store";
+
+/**
+ * A secret input (API keys) that masks its value like `type="password"` but adds
+ * an eye button to reveal/hide it. Behaves like {@link Input}; `className` sizes
+ * the field (applied to the wrapper so width constraints like `max-w-sm` still
+ * work). The toggle is hidden while the field is disabled, since there's nothing
+ * meaningful to reveal.
+ */
+function PasswordInput({
+  className,
+  disabled,
+  ...props
+}: Omit<React.ComponentProps<"input">, "type">) {
+  const [visible, setVisible] = React.useState(false);
+  const language = useStore((s) => s.settings.language);
+  const shown = visible && !disabled;
+
+  return (
+    <div className={cn("relative", className)}>
+      <Input
+        {...props}
+        type={shown ? "text" : "password"}
+        disabled={disabled}
+        className="pr-9"
+      />
+      {!disabled && (
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={translate(language, shown ? "common.hideKey" : "common.showKey")}
+          aria-pressed={shown}
+          className="absolute inset-y-0 right-0 flex items-center rounded-r-lg px-2.5 text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50"
+        >
+          {shown ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export { PasswordInput };

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -71,6 +71,8 @@ export const zhTW = {
   "common.saved": "已儲存",
   "common.settings": "設定",
   "common.template": "模板",
+  "common.showKey": "顯示金鑰",
+  "common.hideKey": "隱藏金鑰",
 
   "titlebar.status.recording": "錄音中",
   "titlebar.status.stopped": "已停止",
@@ -837,6 +839,8 @@ export const en = {
   "common.saved": "Saved",
   "common.settings": "Settings",
   "common.template": "Template",
+  "common.showKey": "Show key",
+  "common.hideKey": "Hide key",
 
   "titlebar.status.recording": "Recording",
   "titlebar.status.stopped": "Stopped",

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -33,6 +33,7 @@ import { STT_PROVIDERS, STT_BY_ID } from "../lib/transcription/providers";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -525,8 +526,7 @@ export function SettingsApp() {
               </Select>
             </Field>
             <Field label={t("settings.provider.apiKey", { provider: providerLabel })}>
-              <Input
-                type="password"
+              <PasswordInput
                 autoComplete="off"
                 placeholder={info.requiresKey === false ? t("settings.provider.noKeyNeeded") : info.keyPlaceholder}
                 className="max-w-sm"
@@ -623,8 +623,7 @@ export function SettingsApp() {
               </p>
             ) : (
               <Field label={t("settings.transcription.apiKey", { provider: sttInfo.label })}>
-                <Input
-                  type="password"
+                <PasswordInput
                   autoComplete="off"
                   placeholder={sttInfo.keyPlaceholder}
                   className="max-w-sm"


### PR DESCRIPTION
## What

API-key fields were masked (`type=password`) with no way to verify what was typed. Added an eye button that toggles show/hide.

## Changes

- New reusable **`PasswordInput`** (`src/components/ui/password-input.tsx`): wraps `Input`, adds an eye/eye-off button that toggles `password` ↔ `text`. Keyboard-accessible with a focus ring, screen-reader labelled via i18n (`common.showKey` / `common.hideKey`, zh-TW + en), and hidden while the field is disabled.
- Wired into both settings key fields — **AI provider** and **transcription** ([SettingsApp.tsx](src/settings/SettingsApp.tsx)) — and both **onboarding** key steps ([Onboarding.tsx](src/components/Onboarding.tsx)).

## Verification

- `tsc --noEmit` clean, `vitest` 119/119 pass
- Rendered the settings window in a browser (`#settings`) and confirmed the toggle: typing a key shows it masked, clicking the eye reveals the plaintext and swaps the icon to eye-off. Both the provider and transcription fields show the button.