### PR TITLE
iOS: finish App Store readiness flows

### DIFF
--- a/docs/design/ios-app-store-readiness.html
+++ b/docs/design/ios-app-store-readiness.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Parley iOS — App Store Readiness</title>
+  <style>
+    :root {
+      --ink: #11151e;
+      --ink-soft: #202735;
+      --paper: #f5f7fb;
+      --panel: #ffffff;
+      --line: #dbe1ec;
+      --muted: #667085;
+      --teal: #57dbd2;
+      --blue: #3baff0;
+      --indigo: #7889f4;
+      --red: #df5963;
+      --amber: #c77c21;
+      --green: #16836d;
+      --font-body: -apple-system, BlinkMacSystemFont, "PingFang TC", "Noto Sans TC", sans-serif;
+      --font-data: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; }
+    }
+    :root[data-theme="light"] { --paper: #f5f7fb; --panel: #ffffff; --line: #dbe1ec; --muted: #667085; --ink: #11151e; --ink-soft: #202735; }
+    :root[data-theme="dark"] { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--paper); color: var(--ink); font: 15px/1.55 var(--font-body); }
+    .shell { width: min(1100px, calc(100% - 40px)); margin: 0 auto; padding: 28px 0 72px; }
+    .mast { display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: start; padding: 26px 0 34px; border-bottom: 1px solid var(--line); }
+    .eyebrow, .kicker { color: var(--muted); font: 600 11px/1 var(--font-data); letter-spacing: .12em; text-transform: uppercase; }
+    h1, h2, h3, p { margin: 0; }
+    h1 { max-width: 720px; margin-top: 12px; font-size: clamp(32px, 6vw, 56px); line-height: 1.05; letter-spacing: -.055em; text-wrap: balance; }
+    .lede { max-width: 660px; margin-top: 16px; color: var(--muted); font-size: 17px; }
+    .signal { display: grid; place-items: center; width: 108px; aspect-ratio: 1; overflow: hidden; border-radius: 24px; background: #131821; position: relative; box-shadow: 0 16px 30px #10162233; }
+    .signal::before, .signal::after { position: absolute; content: ""; width: 130%; height: 130%; border: 1px solid #6be3dc2e; border-radius: 50%; }
+    .signal::before { transform: scale(.64); } .signal::after { transform: scale(.94); }
+    .signal img { position: relative; width: 70%; }
+    .summary { display: grid; grid-template-columns: 1.2fr .8fr; gap: 18px; margin: 28px 0; }
+    .card { padding: 22px; background: var(--panel); border: 1px solid var(--line); border-radius: 16px; }
+    .card h2 { margin-top: 9px; font-size: 20px; letter-spacing: -.025em; }
+    .card p { margin-top: 9px; color: var(--muted); }
+    .meter { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin-top: 18px; }
+    .meter span { height: 6px; border-radius: 999px; background: var(--line); }
+    .meter .ready { background: var(--green); } .meter .watch { background: var(--amber); } .meter .block { background: var(--red); }
+    .metric { font: 600 42px/1 var(--font-data); letter-spacing: -.08em; }
+    section { margin-top: 44px; }
+    .section-head { display: flex; justify-content: space-between; gap: 18px; align-items: baseline; margin-bottom: 14px; }
+    h2 { font-size: 24px; letter-spacing: -.035em; text-wrap: balance; }
+    .options { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .option { min-height: 292px; padding: 20px; border: 1px solid var(--line); background: var(--panel); border-radius: 14px; display: flex; flex-direction: column; }
+    .option.recommended { border-color: #48b5e3; box-shadow: inset 0 3px 0 var(--teal); }
+    .option h3 { margin-top: 10px; font-size: 19px; letter-spacing: -.025em; }
+    .option p { margin-top: 8px; color: var(--muted); }
+    .tag { align-self: flex-start; padding: 4px 8px; border-radius: 999px; color: #176d75; background: #57dbd21f; font: 700 10px/1 var(--font-data); letter-spacing: .08em; text-transform: uppercase; }
+    .tag.neutral { color: var(--muted); background: var(--paper); } .tag.risk { color: #9d3a46; background: #df59631f; }
+    .option .effort { margin-top: auto; padding-top: 16px; font: 11px/1.4 var(--font-data); color: var(--muted); }
+    .preview { height: 82px; margin: 16px 0 2px; overflow: hidden; border: 1px solid #ffffff16; border-radius: 10px; background: #121720; position: relative; }
+    .preview.night::before { content: ""; position: absolute; inset: 18px 18px auto; height: 5px; border-radius: 999px; background: linear-gradient(90deg, var(--teal), var(--blue), var(--indigo)); box-shadow: 0 18px 0 #ffffff1c, 0 36px 0 #ffffff12; }
+    .preview.field { background: linear-gradient(135deg, #e9fbfa, #eef4ff); } .preview.field::before { content: ""; position: absolute; inset: 15px; background: repeating-linear-gradient(90deg, transparent 0 12px, #238b9140 12px 14px, transparent 14px 25px); }
+    .preview.mono { background: var(--ink); } .preview.mono::before { content: "P."; position: absolute; left: 18px; top: 4px; color: var(--paper); font: 700 58px/1 var(--font-body); letter-spacing: -.12em; }
+    .audit { overflow-x: auto; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }
+    table { width: 100%; min-width: 720px; border-collapse: collapse; }
+    th, td { padding: 14px 16px; vertical-align: top; text-align: left; border-bottom: 1px solid var(--line); }
+    th { color: var(--muted); font: 700 11px/1.3 var(--font-data); letter-spacing: .08em; text-transform: uppercase; }
+    tr:last-child td { border-bottom: 0; }
+    td:nth-child(1) { width: 118px; font: 700 12px/1.35 var(--font-data); }
+    td:nth-child(2) { width: 190px; font-weight: 650; }
+    td:last-child { color: var(--muted); }
+    .status { display: inline-block; padding: 4px 7px; border-radius: 5px; font: 700 10px/1 var(--font-data); letter-spacing: .05em; }
+    .status.block { background: #df59631f; color: #b33c4c; } .status.watch { background: #c77c211f; color: #a35e0e; } .status.ok { background: #16836d1f; color: #10705b; }
+    .flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+    .flow > div { min-height: 100px; padding: 14px; border-top: 2px solid var(--line); background: var(--panel); }
+    .flow > div:first-child { border-color: var(--teal); } .flow > div:nth-child(2) { border-color: var(--blue); } .flow > div:nth-child(3) { border-color: var(--indigo); } .flow > div:last-child { border-color: var(--green); }
+    .flow strong { display: block; margin-top: 9px; font-size: 16px; } .flow small { display: block; margin-top: 5px; color: var(--muted); }
+    .note { margin-top: 16px; padding: 15px 17px; color: var(--muted); border-left: 3px solid var(--teal); background: color-mix(in srgb, var(--panel) 85%, var(--teal)); }
+    @media (max-width: 720px) { .shell { width: min(100% - 28px, 1100px); } .mast, .summary, .options, .flow { grid-template-columns: 1fr; } .signal { display: none; } }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="mast">
+      <div>
+        <p class="eyebrow">Parley / iOS release readiness</p>
+        <h1>先把「可信」做成第一個畫面。</h1>
+        <p class="lede">這不是只補一張 icon。Parley 要帶著自己的聲音進 App Store：清楚說明怎麼錄、資料去哪裡、怎麼退出，並讓第一組 screenshots 看起來像同一個產品。</p>
+      </div>
+      <div class="signal"><img src="../../ios/App/Parley/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png" alt="Parley app icon"></div>
+    </header>
+
+    <div class="summary">
+      <article class="card">
+        <p class="kicker">Readiness signal</p>
+        <h2>1 build 已上傳，送審尚未可用</h2>
+        <div class="meter" aria-label="2 ready, 1 watch, 1 block"><span class="ready"></span><span class="ready"></span><span class="watch"></span><span class="block"></span></div>
+        <p>簽章、App ID、Sign in with Apple capability 與 TestFlight upload 已通；商店資料、隱私與帳號生命週期尚未補齊。</p>
+      </article>
+      <article class="card">
+        <p class="kicker">App Store reality</p>
+        <p class="metric">0 / 10</p>
+        <p>目前 App Store Connect 的 screenshots、描述、keywords、Support URL、review credentials、聯絡人與 notes 都是空的。</p>
+      </article>
+    </div>
+
+    <section>
+      <div class="section-head"><h2>品牌處理：三條可選的路</h2><span class="kicker">選一條，整包完成</span></div>
+      <div class="options">
+        <article class="option recommended">
+          <span class="tag">Recommended</span>
+          <h3>Night Signal</h3>
+          <div class="preview night"></div>
+          <p>保留既有深墨底、青藍靛紫 P 與「協議點」。商店截圖以 live transcript 的一條訊號帶作主角；iOS、網站與桌機圖標終於講同一種語言。</p>
+          <p class="effort">Icon refine · 5 screenshot frames · privacy / support pages · in-app consent</p>
+        </article>
+        <article class="option">
+          <span class="tag neutral">Alternative</span>
+          <h3>Listening Field</h3>
+          <div class="preview field"></div>
+          <p>淺色、像會議桌上的聲紋紀錄紙。較溫和、偏專業服務，但會與目前 desktop 的 dark cockpit 拉開距離。</p>
+          <p class="effort">New screenshot art direction · icon variant · copy system</p>
+        </article>
+        <article class="option">
+          <span class="tag risk">Not advised now</span>
+          <h3>Mono Utility</h3>
+          <div class="preview mono"></div>
+          <p>純黑白 P.，像錄音工具。最快、最穩，但捨棄 Parley 已經擁有的辨識度，像一個新的、較冷的產品。</p>
+          <p class="effort">Minimal assets · weaker product continuity</p>
+        </article>
+      </div>
+      <p class="note">推薦 Night Signal：不是再發明一個 logo，而是把目前已經對的 mark、錄音紅點、speaker 色與雲端信任感，整理成同一組商店敘事。</p>
+    </section>
+
+    <section>
+      <div class="section-head"><h2>送審前 audit</h2><span class="kicker">2026-07-27 現況</span></div>
+      <div class="audit">
+        <table>
+          <thead><tr><th>Priority</th><th>項目</th><th>現況</th><th>補法</th></tr></thead>
+          <tbody>
+            <tr><td><span class="status block">BLOCKER</span></td><td>帳號刪除</td><td>Better Auth / app 都沒有 deletion flow。</td><td>雲端刪 session、user、個人 recording/R2；iOS 設定頁內啟動、確認與完成回饋。</td></tr>
+            <tr><td><span class="status block">BLOCKER</span></td><td>隱私政策</td><td><code>parley.tw/privacy</code> 目前 404，app 內也沒有入口。</td><td>上線中英／繁中 policy，描述音訊、逐字稿、帳號、R2、Soniox／Groq、保留／刪除；Settings 加連結。</td></tr>
+            <tr><td><span class="status block">BLOCKER</span></td><td>Store metadata</td><td>Screenshots、描述、keywords、Support URL、copyright、review credentials、聯絡人、notes 均空白。</td><td>產出 Night Signal 5 張 iPhone screenshots，填 zh-Hant 首發資料與 review packet。</td></tr>
+            <tr><td><span class="status watch">WATCH</span></td><td>錄音同意</td><td>目前點「開始錄音」就請求 mic，未提示與會者同意或雲端轉錄。</td><td>首次錄音 sheet：目的、資料流、與會者同意、可在 Settings 關閉；不影響後續一鍵錄音。</td></tr>
+            <tr><td><span class="status watch">WATCH</span></td><td>資料韌性</td><td>停止錄音後若 upload 失敗，temp Ogg 會被刪除，不能重試。</td><td>改成 pending upload queue；顯示同步狀態、保留檔案直到成功或使用者刪除。</td></tr>
+            <tr><td><span class="status watch">WATCH</span></td><td>Login review flow</td><td>Hosted auth 已有 email / Google / Apple；但 review test account 與 Notes 尚未提供。</td><td>建立可測試帳號、資料；Review Notes 說明 ASWebAuthenticationSession handoff 與 hosted STT。</td></tr>
+            <tr><td><span class="status ok">READY</span></td><td>App ID / SIWA</td><td><code>com.pathors.parley.ios</code> 已啟用 Sign in with Apple；hosted auth 已有 Apple 路徑。</td><td>保留，並以 TestFlight 真機驗完整登入。</td></tr>
+            <tr><td><span class="status ok">READY</span></td><td>簽章 / Icon</td><td>Apple Distribution、Store profile、1024 PNG 無 alpha、TestFlight build 1.0 (1) 已上傳。</td><td>Night Signal 只做一致性 refine，不重做識別。</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <div class="section-head"><h2>完整完成後的發佈門</h2><span class="kicker">不是分期，是一個可送審包</span></div>
+      <div class="flow">
+        <div><span class="kicker">01 / Trust</span><strong>Privacy 與 consent</strong><small>網站政策、in-app link、首錄提示、privacy label。</small></div>
+        <div><span class="kicker">02 / Account</span><strong>登入與刪除</strong><small>Apple / Google / email 都可登入；帳號和資料都可從 app 內刪除。</small></div>
+        <div><span class="kicker">03 / Product</span><strong>資料不丟失</strong><small>離線與失敗上傳 queue；TestFlight 真機驗 background、lock、interruption。</small></div>
+        <div><span class="kicker">04 / Store</span><strong>Metadata 與 review packet</strong><small>5 screenshots、商店 copy、支援頁、test account、精準 review notes。</small></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/ios/App/Parley/AppState.swift
+++ b/ios/App/Parley/AppState.swift
@@ -15,6 +15,7 @@ final class AppState: NSObject, ObservableObject {
     @Published var orgs: [CloudOrg] = []
     @Published var signingIn = false
     @Published var signInError: String?
+    @Published var pendingUploadCount = MeetingUploader.pendingCount
 
     @AppStorage("theme") var themeRaw: String = AppTheme.system.rawValue
     /// JSON-encoded `SaveDestination` (mirror of desktop `defaultSaveLocation`).
@@ -47,11 +48,13 @@ final class AppState: NSObject, ObservableObject {
     /// `user: null` → session is dead, clear it; a network error keeps the
     /// session so flaky connectivity never signs the user out.
     func refreshSession() async {
+        pendingUploadCount = MeetingUploader.pendingCount
         guard KeychainStore.get(Self.tokenKey) != nil else { return }
         do {
             user = try await cloud.me()
             if user == nil { KeychainStore.delete(Self.tokenKey) }
             await loadAccountExtras()
+            await syncPendingUploads()
         } catch let err as CloudError where err.isAuthExpired {
             KeychainStore.delete(Self.tokenKey)
             user = nil
@@ -91,6 +94,7 @@ final class AppState: NSObject, ObservableObject {
                     KeychainStore.set(token, for: Self.tokenKey)
                     self.user = try await self.cloud.me()
                     await self.loadAccountExtras()
+                    await self.syncPendingUploads()
                 } catch {
                     self.signInError = "登入失敗：\(error.localizedDescription)"
                 }
@@ -104,6 +108,24 @@ final class AppState: NSObject, ObservableObject {
 
     func signOut() async {
         try? await cloud.signOut()
+        clearLocalSession()
+    }
+
+    func syncPendingUploads() async {
+        guard signedIn else {
+            pendingUploadCount = MeetingUploader.pendingCount
+            return
+        }
+        let result = await MeetingUploader.syncPending(cloud: cloud, orgs: orgs)
+        pendingUploadCount = result.remaining
+    }
+
+    func deleteAccount() async throws {
+        try await cloud.deleteAccount()
+        clearLocalSession()
+    }
+
+    private func clearLocalSession() {
         KeychainStore.delete(Self.tokenKey)
         user = nil
         quota = nil
@@ -111,8 +133,7 @@ final class AppState: NSObject, ObservableObject {
     }
 
     #if DEBUG
-        /// Dev shortcut while Sign in with Apple / mobile OAuth UX is pending:
-        /// paste a session token lent by the desktop build.
+        /// Dev-only shortcut for testing a session minted by the desktop build.
         func adoptToken(_ token: String) async {
             KeychainStore.set(token.trimmingCharacters(in: .whitespacesAndNewlines), for: Self.tokenKey)
             await refreshSession()

--- a/ios/App/Parley/LiveView.swift
+++ b/ios/App/Parley/LiveView.swift
@@ -10,6 +10,7 @@ struct LiveView: View {
     @State private var capture: AudioCapture?
     @State private var relay: SttRelayClient?
     @State private var uploader: MeetingUploader?
+    @State private var showRecordingConsent = false
 
     var body: some View {
         NavigationStack {
@@ -30,6 +31,14 @@ struct LiveView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     LevelMeter(level: store.micLevel)
                 }
+            }
+            .alert("開始錄音前請確認", isPresented: $showRecordingConsent) {
+                Button("取消", role: .cancel) {}
+                Button("我已取得所有與會者同意") {
+                    Task { await start() }
+                }
+            } message: {
+                Text("Parley 會收取房間麥克風聲音，將音訊送往你的 Parley 雲端帳號進行即時轉錄，並同步儲存錄音與逐字稿。請先確認所有與會者同意錄音。")
             }
         }
     }
@@ -90,12 +99,22 @@ struct LiveView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(store.isRecording ? Theme.recording : Theme.primary)
+            .disabled(!store.isRecording && !app.signedIn)
+            if !store.isRecording && !app.signedIn {
+                Text("請先到「設定」登入，錄音才會安全同步到你的雲端帳號。")
+                    .font(.caption)
+                    .foregroundStyle(Theme.mutedForeground)
+            }
         }
         .padding(16)
     }
 
     private func toggle() {
-        if store.isRecording { Task { await stop() } } else { Task { await start() } }
+        if store.isRecording {
+            Task { await stop() }
+        } else {
+            showRecordingConsent = true
+        }
     }
 
     private func start() async {
@@ -175,15 +194,18 @@ struct LiveView: View {
                 defaultSave: app.defaultSave,
                 orgs: app.orgs)
             if let outcome {
+                app.pendingUploadCount = MeetingUploader.pendingCount
                 store.status =
                     outcome.sharedToOrgName.map { "已同步，並分享到「\($0)」" } ?? "已同步到雲端"
             } else {
                 store.status = "錄音太短，已捨棄"
             }
         } catch let e as CloudError where e.status == 402 {
-            store.status = "額度已用完，錄音未上傳"
+            app.pendingUploadCount = MeetingUploader.pendingCount
+            store.status = "額度已用完，錄音已安全保留，額度恢復後會自動同步"
         } catch {
-            store.status = "上傳失敗：\(error.localizedDescription)"
+            app.pendingUploadCount = MeetingUploader.pendingCount
+            store.status = "同步暫時失敗，錄音已安全保留，稍後會自動重試"
         }
     }
 

--- a/ios/App/Parley/MeetingUploader.swift
+++ b/ios/App/Parley/MeetingUploader.swift
@@ -1,17 +1,9 @@
 import Foundation
 import ParleyKit
 
-/// Owns one meeting's recording artifacts: streams PCM into the Ogg/Opus
-/// encoder (pages go straight to a temp file — a 1-hour meeting never sits in
-/// memory), then syncs the finished meeting to the cloud with the desktop's
-/// exact contract:
-///
-///   1. `PUT /recordings/:id/audio` FIRST — a summary row must never claim
-///      `hasAudio` before its blob exists (sync.ts:80-89).
-///   2. `POST /recordings/:id` with `{summary, meta}`.
-///   3. Default-save rule (history.ts:176-215): an org default never moves
-///      the original — the recording lands in the personal space, then a copy
-///      is auto-shared into the org.
+/// Owns one live recording. Finished audio is first moved to Application
+/// Support, then synced with the desktop's audio-first contract. A failed or
+/// interrupted upload remains in the on-device queue until it succeeds.
 final class MeetingUploader {
     let id = UUID().uuidString.lowercased()
     private let startedAt = Date()
@@ -32,8 +24,6 @@ final class MeetingUploader {
         }
     }
 
-    /// Called from the audio callback path — hop to the serial queue so the
-    /// encoder never races.
     func append(_ samples: [Int16]) {
         queue.async { [self] in
             samplesFed += samples.count
@@ -49,63 +39,108 @@ final class MeetingUploader {
         var sharedToOrgName: String?
     }
 
-    /// Finish the file and sync. Discards (returns nil) when the meeting is
-    /// shorter than 2 s — same threshold as the desktop recorder.
+    struct SyncResult {
+        let uploaded: Int
+        let remaining: Int
+    }
+
+    private struct PendingUpload: Codable {
+        let id: String
+        let startedAt: Date
+        let durationMs: Double
+        let segments: [TranscriptSegment]
+        let defaultSave: SaveDestination
+    }
+
+    /// Finalize the Ogg stream, place it in the durable queue, then attempt an
+    /// immediate sync. Files are deleted only after every cloud step succeeds.
     func finishAndUpload(
         segments: [TranscriptSegment],
         cloud: CloudClient,
         defaultSave: SaveDestination,
         orgs: [CloudOrg]
     ) async throws -> Outcome? {
-        // Drain the encoder queue, then close the stream.
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             queue.async { [self] in
                 encoder?.finalize()
                 try? fileHandle?.close()
-                cont.resume()
+                continuation.resume()
             }
         }
-        defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        guard durationMs >= 2000 else { return nil }
+        guard durationMs >= 2_000 else {
+            try? FileManager.default.removeItem(at: fileURL)
+            return nil
+        }
 
-        let finals = segments.filter { $0.isFinal && !$0.id.hasSuffix("-tail") }
-        let personalFolderId = defaultSave.isOrg ? nil : defaultSave.folderId
-        let meta = buildMeta(finals: finals, folderId: personalFolderId)
-        let summary = buildSummary(finals: finals, folderId: personalFolderId)
+        let pending = PendingUpload(
+            id: id,
+            startedAt: startedAt,
+            durationMs: durationMs,
+            segments: segments.filter { $0.isFinal && !$0.id.hasSuffix("-tail") },
+            defaultSave: defaultSave)
+        try Self.persist(pending, audioAt: fileURL)
+        return try await Self.upload(pending, cloud: cloud, orgs: orgs)
+    }
 
-        let audio = try Data(contentsOf: fileURL)
-        try await cloud.uploadAudio(id: id, ogg: audio)
-        try await cloud.pushRecording(id: id, summary: summary, meta: meta)
+    static func syncPending(cloud: CloudClient, orgs: [CloudOrg]) async -> SyncResult {
+        let pending = loadPending()
+        var uploaded = 0
+        for item in pending {
+            do {
+                _ = try await upload(item, cloud: cloud, orgs: orgs)
+                uploaded += 1
+            } catch {
+                // Keep the item in-order. A later recording can be retried by the
+                // next foreground launch, but do not spin a failing network loop.
+                break
+            }
+        }
+        return SyncResult(uploaded: uploaded, remaining: max(0, pending.count - uploaded))
+    }
+
+    static var pendingCount: Int { loadPending().count }
+
+    private static func upload(
+        _ pending: PendingUpload,
+        cloud: CloudClient,
+        orgs: [CloudOrg]
+    ) async throws -> Outcome {
+        let finals = pending.segments
+        let personalFolderId = pending.defaultSave.isOrg ? nil : pending.defaultSave.folderId
+        let meta = buildMeta(pending: pending, finals: finals, folderId: personalFolderId)
+        let summary = buildSummary(pending: pending, finals: finals, folderId: personalFolderId)
+        let audio = try Data(contentsOf: audioURL(for: pending.id))
+
+        try await cloud.uploadAudio(id: pending.id, ogg: audio)
+        try await cloud.pushRecording(id: pending.id, summary: summary, meta: meta)
 
         var outcome = Outcome()
-        if defaultSave.isOrg, let orgId = defaultSave.orgId {
-            try await cloud.shareRecording(id: id, orgId: orgId, folderId: defaultSave.folderId)
+        if pending.defaultSave.isOrg, let orgId = pending.defaultSave.orgId {
+            try await cloud.shareRecording(id: pending.id, orgId: orgId, folderId: pending.defaultSave.folderId)
             outcome.sharedToOrgName = orgs.first { $0.id == orgId }?.name ?? "組織"
         }
+
+        removePending(id: pending.id)
         return outcome
     }
 
-    // MARK: meta / summary (desktop HistoryEntry shape)
-
-    private var defaultTitle: String {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "M/d HH:mm"
-        return "會議 \(fmt.string(from: startedAt))"
-    }
-
-    private func buildMeta(finals: [TranscriptSegment], folderId: String?) -> RecordingMeta {
+    private static func buildMeta(
+        pending: PendingUpload,
+        finals: [TranscriptSegment],
+        folderId: String?
+    ) -> RecordingMeta {
         var raw: [String: Any] = [
-            "id": id,
-            "title": defaultTitle,
+            "id": pending.id,
+            "title": title(for: pending.startedAt),
             "source": "live",
-            "createdAt": startedAt.timeIntervalSince1970 * 1000,
-            "durationMs": durationMs,
-            "segments": finals.map { s in
+            "createdAt": pending.startedAt.timeIntervalSince1970 * 1_000,
+            "durationMs": pending.durationMs,
+            "segments": finals.map { segment in
                 [
-                    "id": s.id, "source": s.source, "speaker": s.speaker,
-                    "text": s.text, "isFinal": true,
-                    "startMs": Double(s.startMs), "endMs": Double(s.endMs),
+                    "id": segment.id, "source": segment.source, "speaker": segment.speaker,
+                    "text": segment.text, "isFinal": true,
+                    "startMs": Double(segment.startMs), "endMs": Double(segment.endMs),
                 ] as [String: Any]
             },
             "speakerNames": [String: String](),
@@ -122,18 +157,73 @@ final class MeetingUploader {
         return RecordingMeta(raw: raw)
     }
 
-    private func buildSummary(finals: [TranscriptSegment], folderId: String?)
-        -> CloudRecordingSummary
-    {
+    private static func buildSummary(
+        pending: PendingUpload,
+        finals: [TranscriptSegment],
+        folderId: String?
+    ) -> CloudRecordingSummary {
         let speakers = Set(finals.map { "\($0.source)-\($0.speaker)" }).count
         let snippet = finals.prefix(3).map(\.text).joined(separator: " ").prefix(120)
         return CloudRecordingSummary(
-            id: id, title: defaultTitle, source: "live",
-            createdAt: startedAt.timeIntervalSince1970 * 1000,
-            durationMs: durationMs,
+            id: pending.id, title: title(for: pending.startedAt), source: "live",
+            createdAt: pending.startedAt.timeIntervalSince1970 * 1_000,
+            durationMs: pending.durationMs,
             speakerCount: max(speakers, finals.isEmpty ? 0 : 1),
             findingsCount: 0, actionItemsCount: 0,
             hasAudio: true, snippet: String(snippet),
             folderId: folderId, updatedAt: nil)
+    }
+
+    private static func title(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M/d HH:mm"
+        return "會議 \(formatter.string(from: date))"
+    }
+
+    private static func pendingDirectory() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true)
+        let directory = base.appendingPathComponent("Parley/PendingUploads", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func audioURL(for id: String) throws -> URL {
+        try pendingDirectory().appendingPathComponent("\(id).ogg")
+    }
+
+    private static func manifestURL(for id: String) throws -> URL {
+        try pendingDirectory().appendingPathComponent("\(id).json")
+    }
+
+    private static func persist(_ pending: PendingUpload, audioAt source: URL) throws {
+        let destination = try audioURL(for: pending.id)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: source, to: destination)
+        let manifest = try manifestURL(for: pending.id)
+        try JSONEncoder().encode(pending).write(to: manifest, options: .atomic)
+    }
+
+    private static func loadPending() -> [PendingUpload] {
+        guard let directory = try? pendingDirectory(),
+            let files = try? FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: [.creationDateKey])
+        else { return [] }
+        return files
+            .filter { $0.pathExtension == "json" }
+            .compactMap { url in
+                guard let data = try? Data(contentsOf: url) else { return nil }
+                return try? JSONDecoder().decode(PendingUpload.self, from: data)
+            }
+            .sorted { $0.startedAt < $1.startedAt }
+    }
+
+    private static func removePending(id: String) {
+        [try? audioURL(for: id), try? manifestURL(for: id)].compactMap { $0 }.forEach { url in
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 }

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -9,6 +9,9 @@ struct SettingsView: View {
     @EnvironmentObject private var app: AppState
     @State private var personalFolders: [CloudFolder] = []
     @State private var orgFolders: [String: [CloudFolder]] = [:]
+    @State private var showDeleteConfirmation = false
+    @State private var deletingAccount = false
+    @State private var deleteAccountError: String?
     #if DEBUG
         @State private var devToken = ""
     #endif
@@ -20,6 +23,7 @@ struct SettingsView: View {
                 if app.signedIn {
                     saveDestinationSection
                     usageSection
+                    syncSection
                 }
                 appearanceSection
                 aboutSection
@@ -29,6 +33,16 @@ struct SettingsView: View {
             }
             .navigationTitle("設定")
             .task { await loadFolders() }
+            .confirmationDialog(
+                "永久刪除帳號？", isPresented: $showDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("永久刪除我的帳號與個人資料", role: .destructive) {
+                    Task { await deleteAccount() }
+                }
+            } message: {
+                Text("這會永久移除你的 Parley 帳號、個人錄音、逐字稿、資料夾與使用資料。你仍是擁有者的組織必須先移轉或刪除。")
+            }
         }
     }
 
@@ -59,9 +73,37 @@ struct SettingsView: View {
                 Button("登出", role: .destructive) {
                     Task { await app.signOut() }
                 }
+                Button("刪除帳號", role: .destructive) {
+                    showDeleteConfirmation = true
+                }
+                .disabled(deletingAccount)
+                if let deleteAccountError {
+                    Text(deleteAccountError)
+                        .font(.caption)
+                        .foregroundStyle(Theme.destructive)
+                }
             } else {
                 signInForm
             }
+        }
+    }
+
+    private var syncSection: some View {
+        Section {
+            if app.pendingUploadCount > 0 {
+                Label("\(app.pendingUploadCount) 筆錄音等待同步", systemImage: "icloud.and.arrow.up")
+                    .foregroundStyle(Theme.warning)
+                Button("立即重試同步") {
+                    Task { await app.syncPendingUploads() }
+                }
+            } else {
+                Label("所有錄音都已同步", systemImage: "checkmark.icloud")
+                    .foregroundStyle(Theme.success)
+            }
+        } header: {
+            Text("同步")
+        } footer: {
+            Text("網路中斷、伺服器暫時無回應或額度不足時，手機會保留完成的錄音，直到同步成功。")
         }
     }
 
@@ -205,6 +247,8 @@ struct SettingsView: View {
         Section {
             LabeledContent("版本", value: Bundle.main.shortVersion)
             Link("Parley 桌面版", destination: URL(string: "https://parley.tw")!)
+            Link("隱私權政策", destination: URL(string: "https://parley.tw/privacy/")!)
+            Link("支援與問題回報", destination: URL(string: "https://parley.tw/support/")!)
         } footer: {
             Text("即時教練與深度分析以桌面版為主；手機負責面對面會議的錄音、轉錄與瀏覽。")
         }
@@ -232,6 +276,19 @@ struct SettingsView: View {
         personalFolders = (try? await app.cloud.listFolders()) ?? []
         for org in app.orgs {
             orgFolders[org.id] = (try? await app.cloud.orgFolders(orgId: org.id)) ?? []
+        }
+    }
+
+    private func deleteAccount() async {
+        deletingAccount = true
+        deleteAccountError = nil
+        defer { deletingAccount = false }
+        do {
+            try await app.deleteAccount()
+        } catch let error as CloudError where error.status == 409 {
+            deleteAccountError = "你仍是至少一個組織的擁有者。請先在桌面版移轉或刪除該組織，再刪除帳號。"
+        } catch {
+            deleteAccountError = "帳號尚未刪除。請確認網路後再試一次。"
         }
     }
 }

--- a/ios/ParleyKit/Sources/ParleyKit/CloudClient.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/CloudClient.swift
@@ -100,6 +100,13 @@ public actor CloudClient {
         _ = try await request("auth/sign-out", method: "POST")
     }
 
+    /// Permanently removes the first-party account and its personal recordings.
+    /// The server returns 409 when the account still owns a shared organization;
+    /// that workspace must be transferred or removed explicitly first.
+    public func deleteAccount() async throws {
+        _ = try await request("me", method: "DELETE")
+    }
+
     // MARK: recordings (personal)
 
     public func listRecordings() async throws -> [CloudRecordingSummary] {

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -1,68 +1,67 @@
-# Parley iOS — App Store 發佈指南
+# Parley iOS — release checklist
 
-從零到上架的完整路徑，以及 Parley 特有的審核風險點。
+Parley iOS is the cloud companion for face-to-face meetings. It records the
+phone microphone, streams it through the hosted Parley relay, and syncs the
+Ogg recording plus transcript to the same account as the desktop app. It does
+not capture phone calls or other apps' audio.
 
-## 0. 前置（一次性）
+## Release build
 
-| 項目 | 說明 |
-|---|---|
-| Apple Developer Program | ✅ 已有（科技派斯，Team ID `SXHVCQXJHZ`） |
-| App ID | ✅ 已註冊：`com.pathors.parley.ios`（explicit）+ **Sign in with Apple** capability（2026-07-27）。SIWA 的 Services ID 與 .p8 key（web flow / 後端驗證用）要用時再建 |
-| App Store Connect | 建 app record：名稱「Parley」、主要語言 zh-Hant、SKU 任意 |
-| 簽章 | Xcode → Settings → Accounts 登入開發者帳號後，`CODE_SIGN_STYLE: Automatic`（已設定）+ 選 Team 即可；CI 要用 fastlane match 或 App Store Connect API key 再說 |
+Prerequisites already configured for the Pathors Apple team (`SXHVCQXJHZ`):
 
-## 1. 每次發佈的流程
+- Bundle ID: `com.pathors.parley.ios`
+- App Store Connect app: `Parley` (`6795031201`)
+- Sign in with Apple capability and hosted Better Auth Apple provider
+- Hosted login page: `https://api.parley.tw/sign-in`
 
-```bash
-cd ios/App && xcodegen generate
-```
-
-1. `project.yml` 進版：`CFBundleShortVersionString`（行銷版號）與 build number
-2. Xcode 開 `Parley.xcodeproj` → 選 **Any iOS Device (arm64)** → Product → **Archive**
-3. Organizer → **Distribute App** → App Store Connect → Upload（自動處理簽章與 dSYM）
-4. App Store Connect → TestFlight 先內測（自己 + 團隊即裝即測，不用等審）
-5. 補齊商店資料 → **Submit for Review**
-
-CLI 等價（之後進 CI 用）：
+Each upload needs a new build number. Update `CFBundleVersion` in
+`App/Parley/Info.plist`, then generate and archive:
 
 ```bash
-xcodebuild -project Parley.xcodeproj -scheme Parley -destination generic/platform=iOS \
+cd ios/App
+xcodegen generate
+xcodebuild -project Parley.xcodeproj -scheme Parley \
+  -destination 'generic/platform=iOS' \
   -archivePath build/Parley.xcarchive archive
 xcodebuild -exportArchive -archivePath build/Parley.xcarchive \
-  -exportOptionsPlist ExportOptions.plist -exportPath build/export
-xcrun altool --upload-app ...   # 或 xcrun notarytool / Transporter
+  -exportOptionsPlist ExportOptions.plist -exportPath build/export \
+  -allowProvisioningUpdates
 ```
 
-發佈節奏依 design doc D5：tag 用 `ios-v*` namespace、獨立 workflow，不碰桌機的 `release.yml`。
+With an Xcode account signed in, the export uploads directly to App Store
+Connect. CI should use an App Store Connect API key with
+`-authenticationKeyPath`, `-authenticationKeyID`, and
+`-authenticationKeyIssuerID` instead of a GUI account.
 
-## 2. 商店資料清單
+## Store metadata
 
-- 截圖：6.9"（iPhone 17 Pro Max）與 6.5" 兩組必備；用 simulator 截即可
-- 描述、關鍵字、支援網址（parley.tw）、隱私政策網址（**必填**，見 §3）
-- App 隱私「營養標籤」要申報：**音訊資料**（使用者內容）、**識別碼**（帳號 email）——有連 Google 登入與雲端同步就必須誠實填
-- 出口合規：只用 HTTPS/標準加密 → `ITSAppUsesNonExemptEncryption: false`（已在 project.yml，送審不會再被問）
+- **Support URL:** `https://parley.tw/support/`
+- **Privacy Policy URL:** `https://parley.tw/privacy/`
+- **Copyright:** `© 2026 Pathors AI`
+- **Screenshots:** upload 1–10 iPhone 6.5-inch PNG/JPEG screenshots without
+  alpha. Use an actual app session that shows live transcription, recording
+  library, and settings; do not use mocked desktop UI.
+- **App Privacy:** declare contact info (email), user content (audio recordings
+  and transcripts), and identifiers/account data. Mark the information as used
+  for app functionality; do not mark it as used for tracking.
 
-## 3. Parley 特有的審核風險（重要）
+## Review notes
 
-按風險排序，前兩項**不解決就會被打回來**：
+Provide a working review account on the hosted email/password sign-in page and
+include this note:
 
-1. **Guideline 4.8 — Sign in with Apple 是硬要求**。app 只有 Google 登入 → 必須同時提供 SIWA。這是 parley-internal #23：後端 Better Auth 加 Apple provider，app 加 `SignInWithAppleButton`。**送審前必須完成。**
-2. **Guideline 5.1.1(v) — 帳號刪除**。有帳號系統的 app 必須提供「刪除帳號」入口（可以導到網頁，但流程要能真的刪）。後端目前沒有 delete-account 端點——要開一張 issue。
-3. **錄音類 app 會被特別檢視**：
-   - Review Notes 主動聲明：**不錄電話**（技術上也不可能）、麥克風只在使用者按下錄音時啟用、音訊只送使用者帳號綁定的轉錄服務
-   - `NSMicrophoneUsageDescription` 文案要具體（已寫）；審核員會實測權限彈窗
-   - 建議 app 內第一次錄音前加一個「確保已取得與會者同意」的提示（各國錄音同意法規不同，這也是產品該有的）
-4. **背景錄音**：`UIBackgroundModes: audio` 用於錄音是合法用途，但審核員若覺得可疑會問——Review Notes 說明是會議錄音 app 即可
-5. **демо帳號**：審核員需要能登入測試。給一組測試 Google 帳號，或做一個 review-mode（feature flag 顯示假資料）。DEBUG 的貼 token 後門**不能**出現在 Release build（已用 `#if DEBUG` 圍住，Release 自動剔除）
-6. **付費**：目前 app 內沒有販售、沒有解鎖，免費額度是帳號屬性 → 不觸發 IAP 要求。未來若在 app 內賣訂閱，**必須走 IAP**（外部購買連結的規則逐年變動，屆時再查）
+> Parley is a microphone-based, in-person meeting recorder. It does not record
+> phone calls or other app audio. The microphone starts only after the user taps
+> Start Recording and confirms they have consent from participants. Audio is
+> sent to the signed-in account's hosted transcription relay, and the completed
+> recording plus transcript sync to that account. Account deletion is available
+> in Settings → Account.
 
-## 4. 送審前 checklist
+## Before submission
 
-- [ ] SIWA 完成（#23）並在登入頁與 Google 並列
-- [ ] 帳號刪除入口（後端 + app 設定頁連結）
-- [ ] 隱私政策頁面上線（parley.tw/privacy）
-- [ ] App 隱私標籤申報完成
-- [ ] 錄音同意提示
-- [ ] 6.9" + 6.5" 截圖（淺色深色各拍一套挑好看的）
-- [ ] TestFlight 真機測過：背景錄音、來電中斷恢復、鎖屏續錄
-- [ ] Review Notes：測試帳號 + 不錄電話聲明
+- [ ] Test hosted email/password, Google, and Apple login end-to-end on device.
+- [ ] Test microphone permission denial, background/lock-screen recording, an
+      interrupted network, and later queued-upload retry.
+- [ ] Verify personal folders, organization share/move, and account deletion.
+- [ ] Confirm the public privacy and support URLs load over HTTPS.
+- [ ] Assign the processed TestFlight build and submit only after the above.

--- a/website/index.html
+++ b/website/index.html
@@ -486,6 +486,8 @@ claude mcp add --transport http parley \
           <a href="#stack">Open source</a>
           <a href="https://github.com/pathorsAI/parley" target="_blank" rel="noopener">GitHub</a>
           <a href="https://github.com/pathorsAI/parley/blob/main/LICENSE" target="_blank" rel="noopener">License</a>
+          <a href="privacy/">Privacy</a>
+          <a href="support/">Support</a>
           <a href="https://pathors.com" target="_blank" rel="noopener">Pathors AI</a>
         </nav>
       </div>

--- a/website/legal.css
+++ b/website/legal.css
@@ -1,0 +1,97 @@
+:root {
+  --ink: #0c111b;
+  --paper: #f6f8fb;
+  --panel: #ffffff;
+  --line: #dce3eb;
+  --muted: #5d6b7d;
+  --signal: #147f8d;
+  --signal-soft: #dff5f4;
+  --link: #195bcc;
+  --focus: #e85b6a;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #edf3fa;
+    --paper: #0c111b;
+    --panel: #131c29;
+    --line: #273548;
+    --muted: #a8b6c8;
+    --signal: #46d4d1;
+    --signal-soft: #11333b;
+    --link: #76a8ff;
+    --focus: #ff8b98;
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="light"] {
+  --ink: #0c111b;
+  --paper: #f6f8fb;
+  --panel: #ffffff;
+  --line: #dce3eb;
+  --muted: #5d6b7d;
+  --signal: #147f8d;
+  --signal-soft: #dff5f4;
+  --link: #195bcc;
+  --focus: #e85b6a;
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  --ink: #edf3fa;
+  --paper: #0c111b;
+  --panel: #131c29;
+  --line: #273548;
+  --muted: #a8b6c8;
+  --signal: #46d4d1;
+  --signal-soft: #11333b;
+  --link: #76a8ff;
+  --focus: #ff8b98;
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+html { background: var(--paper); }
+body {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem clamp(1.25rem, 5vw, 4rem) 4rem;
+  background:
+    linear-gradient(90deg, transparent 0, transparent calc(100% - 1px), var(--line) calc(100% - 1px)) 0 0 / 12rem 100%,
+    var(--paper);
+  color: var(--ink);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+}
+a { color: var(--link); text-underline-offset: 0.16em; }
+a:focus-visible, button:focus-visible { outline: 3px solid var(--focus); outline-offset: 3px; }
+.topline { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: clamp(4rem, 12vw, 8rem); }
+.brand { display: inline-flex; align-items: center; gap: 0.65rem; color: var(--ink); font-weight: 700; text-decoration: none; }
+.brand img { width: 30px; height: 30px; }
+.back { color: var(--muted); font-size: 0.9rem; }
+main { max-width: 48rem; }
+.eyebrow { margin: 0 0 0.9rem; color: var(--signal); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+h1, h2 { line-height: 1.15; letter-spacing: -0.035em; text-wrap: balance; }
+h1 { max-width: 15ch; margin: 0; font-size: clamp(2.4rem, 8vw, 4.8rem); }
+h2 { margin: 3.6rem 0 0.7rem; font-size: clamp(1.35rem, 4vw, 1.9rem); }
+h3 { margin: 1.8rem 0 0.4rem; font-size: 1.1rem; }
+p, li { max-width: 66ch; }
+.lead { max-width: 55ch; margin: 1.2rem 0 0; color: var(--muted); font-size: 1.16rem; }
+.updated { display: inline-block; margin-top: 1.5rem; padding: 0.35rem 0.65rem; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.75rem; }
+.callout { margin: 2.3rem 0; padding: 1.2rem 1.3rem; border-left: 4px solid var(--signal); background: var(--signal-soft); }
+.callout p { margin: 0; }
+.data-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; margin-top: 1.2rem; overflow: hidden; border: 1px solid var(--line); background: var(--line); }
+.data-grid div { padding: 1rem; background: var(--panel); }
+.data-grid strong, .data-grid span { display: block; }
+.data-grid strong { font-size: 0.95rem; }
+.data-grid span { margin-top: 0.35rem; color: var(--muted); font-size: 0.88rem; }
+.support-list { display: grid; gap: 0.75rem; padding: 0; list-style: none; }
+.support-list a { display: block; padding: 1.1rem 1.2rem; border: 1px solid var(--line); background: var(--panel); color: var(--ink); text-decoration: none; }
+.support-list a:hover { border-color: var(--signal); }
+.support-list strong, .support-list span { display: block; }
+.support-list span { margin-top: 0.18rem; color: var(--muted); font-size: 0.9rem; }
+footer { margin-top: 5rem; padding-top: 1.2rem; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.86rem; }
+@media (max-width: 34rem) { .data-grid { grid-template-columns: 1fr; } .topline { margin-bottom: 3.5rem; } }

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parley 隱私權政策</title>
+    <meta name="description" content="Parley 對錄音、逐字稿、雲端同步與帳號資料的處理方式。" />
+    <link rel="canonical" href="https://parley.tw/privacy/" />
+    <link rel="icon" type="image/svg+xml" href="../assets/logo.svg" />
+    <link rel="stylesheet" href="../legal.css" />
+  </head>
+  <body>
+    <header class="topline">
+      <a class="brand" href="../" aria-label="Parley 首頁"><img src="../assets/logo.svg" alt="" />Parley</a>
+      <a class="back" href="../">回到首頁</a>
+    </header>
+    <main>
+      <p class="eyebrow">Privacy / 隱私</p>
+      <h1>你的會議內容，應該清楚知道去了哪裡。</h1>
+      <p class="lead">本政策說明官方雲端版 Parley 如何處理帳號、錄音、逐字稿與 AI 使用資料。開源桌面版在未啟用雲端服務時，可僅依你選擇的本機與第三方供應商設定運作。</p>
+      <span class="updated">最後更新：2026 年 7 月 27 日</span>
+
+      <div class="callout"><p><strong>簡短版：</strong>Parley 只在你按下錄音後收取麥克風音訊；音訊與逐字稿會同步到你的 Parley 帳號，以便你在裝置間查看。你可在 app 設定中永久刪除個人帳號與資料。</p></div>
+
+      <h2>我們收集的資料</h2>
+      <div class="data-grid">
+        <div><strong>帳號資料</strong><span>姓名、電子郵件、登入方式與工作階段，用於建立並保護你的帳號。</span></div>
+        <div><strong>會議內容</strong><span>你主動錄製的音訊、逐字稿、標題、摘要、資料夾與組織歸屬。</span></div>
+        <div><strong>服務用量</strong><span>轉錄秒數與 AI 額度使用量，用於套用方案額度和防止濫用。</span></div>
+        <div><strong>技術資料</strong><span>為安全與服務運作所需的基本請求、錯誤與裝置瀏覽器資訊。</span></div>
+      </div>
+
+      <h2>我們如何使用資料</h2>
+      <ul>
+        <li>提供即時轉錄、錄音庫、跨裝置同步與你選擇的個人或組織資料夾。</li>
+        <li>代表你將音訊送至轉錄服務，並在你使用 AI 功能時送至模型服務。</li>
+        <li>維護帳號安全、計算額度，以及診斷服務故障。</li>
+      </ul>
+      <p>我們不販售你的個人資料，也不會將你的會議內容用於投放廣告。</p>
+
+      <h2>資料儲存與第三方</h2>
+      <p>官方雲端版使用 Cloudflare 的 D1 與 R2 儲存帳號資料、錄音中繼資料和加密傳輸的音訊物件。即時轉錄使用 Soniox；官方 AI 功能使用 Groq。若你選擇以 Google 或 Apple 登入，該登入提供者會依其自身政策處理登入資料。這些供應商只為提供 Parley 服務而處理資料。</p>
+
+      <h2>保留與刪除</h2>
+      <p>你的帳號資料與個人錄音會保留至你刪除它們。可在 iOS app 的「設定 → 帳號 → 刪除帳號」永久刪除帳號、個人錄音、逐字稿、資料夾與使用資料。若你是共享組織的擁有者，必須先移轉或刪除該組織，避免意外刪除其他成員的共同資料。</p>
+      <p>同步失敗的完成錄音會暫存在你的裝置 App Support 空間，直到上傳成功；成功後會自動移除。你可刪除 app 來清除該裝置上的暫存資料。</p>
+
+      <h2>你的責任與選擇</h2>
+      <p>錄音前請依所在地法律取得所有與會者同意。Parley 的 iOS app 不會擷取電話通話或其他 app 的系統音訊；它只會在你主動開始會議錄音時使用麥克風。</p>
+
+      <h2>聯絡我們</h2>
+      <p>隱私問題、資料請求或政策意見，請寄至 <a href="mailto:contact@pathors.com">contact@pathors.com</a>。</p>
+
+      <h2>English summary</h2>
+      <p>Parley processes account information, user-initiated recordings, transcripts, and usage data to provide transcription and synced meeting history. We do not sell personal data or use meeting content for advertising. You can delete your account and personal data from Settings in the iOS app. Contact <a href="mailto:contact@pathors.com">contact@pathors.com</a> for privacy requests.</p>
+    </main>
+    <footer>© 2026 Pathors AI · <a href="../support/">Support</a></footer>
+  </body>
+</html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -5,4 +5,14 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://parley.tw/privacy/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://parley.tw/support/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parley 支援</title>
+    <meta name="description" content="Parley 的支援、問題回報與隱私聯絡方式。" />
+    <link rel="canonical" href="https://parley.tw/support/" />
+    <link rel="icon" type="image/svg+xml" href="../assets/logo.svg" />
+    <link rel="stylesheet" href="../legal.css" />
+  </head>
+  <body>
+    <header class="topline">
+      <a class="brand" href="../" aria-label="Parley 首頁"><img src="../assets/logo.svg" alt="" />Parley</a>
+      <a class="back" href="../">回到首頁</a>
+    </header>
+    <main>
+      <p class="eyebrow">Support / 支援</p>
+      <h1>讓會議紀錄回到正軌。</h1>
+      <p class="lead">遇到登入、錄音、同步或錄音庫問題時，先保留錯誤畫面、發生時間與 app 版本；這些資訊能讓我們更快定位問題。</p>
+
+      <h2>聯絡方式</h2>
+      <ul class="support-list">
+        <li><a href="mailto:contact@pathors.com?subject=Parley%20support"><strong>寄信給 Parley 支援</strong><span>登入、帳號、同步、資料與一般產品問題。</span></a></li>
+        <li><a href="https://github.com/pathorsAI/parley/issues" target="_blank" rel="noopener"><strong>回報開源版本問題</strong><span>附上重現步驟、版本與非敏感性日誌。GitHub 會在新分頁開啟。</span></a></li>
+        <li><a href="../privacy/"><strong>隱私與帳號刪除</strong><span>查看資料處理方式；iOS app 可從「設定 → 帳號」提出永久刪除。</span></a></li>
+      </ul>
+
+      <h2>iOS 常見問題</h2>
+      <h3>為什麼無法開始錄音？</h3>
+      <p>先登入 Parley，接著在 iPhone「設定 → Parley」允許麥克風。Parley 只錄取房間麥克風，不會錄電話或其他 app 的系統音訊。</p>
+      <h3>同步失敗時錄音會不見嗎？</h3>
+      <p>不會。完成的錄音會先保存在 app 的安全佇列，成功同步才會移除。回到網路後開啟 app，或在「設定 → 同步」按下重試。</p>
+      <h3>如何查看或搬移錄音？</h3>
+      <p>到「錄音庫」選擇個人或組織範圍；長按一筆錄音即可移到資料夾、分享至組織、搬移至組織或刪除。</p>
+
+      <h2>English</h2>
+      <p>For sign-in, recording, sync, or account support, email <a href="mailto:contact@pathors.com">contact@pathors.com</a>. Include your app version, the time the issue occurred, and non-sensitive reproduction steps.</p>
+    </main>
+    <footer>© 2026 Pathors AI · <a href="../privacy/">Privacy</a></footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- make finished iOS recordings durable and automatically retry cloud sync
- add recording-consent, deletion, privacy, support, and App Store release guidance
- publish unified Parley privacy/support pages

## Validation
- `swift test` (19 tests)
- iPhone 17 Pro simulator build
