### PR TITLE
[fix] LevelMeter leaked a listener when cleanup beat listen() resolving

### DIFF
--- a/src/components/LevelMeter.tsx
+++ b/src/components/LevelMeter.tsx
@@ -25,11 +25,22 @@ export const LevelMeter = ({
 
   useEffect(() => {
     if (!isTauri()) return;
+    // listen() resolves async: when cleanup wins the race (StrictMode double
+    // effects, fast eventName/source flips), the subscription must be dropped
+    // ON resolution — the same late-unlisten pattern every other listener in
+    // the app uses (IngestWizard, Onboarding, VoiceDiarizeDialog…).
+    let alive = true;
     let unlisten: (() => void) | undefined;
     listen<LevelPayload>(eventName, (e) => {
       if (e.payload.source === source) setLevel(e.payload.level);
-    }).then((fn) => (unlisten = fn));
-    return () => unlisten?.();
+    }).then((u) => {
+      if (alive) unlisten = u;
+      else u();
+    });
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
   }, [eventName, source]);
 
   // Smoothly decay toward 0 when events stop arriving.


### PR DESCRIPTION
## The problem (the diagnosis in #193 was correct)

`LevelMeter` registered its listener with the old shape:

```ts
listen(...).then((fn) => (unlisten = fn));
return () => unlisten?.();
```

If cleanup runs before the promise resolves (StrictMode double effects, fast `eventName`/`source` flips), nothing ever calls the `unlisten` that arrives afterwards — the listener leaks and keeps calling `setLevel` on an unmounted component.

## The fix

Apply the alive-flag late-unlisten pattern every other listener in this codebase already uses (IngestWizard, Onboarding, VoiceDiarizeDialog).

## Sweep

Audited all nine `listen()` call sites. The other eight (SettingsApp, VoiceTypingApp's `track()`, InterpreterApp, Onboarding, IngestWizard, VoiceDiarizeDialog, settingsSync…) already handle late resolution correctly — **LevelMeter was the only one left**.

## Verification

`bunx tsc --noEmit` clean, 305 tests passing.

Closes #193. Supersedes #197 — see the note on that PR.