### PR TITLE
[fix] 情報板抽取:mix 來源會議把使用者自己的話全算成「對方」

### DIFF
--- a/src/lib/intel/extract.test.ts
+++ b/src/lib/intel/extract.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Boundaries only: resolveBoard reads the live stage file, and the logger's
+// non-Tauri path touches `window`. The helpers under test are pure.
+vi.mock("../accounts/currentStage", () => ({ resolveScenarioStageId: vi.fn() }));
+vi.mock("../log", () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  attachConsoleOnce: vi.fn(),
+}));
+
+import { transcriptText, intelTranscriptReady } from "./extract";
+import { seg } from "../test/fixtures";
+
+const CAP = 8_000;
+
+describe("transcriptText (speaker labels handed to the intel-board prompt)", () => {
+  it('labels a "mix" meeting by diarized speaker, never collapsing ME into 對方', () => {
+    // Single diarizing session (mic + system audio in one stream): EVERY
+    // speaker — the user included — arrives as source "mix". This is the only
+    // topology an iOS client can produce, so it must not attribute the user's
+    // own words to the counterpart.
+    const segs = [
+      seg({ id: "a", source: "mix", speaker: 1, text: "我們預算大概三十萬", startMs: 0 }),
+      seg({ id: "b", source: "mix", speaker: 2, text: "那導入要多久", startMs: 1000 }),
+    ];
+    expect(transcriptText(segs, undefined, CAP)).toBe(
+      "[Speaker 1] 我們預算大概三十萬\n[Speaker 2] 那導入要多久"
+    );
+  });
+
+  it("applies user-assigned names to mix speakers", () => {
+    const segs = [
+      seg({ id: "a", source: "mix", speaker: 1, text: "hi", startMs: 0 }),
+      seg({ id: "b", source: "mix", speaker: 2, text: "hello", startMs: 1000 }),
+    ];
+    expect(transcriptText(segs, { "mix-1": "Jack", "mix-2": "Alice" }, CAP)).toBe(
+      "[Jack] hi\n[Alice] hello"
+    );
+  });
+
+  it("keeps the deterministic me/them labels on split-source meetings", () => {
+    const segs = [
+      seg({ id: "a", source: "me", speaker: 1, text: "first", startMs: 0 }),
+      seg({ id: "b", source: "them", speaker: 1, text: "second", startMs: 1000 }),
+    ];
+    expect(transcriptText(segs, undefined, CAP)).toBe("[You] first\n[Remote 1] second");
+  });
+
+  it("drops interim and blank segments and keeps the tail when over the cap", () => {
+    const segs = [
+      seg({ id: "a", source: "mix", speaker: 1, text: "x".repeat(50), startMs: 0 }),
+      seg({ id: "p", source: "mix", speaker: 2, text: "partial", startMs: 1000, isFinal: false }),
+      seg({ id: "e", source: "mix", speaker: 2, text: "   ", startMs: 2000 }),
+      seg({ id: "z", source: "mix", speaker: 2, text: "tail", startMs: 3000 }),
+    ];
+    const out = transcriptText(segs, undefined, 20);
+    expect(out).toHaveLength(20);
+    expect(out.endsWith("[Speaker 2] tail")).toBe(true);
+    expect(out).not.toContain("partial");
+  });
+});
+
+describe("intelTranscriptReady", () => {
+  it("is false below the minimum and true once enough final speech exists", () => {
+    expect(intelTranscriptReady([seg({ source: "mix", text: "短", startMs: 0 })])).toBe(false);
+    expect(
+      intelTranscriptReady([seg({ source: "mix", text: "x".repeat(40), startMs: 0 })])
+    ).toBe(true);
+  });
+
+  it("ignores interim segments and anything outside the replay keep-window", () => {
+    const segs = [
+      seg({ id: "i", source: "mix", text: "y".repeat(60), startMs: 0, endMs: 500, isFinal: false }),
+      seg({ id: "t", source: "mix", text: "z".repeat(60), startMs: 1000, endMs: 2000 }),
+    ];
+    expect(intelTranscriptReady(segs, { startMs: 5000, endMs: 9000 })).toBe(false);
+    expect(intelTranscriptReady(segs, { startMs: 0, endMs: 9000 })).toBe(true);
+  });
+});

--- a/src/lib/intel/extract.ts
+++ b/src/lib/intel/extract.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { useStore, isTrimmed, type ReplayTrim } from "../store";
+import { useStore, isTrimmed, transcriptAsText, type ReplayTrim } from "../store";
 import { hasProviderKey } from "../ai/settings";
-import { outputLanguageInstruction } from "../ai/profile";
+import { outputLanguageInstruction, profileContext } from "../ai/profile";
 import { generateObjectResilient } from "../ai/generate";
 import { resolveBoard, type MeetingBoard } from "./boards";
 import { makeRunGuard } from "../analysis/runGuard";
@@ -32,7 +32,9 @@ const slotFillsSchema = z
       slotId: z.string().describe("id from the provided slot list"),
       text: z.string().describe("the captured intel, ONE sentence, transcript language"),
       quote: z.string().describe("short verbatim quote backing it, else empty"),
-      speaker: z.enum(["me", "them"]).describe("who said it"),
+      speaker: z
+        .enum(["me", "them"])
+        .describe('which side said it: "me" (ME/US) or "them" (the other party)'),
     })
   )
   .describe(
@@ -105,12 +107,22 @@ const boardSchema = z.object({
   todoChecks: todoChecksSchema,
 });
 
-function transcriptText(segments: TranscriptSegment[], capChars: number): string {
-  const lines = segments
-    .filter((s) => s.isFinal && s.text.trim())
-    .map((s) => `${s.source === "me" ? "我" : "對方"}: ${s.text}`);
+/**
+ * Prompt transcript, labelled by REAL speaker (custom names when set) — the same
+ * helper every other prompt builder uses. A binary me/them collapse would LIE on
+ * "mix" segments: a single diarizing STT session carries mic + system audio in
+ * one stream (commands.rs `start_meeting`), so the user's own lines arrive as
+ * source "mix" too and would all be attributed to the counterpart. Which
+ * labelled speaker is ME is pinned down by profileContext in the prompt.
+ * Exported for tests.
+ */
+export function transcriptText(
+  segments: TranscriptSegment[],
+  names: Record<string, string> | undefined,
+  capChars: number
+): string {
+  const joined = transcriptAsText(segments, names);
   // Cap the prompt; the tail of the meeting matters most for current state.
-  const joined = lines.join("\n");
   return joined.length > capChars ? joined.slice(-capChars) : joined;
 }
 
@@ -146,19 +158,22 @@ export function intelTranscriptReady(
 // into the transcript's language via their own descriptions — a line the user
 // will say out loud must be in the meeting's language.
 const SYSTEM =
-  "You are a realtime meeting-intelligence extractor for the user (speaker 我). " +
+  "You are a realtime meeting-intelligence extractor for ME — one of the speakers in the transcript. " +
   "Read the transcript and return ONLY facts grounded in what was actually said — no speculation. " +
   "Empty arrays/strings are correct when nothing qualifies.";
 
 function buildPrompt(opts: {
   board: MeetingBoard;
+  /** profileContext preamble — which labelled speaker is ME (see ai/profile). */
+  profile: string;
   transcript: string;
   openTodos: TodoItem[];
 }): string {
-  const { board, transcript, openTodos } = opts;
+  const { board, profile, transcript, openTodos } = opts;
   const slotLines = board.slots.map((s) => `- ${s.id}: ${s.label} — ${s.hint}`).join("\n");
   const todoLines = openTodos.map((t) => `- [${t.id}] ${t.text}`).join("\n");
   return (
+    profile +
     `${board.guidance}\n\n` +
     `Fill slotFills: map intel that was actually said onto these board slots (ONLY these ids; ` +
     `a slot can receive several items). The slots are listed in their intended question ORDER:\n` +
@@ -172,7 +187,7 @@ function buildPrompt(opts: {
     (todoLines
       ? `Checklist to auto-check (return covered ids in todoChecks):\n${todoLines}\n\n`
       : "") +
-    transcript
+    `Transcript so far (each line is "[speaker] what they said"):\n${transcript}`
   );
 }
 
@@ -194,7 +209,9 @@ function extractableTranscript(workload: LlmWorkload): string | null {
   // REPLAY honors the trim keep-window, same as every other study pass.
   const trim = state.appMode === "replay" ? state.replayTrim : null;
   const segments = trim ? state.segments.filter((s) => !isTrimmed(s, trim)) : state.segments;
-  return intelTranscriptReady(segments) ? transcriptText(segments, CAP_CHARS[workload]) : null;
+  return intelTranscriptReady(segments)
+    ? transcriptText(segments, state.speakerNames, CAP_CHARS[workload])
+    : null;
 }
 
 /** The scenario no longer exists (a deleted custom id on an old recording or
@@ -248,7 +265,12 @@ export async function runIntelExtraction(
       workload,
       schema: boardSchema,
       system: SYSTEM + outputLanguageInstruction(state.settings),
-      prompt: buildPrompt({ board, transcript, openTodos }),
+      prompt: buildPrompt({
+        board,
+        profile: profileContext(state.settings),
+        transcript,
+        openTodos,
+      }),
     });
 
     const known = new Set(board.slots.map((s) => s.id));


### PR DESCRIPTION
## 摘要

情報板抽取的 prompt 把**使用者自己說的話全部歸給對方**——只要會議是 `mix` 來源。

`src/lib/intel/extract.ts` 的 `transcriptText` 用二元塌縮組 transcript:

```ts
`${s.source === "me" ? "我" : "對方"}: ${s.text}`
```

`mix` 是單一 diarizing STT session 的來源:mic + system audio 混成一條流,說話人由 vendor 的 diarization 分辨(`src-tauri/src/commands.rs` `start_meeting` 的 `diarization` 分支)。**使用者自己的 segment 也是 `mix`**,於是整場會議每一句、包含使用者自己講的,都掛上「對方」。情報板據此把使用者的話當成對手的話去填 slot、抓異議、生成下一句該說什麼。

其餘所有 prompt builder(report / timeline / actionItems / todos / delivery / ask / findingSolution)都走 store 的 `transcriptAsText` / `transcriptWithTimestamps`,label 正確。**extract.ts 是唯一的例外**。

> iOS 只能錄麥克風,每一場行動端會議都會是 mix 來源,不修就是每場必中。

## 改了什麼

1. **`transcriptText` 改用 `transcriptAsText(segments, names)`** —— 與其他 builder 同一個 helper,輸出 `[Speaker 1]` / `[You]` / `[Remote 1]` / 自訂名。cap 取尾邏輯不變。
2. **傳入 `state.speakerNames`** —— 使用者在 SpeakerBar 打的名字現在會進到情報板 prompt(以前完全看不到,只有「我/對方」)。
3. **補上 `profileContext(settings)`** —— 這才是真正的修法。extract.ts 原本靠硬編碼的「我:」宣告身份;其他 prompt 都是靠 [`ai/profile.ts`](src/lib/ai/profile.ts) 的 preamble 讓模型從 name/role/company + 說話內容認出哪個 speaker 是 ME(該函式註解本就寫明 *"especially under diarization, where speakers arrive as bare numbers"*)。改成真實 label 後不補這段,mix 會議就沒有任何線索指向使用者。
4. SYSTEM 的 `(speaker 我)` → `ME — one of the speakers in the transcript`;`slotFills.speaker` 的 describe 講清楚是「哪一邊」;transcript 前加一行格式說明。

```mermaid
flowchart LR
  subgraph before["修正前"]
    M1["mix / speaker 1<br/>(使用者)"] --> L1["對方: …"]
    M2["mix / speaker 2<br/>(客戶)"] --> L2["對方: …"]
    L1 & L2 --> X["情報板<br/>❌ 使用者的話算成對手"]
  end
  subgraph after["修正後"]
    N1["mix / speaker 1"] --> R1["[Jack] …"]
    N2["mix / speaker 2"] --> R2["[Speaker 2] …"]
    P["profileContext<br/>name / role / company"] --> R3
    R1 & R2 --> R3["情報板<br/>✅ 依 profile 認出 ME"]
  end
```

## 其他 builder 稽核

`grep 'source === "me"'` 命中的另外 6 處都是 UI / 統計,與 prompt 無關且 me-only 語意本來就正確:`SpeakerBar`、`TranscriptPanel`、`speakerColors`、`DeliveryPanel`(填充詞計數)、`store.upsertSegment`(filler tally)、`analysis/delivery`。所有引用 `TranscriptSegment` 又組 prompt 的檔案都已確認走共用 helper。

## Schema / 檔案影響

無。純 prompt 組裝,不動 DB、不動 config 檔、不動既有錄音資料。舊錄音重跑抽取會直接吃到修正後的 label。

## 測試與驗證

新增 `src/lib/intel/extract.test.ts`(6 tests):

- mix 轉錄依 diarized speaker 標記,**不再把使用者塞進「對方」**
- mix speaker 套用使用者自訂名字
- me/them 分軌會議的 label 維持不變(無回歸)
- interim / 空白 segment 過濾 + 超過 cap 取尾
- `intelTranscriptReady` 的字數門檻與 replay trim window

`npx tsc --noEmit` 乾淨、**238 vitest 全過**(25 files)。
