### PR TITLE
[fix] 開始會議後 mic 被休眠的 system tap 卡住，逐字稿要到結束會議才出現

### DIFF
--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -258,6 +258,18 @@ fn run(tx: UnboundedSender<Vec<i16>>, running: Arc<AtomicBool>, app: &AppHandle)
             return Err(anyhow!("AudioDeviceCreateIOProcID failed: {status}"));
         }
         AudioDeviceStart(agg_id, proc_id);
+        // Kick the tap awake. A global process tap only starts ticking once
+        // SOME process renders audio; until then the tap-backed aggregate sits
+        // dormant, and (observed on macOS 15) coreaudiod wedges the START of
+        // the meeting's MIC stream behind the dormant device — nothing is
+        // captured or transcribed until the first system sound (or until stop
+        // tears the tap down, which is why transcripts appeared only after
+        // ending the meeting; issue reproduced with `stream.play()` blocking
+        // 34 s until a sound played, then returning within 150 ms of the tap's
+        // first IOProc frame). Rendering ~300 ms of silence from our own
+        // process gives the tap its first source; once ticking it keeps
+        // ticking (delivering silence) for the life of the tap.
+        std::thread::spawn(kick_system_output);
 
         // 6. Hold the device open until the meeting stops, then tear everything
         // down. Watchdog: an unauthorized tap "starts" fine but its IOProc never
@@ -350,6 +362,43 @@ unsafe fn tap_uuid_string(desc: *mut Object) -> String {
         return String::new();
     }
     CStr::from_ptr(cstr).to_string_lossy().into_owned()
+}
+
+/// Render ~300 ms of silence on the default output device so the process tap
+/// has a source and starts ticking (see the call site in [`run`]). Failures are
+/// logged and otherwise ignored — the tap then simply stays dormant until the
+/// first real system sound, which is the pre-kick behavior.
+fn kick_system_output() {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    let Some(dev) = cpal::default_host().default_output_device() else {
+        log::warn!("[system] tap kick: no default output device");
+        return;
+    };
+    let Ok(cfg) = dev.default_output_config() else {
+        log::warn!("[system] tap kick: no default output config");
+        return;
+    };
+    if cfg.sample_format() != cpal::SampleFormat::F32 {
+        log::warn!(
+            "[system] tap kick: unexpected output format {:?}; skipping",
+            cfg.sample_format()
+        );
+        return;
+    }
+    let cfg: cpal::StreamConfig = cfg.into();
+    match dev.build_output_stream(
+        &cfg,
+        |data: &mut [f32], _| data.fill(0.0),
+        |e| log::warn!("[system] tap kick stream error: {e}"),
+        None,
+    ) {
+        Ok(stream) => {
+            let _ = stream.play();
+            std::thread::sleep(Duration::from_millis(300));
+            drop(stream);
+        }
+        Err(e) => log::warn!("[system] tap kick: output stream failed: {e}"),
+    }
 }
 
 /// Query the tapped stream's sample rate.


### PR DESCRIPTION
## 問題

開始會議後錄音看似有在跑，但 transcribe 完全沒動；按「結束會議」後逐字稿反而才開始冒出來（#issue 報告：user log 中 7/28 的測試會議出現 `recording: too short to save (0 samples)`、transcript 只在 stop 後出現）。

## Root cause（macOS 15 實測重現）

1. Global process tap（`AudioHardwareCreateProcessTap`）在**沒有任何 process 正在播音訊**之前不會 tick — tap-backed aggregate device 建立後處於休眠狀態（`AudioDeviceStart` 正常返回但 IOProc 永不觸發，watchdog 因此報 "tap delivered no frames in 3s"）。
2. **coreaudiod 會把同 process 的 mic input stream 啟動卡在這個休眠裝置後面**：實測 mic 的 `stream.play()` 被 block **34 秒**，直到第一個系統聲音出現後 150ms 內才返回並開始 callback。
3. 結果：會議開始後 mic 完全沒有 PCM 流出 — 不錄音、不上傳 STT。直到 (a) 使用者播放任何系統音訊（如開視訊/影片），或 (b) 按結束會議，teardown 銷毀 aggregate/tap 解除 wedge — backlog 這時沖進 Soniox，**逐字稿在會議結束後才出現**。

7/20 的 86 分鐘會議正常，是因為會議開始時就有通話音訊在播（tap 立刻有 clock）；快速自測（只講話、不播任何系統聲音）就必中。

## 修法

Aggregate device 啟動後，從自己的 process 播 **~300ms 靜音**（`kick_system_output`，cpal output stream）。tap 拿到第一個 render source 就開始 tick，且實測**之後即使系統完全靜音也持續 tick**（送靜音 frames），mic 因此不再被 wedge。kick 失敗只 log warning，行為退回修復前。

（曾嘗試把 default output device 加進 aggregate 當 clock master（AudioCap 模式），實測無法喚醒休眠的 tap，故不採用。）

## 驗證（dev build、全靜音環境）

| | 修復前 | 修復後 |
|---|---|---|
| mic `stream.play()` | block 34s（直到系統有聲音） | 立即返回 |
| tap 首個 IOProc frame | 永不（直到系統有聲音） | kick 後 173ms |
| 20+ 秒靜音會議錄音 | **0 samples** | **22.1s / 24s wall** |
| 音訊上傳 Soniox | stop 後 backlog 一次沖出 | 即時（TX 1×） |

另用 Soniox API 直測錄下的音檔確認 STT 端正常（processed 58.8s audio）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)