### PR TITLE
iOS: keep generated build number in sync

### DIFF
--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -22,6 +22,8 @@ targets:
       path: Parley/Info.plist
       properties:
         CFBundleDisplayName: Parley
+        CFBundleShortVersionString: "1.0"
+        CFBundleVersion: "2"
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: Parley listens to the meeting to transcribe and coach it live. Audio goes only to the transcription provider tied to your account.
         UIBackgroundModes: [audio]


### PR DESCRIPTION
Ensure xcodegen keeps `CFBundleVersion` at 2, matching the next TestFlight upload.

Validation: regenerated project and verified `Info.plist` is `1.0 (2)`.