### PR TITLE
[feature] MCP apply_company_intel：把結構化戰情（人物+情報卡）灌進 mini-CRM

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -720,6 +720,66 @@ fn tools() -> Vec<Value> {
             }),
         ),
         tool(
+            "apply_company_intel",
+            "Populate a company's people + intel cards",
+            "Write structured intel into an Accounts company's war room: Person cards \
+             and Claim cards (the nine categories: stance / relation / leverage / goal / \
+             risk / redline / competitor / nextmove / openq). Reuses the app's own \
+             apply pipeline — claim `subjects` are person NAMES resolved to ids, a \
+             stance claim auto-updates the person's stance chip, and everything lands \
+             as 'inferred' (imported analysis is never auto-confirmed). Identify the \
+             company by companyName (or companyId). Optionally create a thread (戰線) \
+             so its pipeline stage shows. Feed this the structured cards distilled from \
+             a customer profile so the company page shows the real people roster + \
+             battle intel, not just a doc attachment.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "companyName": { "type": "string", "description": "Company name (as shown in Accounts)." },
+                    "companyId": { "type": "string", "description": "Company id (alternative to companyName)." },
+                    "newPersons": {
+                        "type": "array",
+                        "description": "People at this company.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": { "type": "string" },
+                                "title": { "type": "string", "description": "Title / department." },
+                                "committeeRole": { "type": "string", "enum": ["economic", "champion", "influencer", "user", "gatekeeper", "blocker", ""], "description": "MEDDICC buying-committee role, or empty." },
+                                "reason": { "type": "string", "description": "One line: why this person matters." }
+                            },
+                            "required": ["name"]
+                        }
+                    },
+                    "newClaims": {
+                        "type": "array",
+                        "description": "Intel claims — one assertion each.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "category": { "type": "string", "enum": ["stance", "relation", "leverage", "goal", "risk", "redline", "competitor", "nextmove", "openq"] },
+                                "text": { "type": "string", "description": "One sentence, one assertion (zh-TW)." },
+                                "subjects": { "type": "array", "items": { "type": "string" }, "description": "Person/company NAMES this is about." },
+                                "side": { "type": "string", "enum": ["ours", "theirs", ""], "description": "For leverage/goal." },
+                                "layer": { "type": "string", "enum": ["surface", "deep", ""], "description": "For goal claims." },
+                                "quote": { "type": "string", "description": "Supporting verbatim quote, if any." }
+                            },
+                            "required": ["category", "text"]
+                        }
+                    },
+                    "thread": {
+                        "type": "object",
+                        "description": "Optional 戰線 to create (shows the pipeline stage).",
+                        "properties": {
+                            "kind": { "type": "string", "enum": ["sales", "channel", "investment", "other"] },
+                            "name": { "type": "string" },
+                            "stage": { "type": "string", "description": "For sales: prospecting|discovery|demo|negotiation|closing." }
+                        }
+                    }
+                }
+            }),
+        ),
+        tool(
             "list_orgs",
             "List organizations",
             "List the organizations the signed-in user belongs to, as { id, name, role }. \
@@ -976,6 +1036,20 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
                     "note": args.get("note").cloned().unwrap_or(Value::Null),
                     "profileText": args.get("profileText").cloned().unwrap_or(Value::Null),
                     "profileName": args.get("profileName").cloned().unwrap_or(Value::Null)
+                }),
+            )
+            .await?
+        }
+        "apply_company_intel" => {
+            call_frontend(
+                state,
+                "apply_company_intel",
+                json!({
+                    "companyName": args.get("companyName").cloned().unwrap_or(Value::Null),
+                    "companyId": args.get("companyId").cloned().unwrap_or(Value::Null),
+                    "newPersons": args.get("newPersons").cloned().unwrap_or(Value::Null),
+                    "newClaims": args.get("newClaims").cloned().unwrap_or(Value::Null),
+                    "thread": args.get("thread").cloned().unwrap_or(Value::Null)
                 }),
             )
             .await?

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -3,6 +3,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useStore } from "./store";
 import { isTauri } from "./tauriEvents";
 import type { EvalDef, TimelineEvent } from "./types";
+import type { ClaimCategory } from "./accounts/types";
 
 /**
  * Apply mutation commands the MCP server enqueues (add/check/remove todo,
@@ -325,6 +326,100 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
         }
       }
       return { companyId, name, folderId, meetingsLinked, attached, reused };
+    }
+    case "apply_company_intel": {
+      // Populate a company's structured intel (design §4/§5): create Person cards
+      // + Claim cards (stance/leverage/risk/nextmove/…) from pre-structured ops.
+      // Reuses the app's own applyExtractedOps so subject-name→id resolution,
+      // stance-cache sync and conflict handling all match the reviewed flow —
+      // we just supply the ops instead of the LLM. Claims land as "inferred"
+      // (design §5.1: imported analysis is never auto-confirmed). Idempotent-ish:
+      // pass replace=true to archive the company's prior inferred claims/persons
+      // first so re-runs don't pile up duplicates.
+      const CLAIM_CATEGORIES = [
+        "stance", "relation", "leverage", "goal", "risk",
+        "redline", "competitor", "nextmove", "openq",
+      ];
+      const COMMITTEE = ["economic", "champion", "influencer", "user", "gatekeeper", "blocker"];
+      const name = argStr(a.companyName).trim();
+      const companyIdArg = a.companyId ? argStr(a.companyId) : "";
+      const { useAccounts } = await import("./accounts/store");
+      const acc = useAccounts.getState();
+      const company = companyIdArg
+        ? acc.companies.find((c) => c.id === companyIdArg)
+        : acc.companies.find((c) => !c.archived && c.name === name);
+      if (!company) throw new Error(`company not found: ${name || companyIdArg}`);
+      const companyId = company.id;
+
+      // Optional thread (戰線) so the pipeline stage shows on the company page.
+      let threadId: string | undefined;
+      const th = a.thread as { kind?: string; name?: string; stage?: string } | undefined;
+      if (th && th.name) {
+        const kind = (["sales", "channel", "investment", "other"] as const).includes(
+          th.kind as never,
+        )
+          ? (th.kind as "sales" | "channel" | "investment" | "other")
+          : "sales";
+        const thread = useAccounts
+          .getState()
+          .addThread({ companyId, kind, name: String(th.name), stage: th.stage });
+        threadId = thread.id;
+      }
+
+      const rawPersons = Array.isArray(a.newPersons) ? a.newPersons : [];
+      const newPersons = rawPersons
+        .map((p) => p as Record<string, unknown>)
+        .filter((p) => typeof p.name === "string" && (p.name as string).trim())
+        .map((p) => ({
+          name: argStr(p.name),
+          title: p.title ? argStr(p.title) : "",
+          committeeRole: COMMITTEE.includes(argStr(p.committeeRole)) ? argStr(p.committeeRole) : "",
+          reason: p.reason ? argStr(p.reason) : "",
+        }));
+
+      const rawClaims = Array.isArray(a.newClaims) ? a.newClaims : [];
+      const newClaims = rawClaims
+        .map((c) => c as Record<string, unknown>)
+        .filter((c) => CLAIM_CATEGORIES.includes(argStr(c.category)) && argStr(c.text).trim())
+        .map((c) => {
+          const side: "ours" | "theirs" | "" =
+            c.side === "ours" ? "ours" : c.side === "theirs" ? "theirs" : "";
+          const layer: "surface" | "deep" | "" =
+            c.layer === "surface" ? "surface" : c.layer === "deep" ? "deep" : "";
+          return {
+            category: argStr(c.category) as ClaimCategory,
+            text: argStr(c.text),
+            subjects: Array.isArray(c.subjects) ? c.subjects.map(argStr).filter(Boolean) : [],
+            side,
+            layer,
+            quote: c.quote ? argStr(c.quote) : "",
+            slotIds: Array.isArray(c.slotIds) ? c.slotIds.map(argStr).filter(Boolean) : [],
+          };
+        });
+
+      // Provenance: tie claims to the company's profile doc when one exists.
+      const att = useAccounts
+        .getState()
+        .attachments.find((x) => x.companyId === companyId && x.kind === "doc");
+      const provenance: { kind: "import"; attachmentId: string } | { kind: "user" } = att
+        ? { kind: "import", attachmentId: att.id }
+        : { kind: "user" };
+
+      useAccounts.getState().applyExtractedOps({
+        companyId,
+        threadId,
+        ops: { newPersons, newClaims, claimUpdates: [] },
+        provenance,
+      });
+      const s = useAccounts.getState();
+      return {
+        companyId,
+        personsCreated: newPersons.length,
+        claimsCreated: newClaims.length,
+        threadId: threadId ?? null,
+        totalPersons: s.persons.filter((p) => p.companyId === companyId && !p.archived).length,
+        totalClaims: s.claims.filter((c) => c.companyId === companyId && c.status === "active").length,
+      };
     }
     case "copy_org_recording_to_personal": {
       const id = argStr(a.id);


### PR DESCRIPTION
## 摘要

`create_company_from_folder`（#168）只建了公司 + 綁資料夾 + 掛輪廓「文件」，公司頁仍是空殼——**沒有人物盤點、沒有立場/籌碼/風險/下一步情報卡**，戰情簡報只能吃那份純文字附件。這個工具補上真正的 mini-CRM 內容。

新 MCP 工具 **`apply_company_intel`**（`call_frontend` → sessionCommands RPC）接結構化 ops：
- `newPersons[]`（name / title / committeeRole）→ **人物卡**
- `newClaims[]`（九類：stance / relation / leverage / goal / risk / redline / competitor / nextmove / openq；`subjects` 用「名字」）→ **情報卡**
- 可選 `thread`（戰線 + pipeline stage）

直接呼叫 app 既有的 **`applyExtractedOps`**，沿用其 subject 名字→id 解析、stance→人物 stance chip 同步、衝突處理；claim 一律 **inferred**（design §5.1：匯入分析不自動 confirmed）。等於用「我供 ops」取代「LLM 抽」——把已寫好的客戶輪廓**忠實**轉成卡片,不再二次抽取失真。

- provenance 綁公司的輪廓 doc attachment，卡片可追溯回來源
- category / committeeRole / side / layer 全部驗證，非法值濾除

## 驗證
- `tsc` 乾淨、vitest **220 綠**、clippy 乾淨
- 瀏覽器 mock 實測：人物建立（含 committeeRole）、claim 分類、stance 的 subject 名字→id 解析正確

## 用法（發版後）
把每份 `_客戶輪廓.md` 拆成 `newPersons` + `newClaims`，對每家呼叫 `apply_company_intel`。公司頁即顯示人物盤點 + 戰情卡，戰情簡報改以這些卡為基礎。

🤖 Generated with [Claude Code](https://claude.com/claude-code)