### PR TITLE
[docs] make English the working language of the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Something in Parley behaves incorrectly
+labels: bug
+---
+
+<!-- Please write in English — see CONTRIBUTING.md. -->
+
+## What happened
+
+## What you expected instead
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Parley version:
+- macOS version:
+- Apple silicon or Intel:
+
+## Logs
+
+<!--
+Diagnostics → View Logs (or the Diagnostics window) usually has the relevant lines.
+Please redact API keys and anything from a real meeting transcript.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest something Parley should do
+labels: feature
+---
+
+<!-- Please write in English — see CONTRIBUTING.md. -->
+
+## The problem
+
+<!-- What are you trying to do today, and where does Parley get in the way? -->
+
+## What you'd like instead
+
+## Alternatives you've considered
+
+## Anything else
+
+<!-- Mockups, links, or how you'd expect it to fit alongside the live coach / study view. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Please write in English — see CONTRIBUTING.md. The app is bilingual (zh-TW + en);
+the repository is not.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What is different after this PR? -->
+
+## Why
+
+<!-- The problem this solves. If it fixes an issue, write "Closes #123". -->
+
+## How it was verified
+
+<!-- Tick what you actually ran. -->
+
+- [ ] `bunx tsc --noEmit` passes
+- [ ] `bunx vitest run` passes
+- [ ] Ran the app (`bun run tauri dev`) and exercised the change
+- [ ] Added or updated tests
+- [ ] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts`
+
+## Screenshots
+
+<!-- For UI changes, before/after helps a lot. Delete this section otherwise. -->

--- a/.github/release-notes/v0.22.1.md
+++ b/.github/release-notes/v0.22.1.md
@@ -1,30 +1,30 @@
-App Shell 收斂:場景單一來源、兩個時態、Home 總覽,以及翻譯／匯入／公司連結三條入口的統一。
+App Shell cleanup: one source of truth for the meeting scenario, two clear tenses, a real Home overview, and three scattered entry points (translation, import, company linking) collapsed into one each.
 
-## 不再走進死路
+## No more dead ends
 
-- **錄音存檔後可以補掛公司了**。以前忘了在會前連結,那場會議就永遠進不了客戶戰情、會後審核按鈕也不會出現且不解釋。現在報告頁頂端就能掛上公司/戰線,掛完「審核入庫」立刻可用。
-- **會前準備不再被清空**。進入準備室不再抹掉上一次填的目標、議程與對象;要清空是選單裡的明確動作。
-- **會議中的按鈕誠實了**。錄音時錄音庫與設定會明確變灰並說明原因,不再是點了沒反應。
+- **You can link a recording to a company after the fact.** Previously, if you forgot to link before the call, that meeting could never reach the customer war room — the post-meeting review button simply never appeared, with no explanation. The report page now has a link bar; once linked, "review into war room" is immediately available.
+- **Meeting prep is no longer wiped.** Opening the prep room used to erase the goal, agenda, and attendees you set up last time. Prep is now a draft that survives; clearing it is an explicit menu action.
+- **Buttons are honest during a meeting.** While recording, the library and settings buttons are visibly disabled and say why, instead of looking clickable and doing nothing.
 
-## 開始會議有兩種速度
+## Two speeds for starting a meeting
 
-「開始會議」變成有選單的按鈕:趕時間就「直接開始」沿用上次的場景與連結,想準備就走準備室。
+"Start meeting" is now a split button: **Start now** reuses the current scenario and company link when you're already late, or take the prep room when you have time.
 
-## 一個首頁,而不是空的駕駛艙
+## A home screen, not an empty cockpit
 
-閒置時看到的是總覽:開始會議、待釐清的情報、最近的錄音、匯入。教練畫面只在真的開會時出現。左側的樹回歸單純導覽——建立公司改到區塊標題的 ＋,不再常駐在樹裡。
+When idle you now land on an overview — start a meeting, conflicting intel that needs attention, recent recordings, import. The coach view only appears when a meeting is actually running. The sidebar went back to being pure navigation: creating a company moved to a **+** on the section header instead of living permanently in the tree.
 
-## 入口收斂
+## Entry points collapsed
 
-- **翻譯**:標題列的 🌐 成為唯一入口,開關、目標語言、虛擬麥克風狀態、即時費用、浮動字幕、面對面翻譯都在裡面;會前畫面也能直接切換。
-- **匯入**:四個入口統一,任何一處都能收音檔與逐字稿;從公司頁匯入會自動歸戶。
-- **場景**:場景屬於「這一場會議」,會前選、會中可改、存檔後凍結、事後可覆寫重跑;設定裡只留一個預設值。客戶入口不再因為選了「通用」而整個消失。
+- **Translation** — the 🌐 button in the title bar is now the single door: master switch, target language, virtual microphone status, running cost, floating subtitles, and in-person translation all live there. The pre-flight screen can toggle it directly too.
+- **Import** — all four entry points now accept both audio files and text transcripts; importing from a company page files the recording under that company automatically.
+- **Scenario** — the scenario belongs to *this meeting*: pick it before, change it during, frozen on save, override and re-run afterwards. Settings keeps only a default. The customer entry no longer disappears because the scenario is set to "general".
 
-## 修正
+## Fixes
 
-- 情報板在沒有異議時,待辦上方會出現兩條裸露的分隔線。
-- 系統音訊沒收到時改為常駐提示——原本的十秒提示在使用者發現對方沒聲音前就消失了。
-- 取消匯入後會殘留上一次的公司連結。
-- 自動分析的間隔設定在教練版面看不到。
-- 會前從歷史會議跳走時,已選好的公司與出席者會被無聲丟棄。
-- 設定加入搜尋(中英皆可,例如「金鑰」「mic」)。
+- The intelligence board drew two bare divider lines above the checklist when there were no objections.
+- A failed system-audio tap now shows a persistent warning — the old 10-second toast was gone long before anyone noticed the other party was silent.
+- Cancelling an import left the previous company link attached.
+- The auto-analysis interval was invisible in the coach layout.
+- Jumping to a past meeting from the prep screen silently discarded the company and attendees you had chosen.
+- Settings gained search (works in both languages, e.g. "key" or "mic").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Parley — repository conventions
+
+Parley is a public, Apache-2.0 macOS app (Tauri 2 + React 19 + TypeScript). Anyone should be able to read the history and contribute, so the repository is kept in one language regardless of who — or what — is writing.
+
+## Write English in the repository
+
+**Everything that lands in the repo or on GitHub is written in English:**
+
+- commit messages
+- pull request titles, descriptions, and review comments
+- issue titles and bodies
+- code comments and identifiers
+- release notes (`.github/release-notes/*.md`) and anything published to the Releases page
+- documentation (`README.md`, `CONTRIBUTING.md`, `docs/**`)
+
+This holds even when the conversation that produced the change happened in another language — translate on the way in. A contributor who lands on issue #42 should not need a translator to pick it up.
+
+## The app itself is bilingual
+
+Repository English does *not* mean an English-only product. Every user-facing string lives in `src/i18n/messages.ts` and **must** have both a `zh-TW` and an `en` entry — the Traditional Chinese entry is first-class, not a translation afterthought. Never hard-code display text in a component, including in the secondary windows (settings, interpreter, voice-typing, diagnostics).
+
+The app defaults to `zh-TW`. Page titles and the language switcher itself are translated too.
+
+## Commit messages
+
+Prefix with the kind of change, then say what changed:
+
+```
+[fix] LevelMeter leaked a listener when cleanup beat listen() resolving
+[feature] link a recording to a company after the fact
+[refactor] scenario becomes per-meeting state instead of a global setting
+```
+
+Use `[fix]`, `[feature]`, `[refactor]`, `[chore]`, or `[docs]`. Explain *why* in the body when the diff doesn't make it obvious.
+
+## Before opening a PR
+
+`bunx tsc --noEmit` and `bunx vitest run` must both pass. Add an i18n key to both dictionaries whenever you add user-facing text.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for your interest in contributing to Parley! We welcome community contributions to help improve the project.
 
+## Language
+
+**English is the working language of this repository.** Issues, pull requests, commit messages, code comments, and release notes are all written in English so that anyone can read the history and join in.
+
+This applies to the repository only. The application itself ships in both Traditional Chinese and English — see `src/i18n/messages.ts`, where every user-facing string must have a `zh-TW` and an `en` entry. Never hard-code display text in a component.
+
 ## How to Contribute
 
 ### Reporting Bugs
@@ -14,8 +20,27 @@ Thank you for your interest in contributing to Parley! We welcome community cont
 ### Submitting Pull Requests
 1. Fork the repository and create your branch from `main`.
 2. Ensure the project builds and runs locally (`bun run tauri dev`).
-3. Commit your changes with clear, descriptive commit messages.
-4. Submit your pull request.
+3. Check your work: `bunx tsc --noEmit` and `bunx vitest run` must both pass.
+4. Commit your changes with clear, descriptive commit messages.
+5. Submit your pull request.
+
+### Commit messages
+
+Prefix the subject with the kind of change, then say what changed in plain English:
+
+```
+[fix] LevelMeter leaked a listener when cleanup beat listen() resolving
+[feature] link a recording to a company after the fact
+[refactor] scenario becomes per-meeting state instead of a global setting
+[chore] bump onnxruntime to 1.20
+[docs] document the release process
+```
+
+Use `[fix]`, `[feature]`, `[refactor]`, `[chore]`, or `[docs]`. Explain *why* in the body when the reason isn't obvious from the diff.
+
+### A note on bounties
+
+We don't pay bounties, per-fix donations, or pay-on-merge arrangements, and we won't merge pull requests that attach payment terms. Contributions are welcome on the usual volunteer terms.
 
 ## Local Development
 


### PR DESCRIPTION
## Why

Parley is public and Apache-2.0, but the repository had drifted into a mix of Chinese and English — issues, PR descriptions, and commit subjects. That is readable to the current team and opaque to anyone else who might want to contribute.

## What this changes

- **CONTRIBUTING.md** — states the language rule, documents the commit-message format, lists the checks to run before opening a PR, and notes that we don't do bounties or pay-on-merge arrangements (see #197).
- **CLAUDE.md** (new) — the same rule for AI sessions working in this repo. Without it they inherit a Chinese-language global config and keep reintroducing the drift, which is what happened here.
- **`.github/pull_request_template.md`** and **`.github/ISSUE_TEMPLATE/`** (new) — a starting shape for contributors, including the reminder that any new user-facing string needs both a `zh-TW` and an `en` entry.
- **`.github/release-notes/v0.22.1.md`** — translated; the published release body has been updated to match.

## The rule is repository-only

The app stays bilingual. `src/i18n/messages.ts` must carry both a `zh-TW` and an `en` entry for every user-facing string, zh-TW remains first-class, and the app still defaults to it. Only the repository — the part outside contributors read — is English.

## Also done outside this diff

- All 11 open issues with Chinese titles or bodies were translated in place (terminology aligned with the codebase, e.g. "accounts area" after the `accounts/` directory).
- PRs #198, #203, and #204 were retitled and their descriptions translated.

**Not done:** rewriting commit messages already on `main`. That would mean a force-push to a public branch, breaking every existing clone and fork — precisely the wrong move right before inviting contributors. History stays as it is; everything from here is English.