### PR TITLE
[fix] Voice Typing overlay 出現在滑鼠所在螢幕，而非主視窗所在螢幕

### DIFF
--- a/src/lib/voiceTyping/overlay.test.ts
+++ b/src/lib/voiceTyping/overlay.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { bottomCenterPhysical, type MonitorGeometry } from "./overlay";
+
+// Mirrors the module's own constants (the overlay is 460x180 logical px and
+// clears the Dock by 64).
+const WIDTH = 460;
+const HEIGHT = 180;
+const BOTTOM_MARGIN = 64;
+
+function monitor(over: Partial<MonitorGeometry> = {}): MonitorGeometry {
+  return {
+    position: { x: 0, y: 0 },
+    size: { width: 1920, height: 1080 },
+    scaleFactor: 1,
+    ...over,
+  };
+}
+
+describe("bottomCenterPhysical", () => {
+  it("centres horizontally and clears the bottom by the margin (1x)", () => {
+    const { x, y } = bottomCenterPhysical(monitor());
+    expect(x).toBe((1920 - WIDTH) / 2);
+    expect(y).toBe(1080 - HEIGHT - BOTTOM_MARGIN);
+  });
+
+  it("scales the overlay's logical size on a Retina display", () => {
+    // 2x display: 3024x1964 physical = 1512x982 logical.
+    const { x, y } = bottomCenterPhysical(
+      monitor({ size: { width: 3024, height: 1964 }, scaleFactor: 2 }),
+    );
+    expect(x).toBe((3024 - WIDTH * 2) / 2);
+    expect(y).toBe(1964 - (HEIGHT + BOTTOM_MARGIN) * 2);
+  });
+
+  it("offsets by the monitor's origin, including displays left of primary", () => {
+    const { x, y } = bottomCenterPhysical(
+      monitor({ position: { x: -2560, y: -200 }, size: { width: 2560, height: 1440 } }),
+    );
+    expect(x).toBe(-2560 + (2560 - WIDTH) / 2);
+    expect(y).toBe(-200 + 1440 - HEIGHT - BOTTOM_MARGIN);
+  });
+
+  it("stays inside a small external display", () => {
+    const mon = monitor({ position: { x: 1920, y: 0 }, size: { width: 1280, height: 720 } });
+    const { x, y } = bottomCenterPhysical(mon);
+    expect(x).toBeGreaterThanOrEqual(mon.position.x);
+    expect(x + WIDTH).toBeLessThanOrEqual(mon.position.x + mon.size.width);
+    expect(y).toBeGreaterThanOrEqual(mon.position.y);
+    expect(y + HEIGHT).toBeLessThanOrEqual(mon.position.y + mon.size.height);
+  });
+
+  it("treats a missing scale factor as 1x rather than collapsing to the corner", () => {
+    const { x, y } = bottomCenterPhysical(monitor({ scaleFactor: 0 }));
+    expect(x).toBe((1920 - WIDTH) / 2);
+    expect(y).toBe(1080 - HEIGHT - BOTTOM_MARGIN);
+  });
+
+  it("returns integer physical pixels", () => {
+    const { x, y } = bottomCenterPhysical(
+      monitor({ size: { width: 1707, height: 1067 }, scaleFactor: 1.5 }),
+    );
+    expect(Number.isInteger(x)).toBe(true);
+    expect(Number.isInteger(y)).toBe(true);
+  });
+});

--- a/src/lib/voiceTyping/overlay.ts
+++ b/src/lib/voiceTyping/overlay.ts
@@ -1,6 +1,7 @@
 //! Lifecycle for the floating voice-typing overlay window: a transparent,
-//! always-on-top, non-focusing panel pinned to the bottom-centre of the active
-//! display. Created once (hidden) and shown/repositioned per dictation.
+//! always-on-top, non-focusing panel pinned to the bottom-centre of the display
+//! the mouse pointer sits on. Created once (hidden) and shown/repositioned per
+//! dictation.
 
 import { isTauri } from "../tauriEvents";
 import { log } from "../log";
@@ -62,19 +63,65 @@ async function ensureOverlay(): Promise<void> {
   }
 }
 
-/** Place the overlay at the bottom-centre of the active monitor (logical px). */
-async function positionBottomCenter(win: import("@tauri-apps/api/webviewWindow").WebviewWindow): Promise<void> {
-  const { currentMonitor, primaryMonitor, LogicalPosition } = await import("@tauri-apps/api/window");
-  const mon = (await currentMonitor()) ?? (await primaryMonitor());
-  if (!mon) return;
+/** The bits of Tauri's `Monitor` the geometry needs (physical px + scale). */
+export type MonitorGeometry = {
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+  scaleFactor: number;
+};
+
+/**
+ * Bottom-centre of `mon` for the WIDTH×HEIGHT (logical px) overlay, returned in
+ * PHYSICAL px.
+ *
+ * Physical rather than logical because Tauri converts a logical position using
+ * the window's CURRENT scale factor — which is still the old display's while
+ * the overlay is being moved onto another one. On a mixed-DPI setup (Retina +
+ * external 1x) that lands it at double/half the intended offset. Monitor
+ * geometry is already physical, so doing the whole calculation there sidesteps
+ * the conversion.
+ */
+export function bottomCenterPhysical(mon: MonitorGeometry): { x: number; y: number } {
   const scale = mon.scaleFactor || 1;
-  const monX = mon.position.x / scale;
-  const monY = mon.position.y / scale;
-  const monW = mon.size.width / scale;
-  const monH = mon.size.height / scale;
-  const x = Math.round(monX + (monW - WIDTH) / 2);
-  const y = Math.round(monY + monH - HEIGHT - BOTTOM_MARGIN);
-  await win.setPosition(new LogicalPosition(x, y));
+  return {
+    x: Math.round(mon.position.x + (mon.size.width - WIDTH * scale) / 2),
+    y: Math.round(mon.position.y + mon.size.height - (HEIGHT + BOTTOM_MARGIN) * scale),
+  };
+}
+
+/**
+ * The display the mouse pointer is on. That — not `currentMonitor()`, which
+ * reports where the MAIN WINDOW happens to live — is the screen the user is
+ * looking at when they start dictating. Resolved once per dictation (see
+ * showOverlay), so moving the mouse mid-sentence leaves the overlay put.
+ *
+ * Falls back to the old main-window/primary display when the pointer can't be
+ * located: a misplaced overlay still beats no overlay.
+ */
+async function overlayMonitor(): Promise<MonitorGeometry | null> {
+  const { currentMonitor, primaryMonitor, monitorFromPoint, cursorPosition } = await import(
+    "@tauri-apps/api/window"
+  );
+  try {
+    const cursor = await cursorPosition();
+    const mon = await monitorFromPoint(cursor.x, cursor.y);
+    if (mon) return mon;
+    log.warn("voice-typing: no monitor under cursor", { x: cursor.x, y: cursor.y });
+  } catch (error) {
+    log.warn("voice-typing: cursor monitor lookup failed", { error: String(error) });
+  }
+  return (await currentMonitor()) ?? (await primaryMonitor());
+}
+
+/** Place the overlay at the bottom-centre of the monitor under the cursor. */
+async function positionBottomCenter(
+  win: import("@tauri-apps/api/webviewWindow").WebviewWindow,
+): Promise<void> {
+  const { PhysicalPosition } = await import("@tauri-apps/api/window");
+  const mon = await overlayMonitor();
+  if (!mon) return;
+  const { x, y } = bottomCenterPhysical(mon);
+  await win.setPosition(new PhysicalPosition(x, y));
 }
 
 /** Reposition + show the overlay (creating it on first use). Shown natively via


### PR DESCRIPTION
Closes #182

## 問題

Voice Typing 浮動框用 `currentMonitor()` 定位。`currentMonitor()` 回的是**呼叫端視窗**（Parley 主視窗）所在的螢幕 —— 不是使用者正在看的那面。多螢幕時主視窗在 A、人在 B 螢幕打字，按下 fn 框框跑去 A，即時逐字稿等於看不到。

## 改動

`src/lib/voiceTyping/overlay.ts`

1. **螢幕來源改成游標**：`cursorPosition()` → `monitorFromPoint()`，取滑鼠所在螢幕的下方置中。取不到（非 macOS / API 失敗 / 座標不在任何螢幕上）就 fallback 回原本的 `currentMonitor()` → `primaryMonitor()`，不會因此不顯示。
2. **開啟當下鎖定，之後不跟隨**：位置本來就只在 `showOverlay()` 算一次，所以講到一半把滑鼠移到別的螢幕，框框整段錄音期間留在原地。這是刻意的行為，程式碼註解有寫清楚，避免之後有人「順手」改成每幀跟隨。
3. **`LogicalPosition` → `PhysicalPosition`**：logical 座標會用視窗**當前**螢幕的 scale factor 換算，而移動當下視窗還在舊螢幕上。混合 DPI（Retina + 外接 1x）會把 offset 算成兩倍或一半。monitor 幾何本來就是 physical，整段計算留在 physical 就沒有這個換算。
4. 幾何抽成純函式 `bottomCenterPhysical()`，補 6 條單元測試（1x / 2x / 螢幕在主螢幕左側的負座標 / 小螢幕不出界 / scaleFactor 為 0 的防呆 / 整數 px）。

```
按下 fn
  └─ showOverlay()
       ├─ cursorPosition() ──► monitorFromPoint() ──► 有螢幕？── 是 ─┐
       │                                                └─ 否 ──┐    │
       │                          currentMonitor() ?? primaryMonitor()│
       │                                                   └─────────┤
       └─ bottomCenterPhysical(mon) ──► setPosition(PhysicalPosition)◄┘
          （整段 dictation 只算這一次）
```

## 測試

- `bun run test` → 26 files / 244 tests 全綠（新增 6 條）。
- `tsc --noEmit` 乾淨。
- 多螢幕 + 混合 DPI 的實機行為需要手動確認：主視窗留在 A 螢幕、滑鼠移到 B 螢幕按下 fn，框框應該出現在 B 螢幕底部置中；講話中途把滑鼠移回 A，框框不動。
