### PR TITLE
[fix] Dock 點擊喚不回視窗、睡醒後 Voice Typing 失效：Reopen handler + 關窗改隱藏 + wake 重註冊熱鍵

### DIFF
--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -186,6 +186,46 @@ pub fn init(app: AppHandle) {
     imp::ensure_started(app, false);
 }
 
+/// Watch for sleep/wake and session re-activation (NSWorkspace notifications)
+/// and re-assert the push-to-talk trigger each time. Both delivery paths can
+/// silently die across a sleep cycle: a Carbon hotkey registration can come
+/// back inert, and a CGEventTap can be left disabled without ever receiving
+/// the "disabled by timeout" callback its self-heal relies on (that callback
+/// only fires when an event actually reaches the dead tap). Re-registering is
+/// cheap and idempotent, so we just redo it on every wake.
+pub fn install_wake_observer(app: AppHandle) {
+    imp::install_wake_observer(app);
+}
+
+/// Re-apply the currently selected trigger (see [`install_wake_observer`]).
+fn reassert(app: &AppHandle) {
+    let id = CURRENT
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap_or_else(|| "alt-space".to_string());
+    log::info!("voice-typing: re-asserting trigger {id:?} after wake");
+    // Always revive the tap: in combo mode it's parked (matches nothing) but
+    // must stay alive for the next switch back to a modifier key.
+    imp::reenable_tap();
+    if MODIFIER_IDS.contains(&id.as_str()) {
+        // No-op when the tap thread is alive; recreates it if boot skipped it
+        // (permission granted after launch).
+        imp::ensure_started(app.clone(), false);
+    } else {
+        let gs = app.global_shortcut();
+        let _ = gs.unregister_all();
+        let ok = match parse_combo(&id) {
+            Some(sc) => gs
+                .register(sc)
+                .map_err(|e| log::warn!("voice-typing: wake re-register {id:?} failed: {e}"))
+                .is_ok(),
+            None => false,
+        };
+        COMBO_OK.store(ok, Ordering::SeqCst);
+    }
+}
+
 #[cfg(target_os = "macos")]
 mod imp {
     use std::ffi::c_void;
@@ -397,6 +437,53 @@ mod imp {
         event
     }
 
+    /// Re-enable the live tap if macOS disabled it (sleep/wake can leave a tap
+    /// off without the "disabled" callback ever firing). No-op without a tap.
+    pub fn reenable_tap() {
+        let port = TAP_PORT.load(Ordering::SeqCst);
+        if !port.is_null() {
+            unsafe { CGEventTapEnable(port as CFMachPortRef, true) };
+        }
+    }
+
+    /// Register NSWorkspace wake/session-activation observers that re-assert
+    /// the push-to-talk trigger. Installed once at setup, lives for the app's
+    /// lifetime (the notification center holds the block-based observers).
+    pub fn install_wake_observer(app: AppHandle) {
+        use block2::RcBlock;
+        use core_foundation::base::TCFType;
+        use core_foundation::string::CFString;
+        use objc::runtime::Object;
+        use objc::{class, msg_send, sel, sel_impl};
+
+        // Lid-open wake, and console session re-activation (fast user
+        // switching / some lock-screen returns) — either can strand the
+        // trigger. NSNotificationName is an NSString, so a matching CFString
+        // (toll-free bridged) subscribes to the same notification.
+        const NAMES: [&str; 2] = [
+            "NSWorkspaceDidWakeNotification",
+            "NSWorkspaceSessionDidBecomeActiveNotification",
+        ];
+        unsafe {
+            let ws: *mut Object = msg_send![class!(NSWorkspace), sharedWorkspace];
+            let nc: *mut Object = msg_send![ws, notificationCenter];
+            let queue: *mut Object = msg_send![class!(NSOperationQueue), mainQueue];
+            for name in NAMES {
+                let app = app.clone();
+                let block = RcBlock::<dyn Fn(*mut std::ffi::c_void)>::new(move |_note| {
+                    super::reassert(&app);
+                });
+                let cf = CFString::new(name);
+                let name_obj = cf.as_concrete_TypeRef() as *const Object;
+                let nil: *mut Object = std::ptr::null_mut();
+                let _observer: *mut Object = msg_send![nc, addObserverForName: name_obj object: nil queue: queue usingBlock: &*block];
+                // Never removed — the center keeps the observer + block alive;
+                // forget our handle so the block isn't dropped underneath it.
+                std::mem::forget(block);
+            }
+        }
+    }
+
     /// Start the tap thread if it isn't running; returns whether a live tap
     /// exists. `force` skips the permission pre-gate (explicit user action).
     pub fn ensure_started(app: AppHandle, force: bool) -> bool {
@@ -506,4 +593,6 @@ mod imp {
     pub fn ensure_started(_app: AppHandle, _force: bool) -> bool {
         false
     }
+    pub fn reenable_tap() {}
+    pub fn install_wake_observer(_app: AppHandle) {}
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,10 @@ pub fn run() {
             // Start the global fn-key push-to-talk listener (no-op until the
             // user grants Input Monitoring).
             hotkey::init(app.handle().clone());
+            // Re-assert the push-to-talk trigger after sleep/wake and session
+            // unlock — Carbon hotkey registrations and CGEventTaps can come
+            // back dead from a sleep cycle.
+            hotkey::install_wake_observer(app.handle().clone());
             log::info!("app: starting up (parley {})", env!("CARGO_PKG_VERSION"));
             Ok(())
         })
@@ -166,6 +170,49 @@ pub fn run() {
             mcp::get_mcp_server_info,
             mcp::get_mcp_activity
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(
+            #[allow(unused_variables)]
+            |app, event| {
+                // macOS: a Dock-icon click (or launching the app again while
+                // it's already running) arrives as `Reopen`. tao's app delegate
+                // suppresses AppKit's default un-minimize response, so without
+                // this handler the click does nothing once the main window is
+                // hidden or minimized — the "app sits in the Dock but won't
+                // open" bug.
+                #[cfg(target_os = "macos")]
+                if let tauri::RunEvent::Reopen { .. } = event {
+                    show_main_window(app);
+                }
+            },
+        );
+}
+
+/// Bring the main window back for a Dock-icon click: un-minimize + show +
+/// focus. Recreated from the window config if it was destroyed — possible via
+/// paths that bypass the frontend's hide-on-close (e.g. a crashed webview).
+#[cfg(target_os = "macos")]
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.unminimize();
+        let _ = win.show();
+        let _ = win.set_focus();
+        return;
+    }
+    let Some(config) = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|w| w.label == "main")
+        .cloned()
+    else {
+        log::error!("window: no main window config to recreate from");
+        return;
+    };
+    match tauri::WebviewWindowBuilder::from_config(app, &config).and_then(|b| b.build()) {
+        Ok(_) => log::info!("window: recreated main window on reopen"),
+        Err(e) => log::error!("window: failed to recreate main window: {e}"),
+    }
 }

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -355,7 +355,6 @@ mod imp {
     use objc::runtime::{Class, Object};
     use objc::{class, msg_send, sel, sel_impl};
     use std::ffi::c_void;
-    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[link(name = "AppKit", kind = "framework")]
     extern "C" {}
@@ -449,16 +448,17 @@ mod imp {
     /// Parley or stealing focus.
     const NONACTIVATING_PANEL: usize = 1 << 7;
 
-    /// One-shot: has the overlay window been turned into an NSPanel yet?
-    static OVERLAY_IS_PANEL: AtomicBool = AtomicBool::new(false);
-
     pub fn present_overlay(ns_window: *mut std::ffi::c_void) {
         unsafe {
             let w = ns_window as *mut Object;
             // A plain NSWindow gets isolated to its own Space and can't float over
             // another app's full-screen Space. Turning it into a non-activating
             // NSPanel (+ fullScreenAuxiliary) is the native pattern for overlays.
-            if !OVERLAY_IS_PANEL.swap(true, Ordering::SeqCst) {
+            // Keyed off the window's own class — a process-wide one-shot flag
+            // would skip the conversion forever if the overlay window is ever
+            // destroyed and recreated.
+            let is_panel: bool = msg_send![w, isKindOfClass: class!(NSPanel)];
+            if !is_panel {
                 object_setClass(w, class!(NSPanel) as *const Class);
                 let style: usize = msg_send![w, styleMask];
                 let _: () = msg_send![w, setStyleMask: style | NONACTIVATING_PANEL];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,6 +207,13 @@ const App = () => {
   // other stop_meeting caller is the toolbar toggle, so without this a reload/close
   // leaves the backend recording. Best-effort: the IPC is dispatched even as the
   // webview tears down; stop_meeting is idempotent.
+  //
+  // On macOS the close button HIDES the window instead of destroying it (the
+  // platform convention — the app stays in the Dock and a Dock-icon click
+  // brings the window back via Rust's RunEvent::Reopen handler). Destroying it
+  // would also kill the voice-typing host that lives in this window, leaving
+  // the global push-to-talk key dead until the app is relaunched. An active
+  // meeting is still stopped first: a hidden window must never keep recording.
   useEffect(() => {
     if (!isTauri()) return;
     let active = true;
@@ -218,7 +225,15 @@ const App = () => {
     };
     window.addEventListener("beforeunload", stopIfRecording);
     getCurrentWindow()
-      .onCloseRequested(stopIfRecording)
+      .onCloseRequested((event) => {
+        stopIfRecording();
+        if (navigator.userAgent.includes("Mac")) {
+          event.preventDefault();
+          getCurrentWindow()
+            .hide()
+            .catch((error) => log.warn("window: hide on close failed", { error: String(error) }));
+        }
+      })
       .then((fn) => {
         if (active) {
           unlisten = fn;


### PR DESCRIPTION
## 問題

使用者回報兩個長期困擾的 macOS 行為：

1. **Dock 上還在，點了卻打不開** — 把主視窗按 X（或最小化）之後，Parley 圖示還留在 Dock，但再點它不會把視窗叫回來，只能完全結束 app 再從應用程式資料夾開。
2. **合蓋睡醒 / 放久了 Voice Typing 按不出來** — push-to-talk 熱鍵沒反應，同樣要重啟 app 才恢復。

## 根因

**視窗問題**：主視窗按 X 是直接 `destroy`（`onCloseRequested` 沒有 `preventDefault`），但 prewarm 的 `voice-typing` overlay 視窗讓 process 繼續活著 → Dock 圖示還在、app 沒退出。而整個 app **完全沒有處理 `RunEvent::Reopen`**（Dock 點擊 / 重複啟動）—— tao 的 app delegate 會壓掉 AppKit 預設的還原行為，所以連「點 Dock 還原最小化視窗」都不會發生。

**Voice Typing 問題**是兩個洞疊加：

- PTT 的 handler（`initVoiceTyping`）跑在**主視窗**裡。只要曾按過 X，視窗被 destroy，voice typing 就整個死掉 —— 這是「用著用著就按不出來」最常見的觸發路徑，跟睡眠無關。
- **完全沒有 sleep/wake 處理**。Carbon global shortcut（Option+Space / 自訂 combo）睡醒後可能悶掉，沒有任何重新註冊機制；CGEventTap（`fn` / right-⌘ 等 modifier 觸發）雖有 `TAP_DISABLED_BY_TIMEOUT` 自癒，但那個 callback 要有事件**送達已死的 tap** 才會觸發，睡醒後 tap 被關掉卻可能永遠等不到。

```mermaid
flowchart TD
    A[按 X 關閉主視窗] --> B[視窗 destroy]
    B --> C[voice-typing host 隨視窗死亡]
    B --> D[overlay 視窗仍在 → process 不退出]
    D --> E[Dock 圖示還在]
    E --> F[點 Dock 無 Reopen handler → 沒反應]
    C --> G[PTT 熱鍵失效]
    H[合蓋睡眠] --> I[Carbon 註冊悶掉 / CGEventTap 被停用]
    I --> G
```

## 修法

**`src-tauri/src/lib.rs`** — `.run(context)` 改成 `.build(context)?.run(|app, event| …)`，加上 `RunEvent::Reopen` handler：un-minimize + show + focus 主視窗；視窗若真的已被 destroy（webview crash 等繞過前端 hide 的路徑），從 `tauri.conf.json` 的 window config 用 `WebviewWindowBuilder::from_config` 重建。

**`src/App.tsx`** — macOS 下主視窗關閉改為 **hide 而非 destroy**（平台慣例）：`event.preventDefault()` + `window.hide()`。app 留在 Dock、視窗狀態保留、voice-typing host 不再跟著死。會議進行中按 X 仍然先 `stop_meeting`（隱藏的視窗絕不能繼續錄音）。⌘Q 完全退出的行為不受影響。

**`src-tauri/src/hotkey.rs`** — 新增 `install_wake_observer`：註冊 `NSWorkspaceDidWakeNotification` + `NSWorkspaceSessionDidBecomeActiveNotification`（快速切換使用者 / 部分解鎖情境）observer，每次醒來重新註冊目前選定的 shortcut 並 `CGEventTapEnable` re-enable tap。重註冊冪等又便宜，所以不做狀態判斷、每次都做。

**`src-tauri/src/voice_typing.rs`**（順手修掉的潛在 bug）— overlay 的 NSPanel 轉換原本用 process-wide 的 `OVERLAY_IS_PANEL` one-shot flag，overlay 視窗若曾被重建，新視窗會**永遠轉不成 panel**（浮不到全螢幕 app 之上）。改成用視窗自身的 `isKindOfClass: NSPanel` 判斷。

## 已知範圍外（刻意不做）

⌘Tab 切回 Parley 不會觸發 `Reopen`，視窗隱藏時仍需點一次 Dock。技術上可用 `applicationDidBecomeActive` 補，但該事件太容易誤觸發（點 Settings 視窗也算 activate），會造成主視窗亂跳，不划算。

## 測試

- `cargo check`、`npx tsc --noEmit` 皆過；`npx vitest run` 232 tests 全綠。
- Dock 點擊 / 睡醒這類原生行為無法在單元測試涵蓋，需實機驗證：
  1. 按 X → 點 Dock，視窗回來
  2. 最小化 → 點 Dock，視窗回來
  3. 合蓋數分鐘 → 醒來直接按 PTT 鍵能啟動
  4. 關窗後直接按 PTT 鍵（本次修正後應可用）
  5. ⌘Q 仍完全退出、錄音中按 X 仍會停止錄音

## Schema 影響

無 migration、無 schema change。
