### PR TITLE
[fix] intelligence board drew two bare dividers above the checklist

### DIFF
--- a/src/components/live/IntelligenceBoard.tsx
+++ b/src/components/live/IntelligenceBoard.tsx
@@ -160,8 +160,10 @@ export function ObjectionsLedger({
   if (!objections?.length) return null;
   const open = objections.filter((o) => !o.addressed);
   const addressed = objections.filter((o) => o.addressed);
+  // Each rail section below the board owns its own top rule (the board itself
+  // draws none) — so an absent section can never leave two stacked lines.
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-1 border-t pt-2">
       <div className="flex items-baseline gap-2">
         <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
           {open.length > 0

--- a/src/components/live/ScenarioBoard.tsx
+++ b/src/components/live/ScenarioBoard.tsx
@@ -148,7 +148,7 @@ export function ScenarioBoard({ scenario }: Readonly<{ scenario: Scenario }>) {
   }, [scenario.id, companyId, threadId, bundle.stage]);
 
   return (
-    <div className="flex flex-col gap-2 border-b pb-2.5">
+    <div className="flex flex-col gap-2">
       {/* Counter-the-challenge focus: outranks gap-chasing, one at a time. */}
       {focus?.kind === "objection" && (
         <FocusBanner label={t("board.stage.counter")} question={focus.question} reason={focus.reason} />


### PR DESCRIPTION
## The problem

With a scenario board active (e.g. sales) and no objections recorded, the right rail showed two parallel divider lines above the checklist with an empty band between them.

## Cause

- `ScenarioBoard`'s root carried `border-b pb-2.5`
- `TodosSection` carried `border-t pt-2`
- They are separated by `gap-3`, and `ObjectionsLedger` returns `null` when there are no objections

So with nothing between them, the board's bottom rule and the checklist's top rule stacked into an empty double-line band.

## The fix

Change the rule to "the board draws no line of its own; each rail section below it owns its own `border-t`":

- `ScenarioBoard`: drop `border-b pb-2.5` from the root
- `ObjectionsLedger`: add `border-t pt-2` to the root (unchanged visually when objections exist)

An absent section can no longer leave a stray line behind.

## Verification

Loaded the live view in browser dev (mock stream) and switched to the sales scenario: clean below the hint text, and the checklist keeps only its own `border-t`. `tsc` passes.