### PR TITLE
[fix] voice typing: dictate during a live meeting by tapping the meeting's mic

### DIFF
--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -22,7 +22,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Emitter};
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::audio::AudioSource;
 use crate::transcription::{self, SttProvider, TranscribeConfig};
@@ -149,6 +149,68 @@ impl MicCoordinator {
     /// Who currently owns the mic (`None` when idle).
     pub fn owner(&self) -> Option<MicUser> {
         self.0.lock().unwrap().as_ref().map(|a| a.user)
+    }
+}
+
+/// Live tee of the meeting's raw microphone PCM, so voice typing can dictate
+/// DURING a meeting. The meeting owns the one CoreAudio input stream (see
+/// [`MicCoordinator`] — a second concurrent stream could kill its capture), so
+/// dictation can't open its own; instead the meeting's mic pipeline
+/// (`spawn_mic_prosody_tap`) forwards a clone of every chunk to the subscriber
+/// registered here, and the dictation session reads that.
+#[derive(Clone, Default)]
+pub struct MicTap(Arc<Mutex<MicTapInner>>);
+
+#[derive(Default)]
+struct MicTapInner {
+    /// The live dictation session's input. Dropped when a send fails (the
+    /// session ended) or the last source ends, which closes the session's
+    /// channel — the graceful STT-flush path.
+    subscriber: Option<UnboundedSender<Vec<i16>>>,
+    /// Live meeting mic pipelines currently forwarding (0 or 1 in practice).
+    sources: u32,
+}
+
+impl MicTap {
+    /// A meeting mic pipeline came up and will forward chunks.
+    pub fn source_started(&self) {
+        self.0.lock().unwrap().sources += 1;
+    }
+
+    /// A meeting mic pipeline ended. When it was the last one, drop the
+    /// subscriber so a tapped dictation's input closes now (flushing its final
+    /// tokens) instead of parking silently on a channel nobody feeds.
+    pub fn source_ended(&self) {
+        let mut inner = self.0.lock().unwrap();
+        inner.sources = inner.sources.saturating_sub(1);
+        if inner.sources == 0 {
+            inner.subscriber = None;
+        }
+    }
+
+    /// Register the dictation session's sender: a clone of every meeting mic
+    /// chunk goes to it from now on. Replaces any previous subscriber (whose
+    /// channel thereby closes — a superseded session must stop receiving).
+    /// Errors when no meeting mic pipeline is live to feed it (the meeting
+    /// claimed the mic but its capture failed to start).
+    pub fn subscribe(&self, tx: UnboundedSender<Vec<i16>>) -> Result<(), String> {
+        let mut inner = self.0.lock().unwrap();
+        if inner.sources == 0 {
+            return Err("the meeting's microphone is not capturing".into());
+        }
+        inner.subscriber = Some(tx);
+        Ok(())
+    }
+
+    /// Forward one meeting mic chunk to the subscriber, if any. A failed send
+    /// means the dictation session is gone — unregister it.
+    pub fn forward(&self, chunk: &[i16]) {
+        let mut inner = self.0.lock().unwrap();
+        if let Some(sub) = inner.subscriber.as_ref() {
+            if sub.send(chunk.to_vec()).is_err() {
+                inner.subscriber = None;
+            }
+        }
     }
 }
 
@@ -312,4 +374,67 @@ pub fn run_metered_session(
         // finalize its successor's overlay).
         let _ = app.emit("stt://closed", serde_json::json!({ "source": label }));
     })
+}
+
+#[cfg(test)]
+mod mic_tap_tests {
+    use super::MicTap;
+
+    #[test]
+    fn subscribe_requires_a_live_source() {
+        let tap = MicTap::default();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        assert!(tap.subscribe(tx).is_err());
+    }
+
+    #[test]
+    fn forwards_chunks_to_the_subscriber() {
+        let tap = MicTap::default();
+        tap.source_started();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tap.subscribe(tx).unwrap();
+        tap.forward(&[1, 2, 3]);
+        assert_eq!(rx.try_recv().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn dropped_receiver_unregisters_on_next_forward() {
+        let tap = MicTap::default();
+        tap.source_started();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+        tap.subscribe(tx).unwrap();
+        drop(rx);
+        tap.forward(&[1]); // failed send clears the slot
+        assert!(tap.0.lock().unwrap().subscriber.is_none());
+    }
+
+    #[test]
+    fn last_source_ending_closes_the_subscriber() {
+        let tap = MicTap::default();
+        tap.source_started();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+        tap.subscribe(tx).unwrap();
+        tap.source_ended();
+        // The sender was dropped, so the dictation session's input is closed.
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn resubscribing_closes_the_previous_subscriber() {
+        let tap = MicTap::default();
+        tap.source_started();
+        let (tx1, mut rx1) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+        let (tx2, mut rx2) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+        tap.subscribe(tx1).unwrap();
+        tap.subscribe(tx2).unwrap();
+        tap.forward(&[7]);
+        assert!(matches!(
+            rx1.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
+        assert_eq!(rx2.try_recv().unwrap(), vec![7]);
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::audio::microphone::Microphone;
 use crate::capture::{
-    run_metered_session, spawn_capture, Begin, MicCoordinator, MicUser, RecorderBuf,
+    run_metered_session, spawn_capture, Begin, MicCoordinator, MicTap, MicUser, RecorderBuf,
 };
 use crate::transcription::common::{LevelMeter, LEVEL_EVENT};
 use crate::transcription::{SttProvider, TranscribeConfig};
@@ -719,14 +719,20 @@ fn spawn_mic_prosody_tap(
 ) -> UnboundedReceiver<Vec<i16>> {
     let (tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
     let app = app.clone();
+    // Also the feed point for the voice-typing mic tee (see MicTap): while a
+    // dictation session is subscribed, every raw-mic chunk is cloned to it.
+    let tap = app.state::<MicTap>().inner().clone();
+    tap.source_started();
     tauri::async_runtime::spawn(async move {
         let mut analyzer = crate::audio::prosody::ProsodyAnalyzer::new(app, "me", far);
         while let Some(chunk) = rx.recv().await {
             analyzer.push(&chunk);
+            tap.forward(&chunk);
             if tx.send(chunk).is_err() {
                 break;
             }
         }
+        tap.source_ended();
     });
     out_rx
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use tauri::{Emitter, Manager};
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
-use capture::MicCoordinator;
+use capture::{MicCoordinator, MicTap};
 use commands::MeetingState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -73,6 +73,9 @@ pub fn run() {
         // Single source of truth for "who owns the mic" (meeting / mic test /
         // voice typing) — guarantees at most one live capture session.
         .manage(MicCoordinator::default())
+        // Tee of the live meeting's raw mic PCM so voice typing can dictate
+        // during a meeting without opening a second input stream (see MicTap).
+        .manage(MicTap::default())
         .manage(MeetingState::default())
         // Singleton guard for the voice-typing session task (abort-on-restart
         // + bounded post-release flush) — see voice_typing::VoiceTypingState.

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager, State};
 
 use crate::audio::microphone::Microphone;
-use crate::capture::{run_metered_session, spawn_capture, Begin, MicCoordinator, MicUser};
+use crate::capture::{run_metered_session, spawn_capture, Begin, MicCoordinator, MicTap, MicUser};
 use crate::commands::{read_config_file, write_config_file};
 use crate::transcription::{SttProvider, TranscribeConfig};
 
@@ -58,9 +58,11 @@ struct VtInner {
     cutoff: Option<Arc<AtomicBool>>,
 }
 
-/// Start a mic-only streaming transcription. Idempotent while already running;
-/// refused while a meeting owns the mic (a second input stream could kill the
-/// meeting's capture — see [`MicCoordinator`]).
+/// Start a mic-only streaming transcription. Idempotent while already running.
+/// While a MEETING owns the mic, the session taps the meeting's raw mic stream
+/// instead of opening its own capture (a second input stream could kill the
+/// meeting's capture — see [`MicCoordinator`] / [`MicTap`]), so dictation works
+/// mid-meeting; only the standalone translate pipeline still refuses.
 ///
 /// Streams mic -> provider, emitting `transcript://segment` + `audio://level`
 /// with source "voice-typing"; the overlay window listens for both. The shared
@@ -73,6 +75,7 @@ struct VtInner {
 pub fn start_voice_typing(
     app: AppHandle,
     coord: State<MicCoordinator>,
+    tap: State<MicTap>,
     state: State<VoiceTypingState>,
     provider: String,
     api_key: String,
@@ -117,13 +120,36 @@ pub fn start_voice_typing(
         }
         vt.seq
     };
-    let gate = match coord.begin(MicUser::VoiceTyping) {
-        Begin::Started(gate) => gate,
+    let rx = match coord.begin(MicUser::VoiceTyping) {
+        Begin::Started(gate) => {
+            let mic = Microphone {
+                device_name: input_device,
+            };
+            match spawn_capture(&coord, MicUser::VoiceTyping, mic, gate, "voice-typing") {
+                Ok(rx) => rx,
+                Err(e) => {
+                    coord.stop(MicUser::VoiceTyping);
+                    return Err(format!("microphone failed to start: {e}"));
+                }
+            }
+        }
         // Unreachable in practice: the host serializes press/release, so no
         // second voice-typing start can land between the stop above and this
         // begin. Kept for safety.
         Begin::AlreadyActive => return Ok(()),
-        Begin::Busy(_) => return Err("microphone is in use by the meeting".into()),
+        // Dictating DURING a meeting: the meeting owns the one input stream,
+        // so read a tee of its raw mic instead of opening a second capture.
+        // Everything downstream (session, overlay, cutoff, paste) is
+        // identical; teardown is self-cleaning — when this session's receiver
+        // drops (release cutoff, abort, or new start), the tap unregisters on
+        // its next failed send. The dictated speech naturally also lands in
+        // the meeting transcript, like anything else said aloud.
+        Begin::Busy(MicUser::Meeting) => {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+            tap.subscribe(tx)?;
+            rx
+        }
+        Begin::Busy(owner) => return Err(format!("microphone is in use by {owner:?}")),
     };
     let model = model
         .filter(|m| !m.trim().is_empty())
@@ -134,17 +160,6 @@ pub fn start_voice_typing(
         language_hints: language_hints.unwrap_or_default(),
         diarization: false,
         relay_endpoint,
-    };
-
-    let mic = Microphone {
-        device_name: input_device,
-    };
-    let rx = match spawn_capture(&coord, MicUser::VoiceTyping, mic, gate, "voice-typing") {
-        Ok(rx) => rx,
-        Err(e) => {
-            coord.stop(MicUser::VoiceTyping);
-            return Err(format!("microphone failed to start: {e}"));
-        }
     };
     // Per-session cutoff: `stop_voice_typing` flips it to end the stream the
     // moment the key is released, before the mic thread even notices the gate.


### PR DESCRIPTION
## Problem

Pressing the dictation hotkey while a meeting's live transcript was running failed with a generic「語音輸入發生錯誤」overlay. `start_voice_typing` was hard-refused because the meeting owns the single CoreAudio input stream (a second concurrent capture can make CoreAudio renegotiate the device and silently kill the first — see `MicCoordinator`), so voice typing was unusable for the entire meeting.

## Fix

Instead of opening a second capture, a dictation started mid-meeting now reads a **tee of the meeting's raw mic**:

- **`capture.rs`** — new `MicTap` managed state: a subscriber slot the meeting's mic pipeline clones every PCM chunk into. Self-cleaning: a failed send unregisters the subscriber, and the meeting mic ending drops it, closing the tapped session's input for a graceful final-token flush.
- **`commands.rs`** — `spawn_mic_prosody_tap` (the single raw-mic point every meeting branch flows through: translate / diarized / plain / non-mac) forwards each chunk into the tap.
- **`voice_typing.rs`** — on `Begin::Busy(Meeting)`, subscribe to the tap instead of erroring. Everything downstream (STT session, overlay, release cutoff, paste) is unchanged. The standalone translate pipeline still refuses, now naming the actual owner.

No frontend changes needed: events are already tagged `source: "voice-typing"`, and the meeting store already filters them out — no transcript cross-contamination.

## Notes

- Dictated speech also lands in the meeting transcript (you're speaking into the meeting's mic — physically expected).
- That audio is metered under both the meeting and voice-typing sessions (inherent to two STT sessions).

## Testing

- `cargo check` / `clippy --all-targets` (0 warnings) / `cargo test` — 22 passed, incl. 5 new `MicTap` unit tests (subscribe requires a live source, forwarding, send-failure self-clean, source-end closes subscriber, resubscribe supersedes).
- Manual: dictating mid-meeting needs a live mic + STT key — please verify overlay text + paste-on-release during a real meeting.