### PR TITLE
[fix] HistoryEntry 加 analyzed 欄位，0-findings 錄音重開不再重跑 action items

### DIFF
--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -74,6 +74,13 @@ function snapshotAnalysis() {
     speakerNames: s.speakerNames,
     findings: s.findings,
     actionItems: s.actionItems,
+    // "Pipeline completed" marker — lets loadHistory restore even an EMPTY result
+    // as done instead of re-running it. False when a pass hasn't run or failed
+    // (a live save before the post-meeting pass; an errored action-items pass):
+    // loading then falls back to the content heuristic, and the flag turns true
+    // once a completed re-run persists (initHistoryPersistSync snapshots only
+    // after both statuses settle "done").
+    analyzed: s.analysisStatus === "done" && s.actionItemsStatus === "done",
     meetingContext: s.meetingContext,
     companyId: s.meetingCompanyId,
     threadId: s.meetingThreadId,
@@ -405,6 +412,7 @@ export async function persistStudyOutputs(): Promise<void> {
     writeStudyCache(s.replay.id, {
       findings: s.findings,
       actionItems: s.actionItems,
+      analyzed: s.analysisStatus === "done" && s.actionItemsStatus === "done",
       brief: s.brief,
       intel: s.intel,
       deliveryAssessment: s.deliveryAssessment,
@@ -560,6 +568,9 @@ export async function loadOrgEntry(orgId: string, id: string): Promise<void> {
   if (cached) {
     if (!meta.findings.length && cached.findings?.length) meta.findings = cached.findings;
     if (!meta.actionItems.length && cached.actionItems?.length) meta.actionItems = cached.actionItems;
+    // The VIEWER's own completed pass also counts as analyzed — a clean-empty
+    // result must restore as done here too, or every open re-spends it.
+    if (cached.analyzed) meta.analyzed = true;
     meta.brief = meta.brief ?? cached.brief ?? null;
     meta.intel = meta.intel ?? cached.intel ?? null;
     meta.deliveryAssessment = meta.deliveryAssessment ?? cached.deliveryAssessment ?? null;

--- a/src/lib/history/studyCache.test.ts
+++ b/src/lib/history/studyCache.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The unit suite runs in a plain Node env (no DOM); back the best-effort
+// localStorage cache with a Map so the merge semantics are actually exercised.
+const backing = new Map<string, string>();
+vi.stubGlobal("localStorage", {
+  getItem: (k: string) => backing.get(k) ?? null,
+  setItem: (k: string, v: string) => void backing.set(k, v),
+  removeItem: (k: string) => void backing.delete(k),
+  key: (i: number) => [...backing.keys()][i] ?? null,
+  get length() {
+    return backing.size;
+  },
+});
+
+import { readStudyCache, writeStudyCache, clearStudyCache } from "./studyCache";
+import type { TimelineEvent } from "../types";
+
+const finding: TimelineEvent = {
+  id: "f1",
+  atMs: 1000,
+  side: "them",
+  severity: "warn",
+  source: "extra",
+  title: "moment",
+  detail: "something happened",
+};
+
+beforeEach(() => {
+  clearStudyCache(); // resets the module memo AND drops the backing keys
+});
+
+describe("writeStudyCache `analyzed` merge", () => {
+  it("accretes and never un-sets: a mid-pipeline false keeps an earlier true", () => {
+    writeStudyCache("e1", { findings: [finding], analyzed: true });
+    // A later persist while a re-run is still in flight reports false — the
+    // completed marker (and the untouched outputs) must survive it.
+    writeStudyCache("e1", { analyzed: false, brief: "debrief" });
+
+    const cached = readStudyCache("e1");
+    expect(cached?.analyzed).toBe(true);
+    expect(cached?.findings).toEqual([finding]);
+    expect(cached?.brief).toBe("debrief");
+  });
+
+  it("a plain false is dropped, not stored (absent ≙ unknown for old caches)", () => {
+    writeStudyCache("e2", { analyzed: false });
+    expect(readStudyCache("e2")?.analyzed).toBeUndefined();
+  });
+});

--- a/src/lib/history/studyCache.ts
+++ b/src/lib/history/studyCache.ts
@@ -21,6 +21,10 @@ const key = (entryId: string) => `${PREFIX}${entryId}`;
 export interface StudyCacheEntry {
   findings?: TimelineEvent[];
   actionItems?: ActionItem[];
+  /** True once the findings + action-items pipeline completed — marks even an
+   *  EMPTY result as done so reopening doesn't re-run it (the read-only twin of
+   *  HistoryEntry.analyzed). Accretive: once true it never un-sets. */
+  analyzed?: boolean;
   brief?: string | null;
   intel?: IntelState | null;
   deliveryAssessment?: DeliveryAssessment | null;
@@ -48,6 +52,9 @@ export function writeStudyCache(entryId: string, patch: StudyCacheEntry): void {
     ...prev,
     findings: patch.findings?.length ? patch.findings : prev.findings,
     actionItems: patch.actionItems?.length ? patch.actionItems : prev.actionItems,
+    // `|| undefined` so a mid-pipeline persist (actions still running → false)
+    // keeps an earlier true and a plain false is dropped from the JSON.
+    analyzed: patch.analyzed || prev.analyzed || undefined,
     brief: patch.brief ?? prev.brief ?? null,
     intel: patch.intel ?? prev.intel ?? null,
     deliveryAssessment: patch.deliveryAssessment ?? prev.deliveryAssessment ?? null,

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -33,6 +33,13 @@ export interface HistoryEntry {
   findings: TimelineEvent[];
   /** Post-meeting follow-ups generated from the analysis. */
   actionItems: ActionItem[];
+  /** True once the findings + action-items pipeline COMPLETED for this recording.
+   *  The arrays alone can't distinguish "analyzed, genuinely empty" from "never
+   *  analyzed" (a clean short meeting legitimately yields 0 of both), and loading
+   *  must not re-spend the model on the former. Optional: entries saved before
+   *  this field existed omit it → loading falls back to inferring completion from
+   *  non-empty findings/actionItems. */
+  analyzed?: boolean;
   /** Per-meeting free-text context + principled-negotiation setup. */
   meetingContext: string;
   /** Accounts link (mini-CRM, design §3.2): which company/thread this meeting

--- a/src/lib/store.actions.test.ts
+++ b/src/lib/store.actions.test.ts
@@ -10,6 +10,7 @@ vi.mock("./log", () => ({
 import { useStore } from "./store";
 import { seg, replaySession } from "./test/fixtures";
 import type { TimelineEvent } from "./types";
+import type { HistoryEntry } from "./history/types";
 
 // Snapshot the pristine initial state once, then restore before every test so
 // each case drives the store from a known baseline (the store is a singleton).
@@ -145,6 +146,73 @@ describe("loadHistory", () => {
     expect(s.meetingFloor).toBe("floor");
     // A non-stale eval signature so findings aren't flagged stale.
     expect(s.analyzedEvalSig).not.toBe("");
+  });
+
+  // Minimal saved entry for the status-restore cases; override per test.
+  function histEntry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {
+    return {
+      id: "hist-1",
+      title: "entry",
+      source: "live",
+      createdAt: 123,
+      durationMs: 60_000,
+      segments: [seg({ id: "s1", text: "saved line" })],
+      speakerNames: {},
+      findings: [],
+      actionItems: [],
+      meetingContext: "",
+      meetingBatna: "",
+      meetingTarget: "",
+      meetingFloor: "",
+      audio: "audio.ogg",
+      ...overrides,
+    };
+  }
+
+  it("restores an analyzed-but-EMPTY entry as done — a clean meeting must not re-run on reopen", () => {
+    const session = replaySession([seg({ id: "s1", text: "short clean meeting" })], {
+      id: "hist-2",
+    });
+    useStore.getState().loadHistory(histEntry({ id: "hist-2", analyzed: true }), session);
+
+    const s = useStore.getState();
+    expect(s.findings).toEqual([]);
+    expect(s.actionItems).toEqual([]);
+    // Both "done": the study pipeline dispatches nothing, so no model re-spend.
+    expect(s.analysisStatus).toBe("done");
+    expect(s.actionItemsStatus).toBe("done");
+  });
+
+  it("falls back to content inference for entries predating `analyzed`", () => {
+    const session = replaySession([seg({ id: "s1", text: "hi" })], { id: "hist-3" });
+
+    // Legacy empty entry: can't tell "clean" from "never ran" → idle, so the
+    // pipeline generates once on open (and the persist writes the flag).
+    useStore.getState().loadHistory(histEntry({ id: "hist-3" }), session);
+    expect(useStore.getState().analysisStatus).toBe("idle");
+    expect(useStore.getState().actionItemsStatus).toBe("idle");
+
+    // Legacy entry WITH content restores done, exactly as before the flag.
+    useStore
+      .getState()
+      .loadHistory(histEntry({ id: "hist-3", findings: [makeFinding("f1")] }), session);
+    expect(useStore.getState().analysisStatus).toBe("done");
+    expect(useStore.getState().actionItemsStatus).toBe("done");
+  });
+
+  it("analyzed:false defers to content — an errored pass must not force re-runs when findings exist", () => {
+    // Shape saveUploadToHistory writes when action items ERRORED after a good
+    // findings pass: analyzed false, findings present. Reopen keeps them "done"
+    // (retry stays manual, matching pre-flag behavior).
+    const session = replaySession([seg({ id: "s1", text: "hi" })], { id: "hist-4" });
+    useStore
+      .getState()
+      .loadHistory(
+        histEntry({ id: "hist-4", analyzed: false, findings: [makeFinding("f1")] }),
+        session,
+      );
+    expect(useStore.getState().analysisStatus).toBe("done");
+    expect(useStore.getState().actionItemsStatus).toBe("done");
   });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -610,6 +610,13 @@ export const useStore = create<ParleyState>()(
       findings: entry.findings.length,
       readOnly: !!opts?.readOnly,
     });
+    // Did the findings + action-items pipeline already run for this entry? The
+    // saved `analyzed` flag says so even when the result was genuinely EMPTY (a
+    // clean meeting yields 0 findings and 0 action items) — without it, every
+    // reopen would re-dispatch and re-spend the action-items generation. Entries
+    // predating the flag fall back to inferring completion from content.
+    const analysisDone =
+      entry.analyzed || entry.findings.length > 0 || entry.actionItems.length > 0;
     set((state) => ({
       appMode: "replay",
       replay: session,
@@ -634,10 +641,10 @@ export const useStore = create<ParleyState>()(
       // open, written back by initHistoryPersistSync / persistStudyOutputs.
       ...CLEARED_STUDY_SLICE,
       findings: entry.findings,
-      analysisStatus: entry.findings.length > 0 || entry.actionItems.length > 0 ? "done" : "idle",
+      analysisStatus: analysisDone ? "done" : "idle",
       analyzedEvalSig: evalSignature(state.evaluations),
       actionItems: entry.actionItems,
-      actionItemsStatus: entry.findings.length > 0 || entry.actionItems.length > 0 ? "done" : "idle",
+      actionItemsStatus: analysisDone ? "done" : "idle",
       deliveryAssessment: entry.deliveryAssessment ?? null,
       deliveryStatus: entry.deliveryAssessment ? "done" : "idle",
       brief: entry.brief ?? null,


### PR DESCRIPTION
## 問題

`loadHistory` 用 `entry.findings.length > 0 || entry.actionItems.length > 0` 推斷 `analysisStatus` / `actionItemsStatus`。當一場會議的分析真的產出 **0 findings 且 0 action items**（乾淨的短會議），每次從 History 重開該錄音都會被判成 `idle`，studyPipeline 重新 dispatch：findings 有 content-keyed 快取擋下（免費），但 `runActionItems` 沒有快取，**每次重開都真的再打一次 LLM**。

## 修法

`HistoryEntry` 加 optional `analyzed: boolean`（「findings + action-items pipeline 已跑完」），`loadHistory` 改判 `entry.analyzed || 內容非空`：

- **types.ts** — 加 `analyzed?: boolean`，記錄「分析過但真的是空」與「從沒分析過」的差別（陣列本身分不出來）。
- **store.ts `loadHistory`** — 兩個 status 共用一次算好的 `analysisDone`；`analyzed: true` 的空結果直接還原 `"done"`，pipeline 不再 dispatch。
- **history.ts `snapshotAnalysis()`** — 在所有存檔路徑的共同 chokepoint 寫入 `analyzed: analysisStatus === "done" && actionItemsStatus === "done"`。upload 存檔（actions settle 後）自然為 true；live 存檔（會後 pass 還沒跑）為 false，等重播 pipeline 跑完由 `initHistoryPersistSync` 回寫 true（它本來就只在兩者皆 done 時 snapshot）。
- **唯讀 org 錄音（同一個 bug 的另一半）** — viewer 跑完得到空結果時 study cache 原本只存非空陣列，每次開都重跑。`StudyCacheEntry` 也加 `analyzed`（accretive merge：pipeline 中途的 false 不會蓋掉先前的 true、單獨的 false 不落地），`loadOrgEntry` fold 回 meta。

## 相容性

- **舊 entry**：缺欄位 → fallback 到現行 heuristic，行為 byte-for-byte 不變；0/0 的舊 entry 重跑一次後 persist 會自動補上欄位（self-healing）。
- **`analyzed: false`**（例如 actions 失敗但 findings 有東西）：走 fallback 而非強制 idle → 重開仍 `"done"`、重試維持手動，與改動前一致。唯一的行為變化就是「分析過且真的是空」這一種 case。
- **Rust 端**：`meta.json` 是 `serde_json::Value` / 原字串直寫，rename 等 read-modify-write 不會丟欄位。
- **Cloud sync**：push/pull 整包 meta JSON round-trip，org 分享 `{ ...meta, folderId: null }` 也保留；`buildSummary` 吃整個 entry、多的欄位自然忽略，summary 卡片不需要新欄位。

## 測試

- `store.actions.test.ts`：analyzed + 空 → done（bug 本體）；舊 entry 空 → idle、有內容 → done（fallback）；`analyzed:false` + findings → done（語意 pin 住）。
- 新增 `studyCache.test.ts`：merge 的 accretive 語意（node 環境用 Map stub localStorage）。
- `bun run test` 197 全綠、`tsc` 乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)