### PR TITLE
[feature] replay 逐字稿 Ctrl+F 搜尋：命中計數、上下跳轉、關鍵字高亮

### DIFF
--- a/src/components/replay/ReplayTranscript.tsx
+++ b/src/components/replay/ReplayTranscript.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useI18n } from "../../i18n";
 import { speakerBadgeClass } from "../../lib/speakerColors";
 import { speakerLabel, speakerKey, defaultSpeakerLabel, formatClock, isTrimmed, useStore, type ReplayTrim } from "../../lib/store";
 import { cn } from "@/lib/utils";
@@ -44,6 +46,7 @@ export function ReplayTranscript({
   emptyLabel,
   preview = false,
 }: Readonly<ReplayTranscriptProps>) {
+  const { t } = useI18n();
   const rowRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const setSpeakerName = useStore((s) => s.setSpeakerName);
   // Bumped on every explicit seek (scrubber, timeline finding, action item) so we
@@ -51,6 +54,14 @@ export function ReplayTranscript({
   const seekNonce = useStore((s) => s.replaySeekNonce);
   // Which speaker key is being edited inline (null = none).
   const [editingKey, setEditingKey] = useState<string | null>(null);
+
+  // Ctrl/⌘F-style find: a floating bar over the transcript. A "match" is a LINE
+  // (segment) whose text contains the query — Enter/arrows jump line-to-line and
+  // the counter reads "current / total lines".
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [matchIdx, setMatchIdx] = useState(0);
 
   const rows = useMemo(
     () =>
@@ -60,6 +71,64 @@ export function ReplayTranscript({
         .sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs),
     [segments]
   );
+
+  const trimmedQuery = query.trim();
+  const searching = searchOpen && trimmedQuery.length > 0;
+  const matchIds = useMemo(() => {
+    if (!trimmedQuery) return [];
+    const q = trimmedQuery.toLowerCase();
+    return rows.filter((r) => r.text.toLowerCase().includes(q)).map((r) => r.id);
+  }, [rows, trimmedQuery]);
+  const currentMatchId = matchIds.length > 0 ? matchIds[Math.min(matchIdx, matchIds.length - 1)] : null;
+
+  function openSearch() {
+    setSearchOpen(true);
+    // Focus after the bar renders (also re-focuses if it's already open).
+    requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+  }
+
+  function closeSearch() {
+    setSearchOpen(false);
+    setQuery("");
+    setMatchIdx(0);
+  }
+
+  function stepMatch(dir: 1 | -1) {
+    if (matchIds.length === 0) return;
+    setMatchIdx((i) => (Math.min(i, matchIds.length - 1) + dir + matchIds.length) % matchIds.length);
+  }
+
+  // ⌘F / Ctrl+F opens (or refocuses) the find bar. Not in the ingest-wizard
+  // preview, where the transcript is a secondary pane.
+  useEffect(() => {
+    if (preview) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        setSearchOpen(true);
+        requestAnimationFrame(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        });
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [preview]);
+
+  // Typing a new query restarts at the first match.
+  useEffect(() => {
+    setMatchIdx(0);
+  }, [trimmedQuery]);
+
+  // Bring the current match into view when the query or the position changes.
+  useEffect(() => {
+    if (!currentMatchId) return;
+    rowRefs.current[currentMatchId]?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [currentMatchId, matchIdx]);
 
   // Index of the segment that "owns" the playhead: the last one started.
   const activeId = useMemo(() => {
@@ -71,11 +140,12 @@ export function ReplayTranscript({
     return id;
   }, [rows, playheadMs]);
 
-  // Keep the active row visible while playing.
+  // Keep the active row visible while playing — unless a search is in progress,
+  // so playback doesn't yank the view away from the match being inspected.
   useEffect(() => {
-    if (!playing || !activeId) return;
+    if (!playing || !activeId || searching) return;
     rowRefs.current[activeId]?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, [activeId, playing]);
+  }, [activeId, playing, searching]);
 
   // On an explicit seek (scrubber / timeline / action item), scroll to the
   // jumped-to line even while paused — so audio ⇄ timeline ⇄ transcript stay in
@@ -96,84 +166,190 @@ export function ReplayTranscript({
   }
 
   return (
-    <ScrollArea className="h-full">
-      <div className="mx-auto flex max-w-3xl flex-col gap-1 px-4 py-4">
-        {rows.map((seg, i) => {
-          const masked = !preview && seg.startMs > playheadMs;
-          const trimmed = isTrimmed(seg, trim);
-          // Highlight the playing line even in preview (the wizard trim step plays
-          // audio) — but not when there's no playback (review step: playheadMs=0).
-          const active = seg.id === activeId && (!preview || playheadMs > 0);
-          const showBadge = i === 0 || speakerLabel(seg, speakerNames) !== speakerLabel(rows[i - 1], speakerNames);
-          const key = speakerKey(seg);
-          return (
-            <div
-              key={seg.id}
-              ref={(el) => {
-                rowRefs.current[seg.id] = el;
+    <div className="relative h-full">
+      {!preview &&
+        (searchOpen ? (
+          <div className="absolute right-3 top-2 z-10 flex items-center gap-0.5 rounded-md border bg-background/95 py-1 pl-2 pr-1 shadow-md backdrop-blur">
+            <Search className="size-3.5 shrink-0 text-muted-foreground/70" />
+            <input
+              ref={searchInputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  stepMatch(e.shiftKey ? -1 : 1);
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  closeSearch();
+                }
               }}
-              className={cn(
-                "group flex w-full cursor-pointer select-text gap-2.5 rounded-md px-2 py-1.5 text-left text-sm leading-6 transition-colors",
-                "hover:bg-muted/60",
-                active && "bg-primary/10 ring-1 ring-primary/30",
-                masked && "opacity-35",
-                trimmed && "opacity-50"
-              )}
-            >
-              <button
-                type="button"
-                onClick={() => onSeek(seg.startMs)}
-                className="mt-0.5 w-9 shrink-0 select-none text-right font-mono text-[10px] tabular-nums text-muted-foreground"
+              placeholder={t("replay.searchPlaceholder")}
+              className="h-6 w-40 bg-transparent px-1.5 text-xs outline-none placeholder:text-muted-foreground/60"
+            />
+            {trimmedQuery && (
+              <span
+                className={cn(
+                  "select-none whitespace-nowrap px-1 font-mono text-[10px] tabular-nums",
+                  matchIds.length === 0 ? "text-destructive" : "text-muted-foreground"
+                )}
               >
-                {formatClock(seg.startMs)}
-              </button>
-              <span className="flex min-w-0 flex-1 items-start">
-                {showBadge &&
-                  (editingKey === key ? (
-                    <SpeakerNameInput
-                      defaultValue={speakerNames[key] ?? ""}
-                      placeholder={defaultSpeakerLabel(seg)}
-                      onCommit={(name) => {
-                        setSpeakerName(key, name);
-                        setEditingKey(null);
-                      }}
-                      onCancel={() => setEditingKey(null)}
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      title={speakerLabel(seg, speakerNames)}
-                      onClick={(e) => {
-                        // Don't let the rename click also seek the row.
-                        e.stopPropagation();
-                        setEditingKey(key);
-                      }}
-                      className={cn(
-                        "mr-1.5 inline-flex translate-y-[-1px] cursor-text items-center rounded-md px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide ring-1 hover:ring-2",
-                        speakerBadgeClass(seg)
-                      )}
-                    >
-                      {speakerLabel(seg, speakerNames)}
-                    </button>
-                  ))}
+                {matchIds.length === 0 ? 0 : Math.min(matchIdx, matchIds.length - 1) + 1}/{matchIds.length}
+              </span>
+            )}
+            <button
+              type="button"
+              aria-label={t("replay.searchPrev")}
+              title={t("replay.searchPrev")}
+              disabled={matchIds.length === 0}
+              onClick={() => stepMatch(-1)}
+              className="grid size-5 place-items-center rounded text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:hover:text-muted-foreground"
+            >
+              <ChevronUp className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label={t("replay.searchNext")}
+              title={t("replay.searchNext")}
+              disabled={matchIds.length === 0}
+              onClick={() => stepMatch(1)}
+              className="grid size-5 place-items-center rounded text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:hover:text-muted-foreground"
+            >
+              <ChevronDown className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label={t("replay.searchClose")}
+              title={t("replay.searchClose")}
+              onClick={closeSearch}
+              className="grid size-5 place-items-center rounded text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            aria-label={t("replay.searchOpen")}
+            title={t("replay.searchOpen")}
+            onClick={openSearch}
+            className="absolute right-3 top-2 z-10 grid size-7 place-items-center rounded-md border bg-background/90 text-muted-foreground shadow-sm backdrop-blur hover:text-foreground"
+          >
+            <Search className="size-3.5" />
+          </button>
+        ))}
+      <ScrollArea className="h-full">
+        <div className="mx-auto flex max-w-3xl flex-col gap-1 px-4 py-4">
+          {rows.map((seg, i) => {
+            const masked = !preview && seg.startMs > playheadMs;
+            const trimmed = isTrimmed(seg, trim);
+            // Highlight the playing line even in preview (the wizard trim step plays
+            // audio) — but not when there's no playback (review step: playheadMs=0).
+            const active = seg.id === activeId && (!preview || playheadMs > 0);
+            const isCurrentMatch = searching && seg.id === currentMatchId;
+            const showBadge = i === 0 || speakerLabel(seg, speakerNames) !== speakerLabel(rows[i - 1], speakerNames);
+            const key = speakerKey(seg);
+            return (
+              <div
+                key={seg.id}
+                ref={(el) => {
+                  rowRefs.current[seg.id] = el;
+                }}
+                className={cn(
+                  "group flex w-full cursor-pointer select-text gap-2.5 rounded-md px-2 py-1.5 text-left text-sm leading-6 transition-colors",
+                  "hover:bg-muted/60",
+                  active && "bg-primary/10 ring-1 ring-primary/30",
+                  isCurrentMatch && "ring-1 ring-amber-400/70",
+                  masked && "opacity-35",
+                  trimmed && "opacity-50"
+                )}
+              >
                 <button
                   type="button"
                   onClick={() => onSeek(seg.startMs)}
-                  className={cn(
-                    "min-w-0 flex-1 text-left",
-                    active ? "text-foreground" : "text-foreground/90",
-                    trimmed && "line-through"
-                  )}
+                  className="mt-0.5 w-9 shrink-0 select-none text-right font-mono text-[10px] tabular-nums text-muted-foreground"
                 >
-                  {seg.text}
+                  {formatClock(seg.startMs)}
                 </button>
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </ScrollArea>
+                <span className="flex min-w-0 flex-1 items-start">
+                  {showBadge &&
+                    (editingKey === key ? (
+                      <SpeakerNameInput
+                        defaultValue={speakerNames[key] ?? ""}
+                        placeholder={defaultSpeakerLabel(seg)}
+                        onCommit={(name) => {
+                          setSpeakerName(key, name);
+                          setEditingKey(null);
+                        }}
+                        onCancel={() => setEditingKey(null)}
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        title={speakerLabel(seg, speakerNames)}
+                        onClick={(e) => {
+                          // Don't let the rename click also seek the row.
+                          e.stopPropagation();
+                          setEditingKey(key);
+                        }}
+                        className={cn(
+                          "mr-1.5 inline-flex translate-y-[-1px] cursor-text items-center rounded-md px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide ring-1 hover:ring-2",
+                          speakerBadgeClass(seg)
+                        )}
+                      >
+                        {speakerLabel(seg, speakerNames)}
+                      </button>
+                    ))}
+                  <button
+                    type="button"
+                    onClick={() => onSeek(seg.startMs)}
+                    className={cn(
+                      "min-w-0 flex-1 text-left",
+                      active ? "text-foreground" : "text-foreground/90",
+                      trimmed && "line-through"
+                    )}
+                  >
+                    {searching ? highlightMatches(seg.text, trimmedQuery, isCurrentMatch) : seg.text}
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
   );
+}
+
+/**
+ * Wrap every case-insensitive occurrence of `query` in a <mark>. Marks on the
+ * current match row are stronger (amber) than on the other matching rows, the
+ * same current-vs-rest convention as a browser's find bar.
+ */
+function highlightMatches(text: string, query: string, current: boolean): ReactNode {
+  if (!query) return text;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const parts: ReactNode[] = [];
+  let from = 0;
+  for (let at = lower.indexOf(q); at !== -1; at = lower.indexOf(q, from)) {
+    if (at > from) parts.push(text.slice(from, at));
+    from = at + q.length;
+    parts.push(
+      <mark
+        key={at}
+        className={cn(
+          "rounded-[2px] text-inherit",
+          current ? "bg-amber-400/80 dark:bg-amber-400/50" : "bg-yellow-300/50 dark:bg-yellow-400/25"
+        )}
+      >
+        {text.slice(at, from)}
+      </mark>
+    );
+  }
+  if (parts.length === 0) return text;
+  if (from < text.length) parts.push(text.slice(from));
+  return parts;
 }
 
 /**

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -917,6 +917,11 @@ export const zhTW = {
   "replay.trimNote": "立即套用：範圍外的逐字稿與分析會移除，播放也只會播保留範圍（不會重新分析；重新上傳即可還原）。",
   "replay.trimStart": "修剪起點",
   "replay.trimEnd": "修剪終點",
+  "replay.searchOpen": "搜尋逐字稿（⌘F）",
+  "replay.searchPlaceholder": "搜尋逐字稿",
+  "replay.searchPrev": "上一個結果",
+  "replay.searchNext": "下一個結果",
+  "replay.searchClose": "關閉搜尋",
   // Time-anchored retro timeline (whole-recording analysis → markers).
   "timeline.title": "時間軸分析",
   "timeline.analyze": "分析",
@@ -2024,6 +2029,11 @@ export const en = {
   "replay.trimNote": "Applies instantly: transcript & findings outside the range are removed and playback is limited to it (no re-analysis; re-upload to restore).",
   "replay.trimStart": "Trim start",
   "replay.trimEnd": "Trim end",
+  "replay.searchOpen": "Search transcript (⌘F)",
+  "replay.searchPlaceholder": "Search transcript",
+  "replay.searchPrev": "Previous match",
+  "replay.searchNext": "Next match",
+  "replay.searchClose": "Close search",
   // Time-anchored retro timeline (whole-recording analysis → markers).
   "timeline.title": "Timeline analysis",
   "timeline.analyze": "Analyze",


### PR DESCRIPTION
## Summary

Replay 的逐字稿面板加入瀏覽器 Ctrl+F 式的搜尋：

- **開啟**：`⌘F` / `Ctrl+F`，或點逐字稿右上角浮動的放大鏡按鈕；`Esc` 關閉並清空。
- **計數**：即時顯示「目前位置/總命中數」（如 `3/12`），無結果時顯示紅色 `0/0`。命中單位是一行逐字稿（segment）。
- **跳轉**：`Enter` 下一個、`Shift+Enter` 上一個，另有 ↑↓ 按鈕；到底循環。跳轉沿用既有 `rowRefs` + `scrollIntoView` 機制置中該行。
- **高亮**：所有命中以黃色 `<mark>` 標示，目前那筆用較深 amber 並在該行加 ring（瀏覽器 find 的「全部 vs 目前」慣例）。
- 搜尋進行中會暫停「播放時自動捲動到目前播放行」，避免播放把視野拉走；點命中行仍會 seek 音檔。
- ingest wizard 的 preview 模式不啟用（該處逐字稿為次要面板）。

## Changes

- `src/components/replay/ReplayTranscript.tsx`：搜尋 state / ⌘F 監聽 / 浮動 find bar / 高亮 render，全部 self-contained，`ReplayScreen` 無需改動。
- `src/i18n/messages.ts`：新增 `replay.searchOpen / searchPlaceholder / searchPrev / searchNext / searchClose`（zh-TW + en）。

## Test plan

- `tsc --noEmit` 通過
- `vitest`：21 files / 192 tests 全數通過
- 手動：開任一 replay 錄音 → ⌘F → 輸入關鍵字 → Enter / Shift+Enter 跳轉、計數與高亮正確；Esc 關閉；播放中搜尋不被自動捲動干擾