### PR TITLE
[feature] MCP create_company_from_folder：History 資料夾一鍵同步成 Accounts 公司卡

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -697,6 +697,29 @@ fn tools() -> Vec<Value> {
             }),
         ),
         tool(
+            "create_company_from_folder",
+            "Sync a history folder into an Accounts company",
+            "Create (or reuse a same-name) company card in the Accounts mini-CRM from a \
+             history folder: links the existing same-name folder, backfills the folder's \
+             recordings onto the company so they show in its meeting timeline, and — when \
+             `profileText` is given — attaches that text as a 'doc' source on the company. \
+             Idempotent: re-running with the same name reuses the company and only fills \
+             what's missing. Get folder ids/names from list_folders. This is the \
+             folder→客戶 sync; run once per customer folder.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Company name (usually the folder name)." },
+                    "folderId": { "type": "string", "description": "The history folder to link + backfill (from list_folders)." },
+                    "aliases": { "type": "array", "items": { "type": "string" }, "description": "Alternate spellings/nicknames for transcript matching." },
+                    "note": { "type": "string", "description": "One-line positioning for the company." },
+                    "profileText": { "type": "string", "description": "Customer-profile text to attach as a doc source (e.g. the _客戶輪廓.md contents)." },
+                    "profileName": { "type": "string", "description": "Attachment display name (default 客戶輪廓)." }
+                },
+                "required": ["name"]
+            }),
+        ),
+        tool(
             "list_orgs",
             "List organizations",
             "List the organizations the signed-in user belongs to, as { id, name, role }. \
@@ -938,6 +961,21 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
                 json!({
                     "id": required_str(&args, "id")?,
                     "folderId": args.get("folderId").cloned().unwrap_or(Value::Null)
+                }),
+            )
+            .await?
+        }
+        "create_company_from_folder" => {
+            call_frontend(
+                state,
+                "create_company_from_folder",
+                json!({
+                    "name": required_str(&args, "name")?,
+                    "folderId": args.get("folderId").cloned().unwrap_or(Value::Null),
+                    "aliases": args.get("aliases").cloned().unwrap_or(Value::Null),
+                    "note": args.get("note").cloned().unwrap_or(Value::Null),
+                    "profileText": args.get("profileText").cloned().unwrap_or(Value::Null),
+                    "profileName": args.get("profileName").cloned().unwrap_or(Value::Null)
                 }),
             )
             .await?

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -549,6 +549,27 @@ export async function setEntryFolder(id: string, folderId: string | null): Promi
   pushToCloud(id); // sync the new folderId (best-effort; gated by the sync toggle)
 }
 
+/**
+ * Link an entry to an Accounts company (or clear with null) by patching its
+ * `companyId` in meta + summary. The company page's meeting timeline filters by
+ * `companyId` (not folder), so this is what makes an imported recording show up
+ * under its company — used by the folder→company sync (create_company_from_folder).
+ * Leaves the recording + folder untouched.
+ */
+export async function setEntryCompany(id: string, companyId: string | null): Promise<void> {
+  if (!isTauri()) return;
+  const { meta } = await invoke<HistoryReadResult>("read_history_entry", { id });
+  const updated: HistoryEntry = { ...meta, companyId };
+  await invoke("save_history_entry", {
+    id,
+    summaryJson: JSON.stringify(buildSummary(updated)),
+    metaJson: JSON.stringify(updated),
+    audioSourcePath: null, // leave the recording untouched
+    compress: false,
+  });
+  pushToCloud(id); // sync the new companyId (best-effort; gated by the sync toggle)
+}
+
 /** Delete one entry's folder. */
 export async function deleteHistoryEntry(id: string): Promise<void> {
   if (!isTauri()) return;

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -262,6 +262,70 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       }
       return { imported, failed, folderId, folder: folderName || null };
     }
+    case "create_company_from_folder": {
+      // Folder → Accounts sync: turn an imported history folder into a mini-CRM
+      // company card, link the existing same-name folder, backfill companyId onto
+      // that folder's recordings (the company page's meeting timeline filters by
+      // companyId, not folder), and attach the profile text as a "doc" source.
+      // Idempotent: an existing same-name active company is reused, not duplicated.
+      const name = argStr(a.name).trim();
+      if (!name) throw new Error("name is required");
+      const aliases = Array.isArray(a.aliases) ? a.aliases.map(argStr).filter(Boolean) : [];
+      const note = a.note ? argStr(a.note) : "";
+      const folderId = a.folderId ? argStr(a.folderId) : null;
+      const profileText = a.profileText ? argStr(a.profileText) : "";
+      const profileName = a.profileName ? argStr(a.profileName) : "客戶輪廓";
+
+      const { useAccounts } = await import("./accounts/store");
+      const acc = useAccounts.getState();
+      const existing = acc.companies.find((c) => !c.archived && c.name === name);
+      const reused = !!existing;
+      let company = existing;
+      if (company) {
+        // Reuse: refresh aliases/note without clobbering a manual edit with empties.
+        const patch: Record<string, unknown> = {};
+        if (aliases.length) patch.aliases = aliases;
+        if (note) patch.note = note;
+        if (folderId) patch.folderId = folderId;
+        if (Object.keys(patch).length) acc.updateCompany(company.id, patch);
+      } else {
+        company = acc.addCompany({ name, note, aliases });
+        if (folderId) acc.updateCompany(company.id, { folderId });
+      }
+      const companyId = company.id;
+
+      // Backfill companyId onto the folder's recordings so they surface in the
+      // company's meeting timeline.
+      let meetingsLinked = 0;
+      if (folderId) {
+        const { listHistory, setEntryCompany } = await import("./history/history");
+        const summaries = await listHistory();
+        for (const s of summaries) {
+          if (s.folderId === folderId && s.companyId !== companyId) {
+            await setEntryCompany(s.id, companyId);
+            meetingsLinked++;
+          }
+        }
+      }
+
+      // Attach the profile as a doc source (skip if one with this name exists).
+      let attached = false;
+      if (profileText.trim()) {
+        const dup = useAccounts
+          .getState()
+          .attachments.some((at) => at.companyId === companyId && at.name === profileName);
+        if (!dup) {
+          useAccounts.getState().addAttachment({
+            companyId,
+            name: profileName,
+            kind: "doc",
+            text: profileText,
+          });
+          attached = true;
+        }
+      }
+      return { companyId, name, folderId, meetingsLinked, attached, reused };
+    }
     case "copy_org_recording_to_personal": {
       const id = argStr(a.id);
       const { saveOrgRecordingToPersonal } = await import("./cloud/sync");


### PR DESCRIPTION
## 摘要

補上 mini-CRM 缺的「**資料夾 → 客戶**」橋樑。逐字稿匯入（PR #167）只填了 **History**（`folders.json` 的資料夾 + 錄音），**Accounts**（`accounts.json` 的公司卡）是另一套獨立資料、不會自動生成——所以「客戶」分頁一直是空的，兩邊也不同步。

新 MCP 工具 **`create_company_from_folder`**（`call_frontend` → sessionCommands RPC）對一個 History 資料夾做四件事：

1. **建公司卡**（`addCompany`）——同名 active 公司則沿用、不重複建（idempotent，可安全重跑）
2. **綁既有同名資料夾**（`folderId`；`ensureCompanyFolder` 本來就 adopt 同名夾，不會產生重複資料夾）
3. **回填 `companyId` 到該資料夾所有錄音**——關鍵：`CompanyPage` 的會議時間軸用 `companyId` 過濾（不是 folder），匯入的錄音原本只有 `folderId`、沒 `companyId`，不回填就不會出現在公司頁
4. 把 `profileText`（`_客戶輪廓.md` 內容）掛成 **"doc" attachment**（同名已存在則跳過）

## 設計取捨

- `history.ts` 新增 `setEntryCompany`（read-modify-write meta+summary 的 `companyId`，鏡像既有的 `setEntryFolder`）。
- **不自動抽 claim 情報卡**：design doc（#130）**D8「絕不自動寫入、一律 diff 逐項審核」**——輪廓以 attachment 進場，使用者可再走既有「餵資料」流程抽卡審核。

## 驗證

- `tsc --noEmit` 乾淨、vitest **220 綠**、`cargo clippy --all-targets` 乾淨
- 瀏覽器 mock 實測：公司建立（0→1）、folderId 綁定、aliases、輪廓 attachment 皆正常；meeting 回填走 Tauri（鏡像已驗證的 `setEntryFolder`）

## 用法（發版後）

MCP 對每個客戶資料夾跑一次：`create_company_from_folder { name, folderId, aliases?, note?, profileText }`。之後「客戶」分頁就會出現公司卡，每家點進去有會議時間軸 + 輪廓文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)