### PR TITLE
[feature] MCP connection popover 加上 endpoint copy 按鈕

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { useI18n } from "../i18n";
+import { Button } from "@/components/ui/button";
+
+/** Copy-to-clipboard button with a 2s "copied" confirmation. */
+export function CopyButton({
+  value,
+  label,
+  title,
+  className,
+  iconOnly,
+  disabled,
+}: Readonly<{
+  /** Text to copy, or a thunk evaluated at click time for computed values. */
+  value: string | (() => string);
+  label?: string;
+  title?: string;
+  className?: string;
+  iconOnly?: boolean;
+  disabled?: boolean;
+}>) {
+  const { t } = useI18n();
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(typeof value === "function" ? value() : value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  if (iconOnly) {
+    return (
+      <Button variant="ghost" size="icon" className={className} title={title} disabled={disabled} onClick={copy}>
+        {copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
+      </Button>
+    );
+  }
+  return (
+    <Button variant="outline" size="sm" className={className} title={title} disabled={disabled} onClick={copy}>
+      {copied ? (
+        <>
+          <Check className="size-3.5 text-emerald-500" />
+          <span>{t("settings.mcp.copied")}</span>
+        </>
+      ) : (
+        <>
+          <Copy className="size-3.5" />
+          <span>{label}</span>
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/components/McpStatusChip.tsx
+++ b/src/components/McpStatusChip.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, Plug } from "lucide-react";
 import { isTauri } from "../lib/tauriEvents";
 import { useI18n } from "../i18n";
 import { cn } from "@/lib/utils";
+import { CopyButton } from "@/components/CopyButton";
 
 /** One tool call recorded by the MCP server (newest first in `recent`). */
 export interface McpActivityEntry {
@@ -142,9 +143,17 @@ export function McpStatusChip() {
               </span>
             </div>
             {endpoint && (
-              <div className="flex items-baseline justify-between gap-2">
+              <div className="flex items-center justify-between gap-2">
                 <span className="shrink-0 text-muted-foreground">Endpoint</span>
-                <span className="truncate font-mono text-[10px] text-muted-foreground">{endpoint}</span>
+                <span className="flex min-w-0 items-center gap-1">
+                  <span className="truncate font-mono text-[10px] text-muted-foreground">{endpoint}</span>
+                  <CopyButton
+                    value={endpoint}
+                    iconOnly
+                    title={t("settings.mcp.copyUrl")}
+                    className="size-5 shrink-0 text-muted-foreground"
+                  />
+                </span>
               </div>
             )}
           </div>

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -6,7 +6,7 @@ import { appLogDir, join } from "@tauri-apps/api/path";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
 import { log } from "../lib/log";
-import { Check, Copy, Download, Loader2, LogIn, LogOut, Monitor, Moon, PlugZap, Plus, ScrollText, Sun, Trash2 } from "lucide-react";
+import { Check, Download, Loader2, LogIn, LogOut, Monitor, Moon, PlugZap, Plus, ScrollText, Sun, Trash2 } from "lucide-react";
 import { useStore } from "../lib/store";
 import { LANGUAGE_OPTIONS, useI18n, type TranslationKey } from "../i18n";
 import { broadcastSettings } from "../lib/settingsSync";
@@ -32,6 +32,7 @@ import { ReleaseNotesDialog } from "../components/ReleaseNotesDialog";
 import { UsagePanel } from "./UsagePanel";
 import { STT_PROVIDERS, STT_BY_ID } from "../lib/transcription/providers";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/CopyButton";
 import { Toaster } from "@/components/ui/sonner";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
@@ -1175,54 +1176,6 @@ function AccountSignInField({
         </div>
       )}
     </Field>
-  );
-}
-
-/** Copy-to-clipboard button with a 2s "copied" confirmation. */
-function CopyButton({
-  value,
-  label,
-  title,
-  className,
-  iconOnly,
-  disabled,
-}: Readonly<{
-  /** Text to copy, or a thunk evaluated at click time for computed values. */
-  value: string | (() => string);
-  label?: string;
-  title?: string;
-  className?: string;
-  iconOnly?: boolean;
-  disabled?: boolean;
-}>) {
-  const { t } = useI18n();
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(typeof value === "function" ? value() : value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-  if (iconOnly) {
-    return (
-      <Button variant="ghost" size="icon" className={className} title={title} disabled={disabled} onClick={copy}>
-        {copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
-      </Button>
-    );
-  }
-  return (
-    <Button variant="outline" size="sm" className={className} title={title} disabled={disabled} onClick={copy}>
-      {copied ? (
-        <>
-          <Check className="size-3.5 text-emerald-500" />
-          <span>{t("settings.mcp.copied")}</span>
-        </>
-      ) : (
-        <>
-          <Copy className="size-3.5" />
-          <span>{label}</span>
-        </>
-      )}
-    </Button>
   );
 }
 


### PR DESCRIPTION
## Summary
- MCP connection & activity popover（titlebar 插頭圖示）現在在 Endpoint 旁邊加上複製按鈕，不用再手動選取文字。
- 把 SettingsApp.tsx 裡原本私有的 `CopyButton` 抽成共用元件 `src/components/CopyButton.tsx`，Settings 頁與 popover 共用同一份實作。

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] `npm run test`（192 tests）全數通過
- [ ] 實機跑一次 app，開啟 titlebar 的 MCP 插頭圖示 popover，確認 Endpoint 旁的複製按鈕能正確複製並顯示已複製的勾勾狀態