### PR TITLE
[fix] iOS: nonisolated tokenKey — clear the Swift 6 actor-isolation warning

### DIFF
--- a/ios/App/Parley/AppState.swift
+++ b/ios/App/Parley/AppState.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// the token lives in the Keychain, never UserDefaults.
 @MainActor
 final class AppState: NSObject, ObservableObject {
-    static let tokenKey = "cloud-session-token"
+    nonisolated static let tokenKey = "cloud-session-token"
 
     @Published var user: CloudUser?
     @Published var quota: HostedQuota?


### PR DESCRIPTION
## What

\`AppState.tokenKey\` 是 \`@MainActor\` class 上的 static stored property，被 \`CloudClient\` 的 \`@Sendable\` tokenProvider closure 引用，每次 build 都噴：

> main actor-isolated static property 'tokenKey' can not be referenced from a Sendable closure; **this is an error in the Swift 6 language mode**

改成 \`nonisolated static let\`——它是不可變字串常數，本來就不需要 actor 隔離。

## 驗證

- Build 成功，該警告數量 1 → **0**
- 單行變更，不影響行為

🤖 Generated with [Claude Code](https://claude.com/claude-code)