### PR TITLE
[fix] Settings opens as its own window again; Home gets a staged entrance

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { stopMockStream } from "../lib/mockStream";
 import { isTauri } from "../lib/tauriEvents";
 import { beginMeeting } from "../lib/meeting/start";
+import { openSettings } from "../lib/nav";
 import { useI18n } from "../i18n";
 import { Button } from "@/components/ui/button";
 import {
@@ -430,8 +431,8 @@ function PrimaryAction({
       </Button>
     );
   }
-  // "accounts", "library" and "settings" have no exit button: the tree beside
-  // them is always on screen, so leaving is picking somewhere else (#195).
+  // "accounts" and "library" have no exit button: the tree beside them is
+  // always on screen, so leaving is picking somewhere else (#195).
   if (mode === "preflight") {
     // Starting happens in the pre-flight footer, next to what it commits to;
     // up here there is only the way back out.
@@ -552,7 +553,6 @@ export function TitleBar({ fullscreen = false }: Readonly<{ fullscreen?: boolean
   const exitReplay = useStore((s) => s.exitReplay);
   const openAccounts = useStore((s) => s.openAccounts);
   const openLibrary = useStore((s) => s.openLibrary);
-  const openSettingsRoute = useStore((s) => s.openSettings);
   const showReplay = useStore((s) => s.showReplay);
   const replayName = useStore((s) => s.replay?.name ?? null);
   const enterPreflight = useStore((s) => s.enterPreflight);
@@ -858,13 +858,12 @@ export function TitleBar({ fullscreen = false }: Readonly<{ fullscreen?: boolean
             language, HUD pop-out, the standalone window and the settings link. */}
         <TranslateMenu />
 
-        {/* History and Settings are ROUTES in this window now (#195). While a
-            meeting runs the screen belongs to the call, so these two are
-            HONESTLY disabled (R2) — greyed with a reason — instead of looking
-            clickable and silently doing nothing. */}
-        {/* The wrapping spans exist because a disabled button has
-            pointer-events:none — the reason-tooltip must live on a hoverable
-            parent or it never shows. */}
+        {/* History is a ROUTE in this window (#195). While a meeting runs the
+            screen belongs to the call, so it is HONESTLY disabled (R2) —
+            greyed with a reason — instead of looking clickable and silently
+            doing nothing. The wrapping span exists because a disabled button
+            has pointer-events:none — the reason-tooltip must live on a
+            hoverable parent or it never shows. */}
         <span title={meetingActive ? t("titlebar.lockedWhileMeeting") : t("titlebar.history")}>
           <Button
             size="icon"
@@ -878,20 +877,21 @@ export function TitleBar({ fullscreen = false }: Readonly<{ fullscreen?: boolean
           </Button>
         </span>
 
-        <span title={meetingActive ? t("titlebar.lockedWhileMeeting") : t("common.settings")}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-8 w-8"
-            aria-label={t("common.settings")}
-            disabled={meetingActive}
-            // Arrow, not a bare reference: openSettings takes an optional
-            // category, and a passed-through MouseEvent would land in it.
-            onClick={() => openSettingsRoute()}
-          >
-            <Settings className="size-4" />
-          </Button>
-        </span>
+        {/* Settings is its own OS window, so unlike History it never takes the
+            screen from a live call — no meeting lock. This gear is the ONE
+            settings entry in the app (the sidebar deliberately has none). */}
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8"
+          aria-label={t("common.settings")}
+          title={t("common.settings")}
+          // Arrow, not a bare reference: openSettings takes an optional
+          // category, and a passed-through MouseEvent would land in it.
+          onClick={() => openSettings()}
+        >
+          <Settings className="size-4" />
+        </Button>
       </div>
     </header>
   );

--- a/src/components/TranslateMenu.tsx
+++ b/src/components/TranslateMenu.tsx
@@ -7,6 +7,7 @@ import { isTauri } from "../lib/tauriEvents";
 import { log } from "../lib/log";
 import { formatElapsed, translateCostUsd, useMeetingTranslateElapsed } from "../lib/translateCost";
 import { openInterpreterWindow, openLiveTranslateWindow } from "../lib/liveTranslate";
+import { openSettings } from "../lib/nav";
 import { useI18n } from "../i18n";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -59,7 +60,6 @@ export function TranslateMenu() {
   const { t } = useI18n();
   const enabled = useStore((s) => s.settings.meetingTranslateEnabled);
   const status = useStore((s) => s.meetingStatus);
-  const openSettingsRoute = useStore((s) => s.openSettings);
   const meetingActive = status === "recording" || status === "paused";
   const { active: translating, elapsedSec } = useMeetingTranslateElapsed();
   const [open, setOpen] = useState(false);
@@ -152,12 +152,12 @@ export function TranslateMenu() {
         </div>
 
         <div className="border-t p-1">
+          {/* Settings opens as its own OS window, so it works mid-call too —
+              no meeting lock, unlike the routes that would take the screen. */}
           <MenuAction
             icon={Settings2}
-            disabled={meetingActive}
-            hint={t("titlebar.lockedWhileMeeting")}
             onClick={() => {
-              openSettingsRoute("translate");
+              openSettings("translate");
               setOpen(false);
             }}
           >

--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -36,11 +36,16 @@ export function HomeScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
   const recent = tree.summaries.slice(0, 6);
   const locale = language === "en" ? "en-US" : "zh-TW";
 
+  // Staged entrance: sections land in reading order (start → triage → recent),
+  // then the recent rows cascade. Delays are inline so the sequence stays put
+  // when a section is conditionally absent.
+  const delay = (ms: number) => ({ animationDelay: `${ms}ms` });
+
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto flex max-w-2xl flex-col gap-8 px-6 py-10">
         {/* ── Start ─────────────────────────────────────────────────────── */}
-        <section className="flex flex-col gap-3">
+        <section className="animate-fade-up flex flex-col gap-3">
           <h1 className="text-lg font-semibold">
             {userName ? t("home.greetingNamed", { name: userName }) : t("home.greeting")}
           </h1>
@@ -83,7 +88,7 @@ export function HomeScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
 
         {/* ── Triage backlog: conflicts queue, they must stay visible ────── */}
         {triage.length > 0 && (
-          <section className="flex flex-col gap-1.5">
+          <section className="animate-fade-up flex flex-col gap-1.5" style={delay(90)}>
             <h2 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
               {t("home.triage")}
             </h2>
@@ -106,15 +111,21 @@ export function HomeScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
 
         {/* ── Recent recordings ───────────────────────────────────────────── */}
         <section className="flex flex-col gap-1.5">
-          <h2 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+          <h2
+            className="animate-fade-up text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
+            style={delay(180)}
+          >
             {t("home.recent")}
           </h2>
           {recent.length === 0 && (
-            <p className="rounded-md border border-dashed px-3 py-6 text-center text-xs text-muted-foreground">
+            <p
+              className="animate-fade-up rounded-md border border-dashed px-3 py-6 text-center text-xs text-muted-foreground"
+              style={delay(220)}
+            >
               {t("home.emptyRecordings")}
             </p>
           )}
-          {recent.map((e) => {
+          {recent.map((e, i) => {
             const company = e.companyId
               ? acc.companies.find((c) => c.id === e.companyId)
               : undefined;
@@ -128,7 +139,8 @@ export function HomeScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
                     toast.error(String(err instanceof Error ? err.message : err));
                   })
                 }
-                className="flex cursor-pointer items-center gap-2.5 rounded-md border px-3 py-2 text-left transition-colors hover:bg-muted/50"
+                className="animate-fade-up flex cursor-pointer items-center gap-2.5 rounded-md border px-3 py-2 text-left transition-colors hover:bg-muted/50"
+                style={delay(220 + i * 40)}
               >
                 <FileAudio className="size-4 shrink-0 text-muted-foreground" />
                 <span className="flex min-w-0 flex-1 flex-col">

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -21,10 +21,6 @@ const PreflightScreen = lazy(() =>
 const LibraryScreen = lazy(() =>
   import("../library/LibraryScreen").then((m) => ({ default: m.LibraryScreen }))
 );
-const SettingsApp = lazy(() =>
-  import("../../settings/SettingsApp").then((m) => ({ default: m.SettingsApp }))
-);
-
 /**
  * The app shell (issue #195): one persistent left tree, and the route beside it.
  *
@@ -33,8 +29,9 @@ const SettingsApp = lazy(() =>
  *   - a RUNNING meeting (the live coach owns the window; the account dossier is
  *     still reachable mid-call through the titlebar sheet), and
  *   - pre-flight, which is a focused three-column commitment to one call.
- * Everything else — live idle, a loaded recording, a company, the library,
- * settings — keeps the tree on screen, so nothing is a mode you have to exit.
+ * Everything else — live idle, a loaded recording, a company, the library —
+ * keeps the tree on screen, so nothing is a mode you have to exit. (Settings is
+ * not a route here: it opens as its own OS window, see lib/nav.ts.)
  */
 export function AppShell() {
   const appMode = useStore((s) => s.appMode);
@@ -102,13 +99,6 @@ function RouteContent({
     return (
       <Suspense fallback={null}>
         <LibraryScreen tree={tree} />
-      </Suspense>
-    );
-  }
-  if (mode === "settings") {
-    return (
-      <Suspense fallback={null}>
-        <SettingsApp embedded />
       </Suspense>
     );
   }

--- a/src/components/shell/AppSidebar.tsx
+++ b/src/components/shell/AppSidebar.tsx
@@ -11,7 +11,6 @@ import {
   Mic,
   Pencil,
   Plus,
-  Settings,
   Swords,
   Trash2,
   UsersRound,
@@ -52,7 +51,6 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
   const selection = useStore((s) => s.librarySelection);
   const openAccounts = useStore((s) => s.openAccounts);
   const openLibrary = useStore((s) => s.openLibrary);
-  const openSettings = useStore((s) => s.openSettings);
   const openHome = useStore((s) => s.openHome);
   const enterPreflight = useStore((s) => s.enterPreflight);
 
@@ -394,14 +392,6 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
         </>
       )}
 
-      <div className="mt-auto shrink-0 pt-2">
-        <Row
-          icon={<Settings className="size-3.5" />}
-          label={t("common.settings")}
-          active={appMode === "settings"}
-          onSelect={openSettings}
-        />
-      </div>
     </nav>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -186,6 +186,28 @@ textarea,
   }
 }
 
+/* Staged entrance for landing surfaces (Home): each block fades up in reading
+   order, sequenced by an inline animation-delay. `both` keeps a delayed block
+   invisible until its turn instead of flashing in at full opacity first. */
+@keyframes fade-up-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-fade-up {
+  animation: fade-up-in 0.4s ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up {
+    animation: none;
+  }
+}
+
 /* Cursor behaviour: interactive controls (buttons, tabs, dropdown triggers
    and items, links, and custom role="button" elements) use the pointing-hand
    cursor. Text inputs keep their default I-beam; disabled controls do not. */

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,4 +1,4 @@
-import { useStore } from "./store";
+import type { SettingsCategory } from "./store";
 import { openSettingsWindow } from "./settingsSync";
 import { log } from "./log";
 
@@ -6,28 +6,12 @@ import { log } from "./log";
  * Where "go somewhere else in the app" is decided — one module, so a call site
  * never has to know whether a destination is a route in this window or its own
  * OS window.
- *
- * The main window navigates in place (issue #195: the recordings library and
- * Settings stopped being separate windows, so the company tree and the folder
- * tree are one tree). A SECONDARY window has no shell to navigate into, so it
- * still opens the standalone Settings window.
  */
 
-/** True in the main window. Reads the marker main.tsx stamps on <html> when it
- *  routes the bundle, so this can't drift from that routing table. */
-function inMainWindow(): boolean {
-  return document.documentElement.dataset.appWindow !== undefined
-    ? document.documentElement.dataset.appWindow === "main"
-    : !window.location.hash.replace(/^#/, "");
-}
-
-/** Open Settings — a route in the main window, a window everywhere else. */
-export function openSettings(): void {
-  if (inMainWindow()) {
-    useStore.getState().openSettings();
-    return;
-  }
-  openSettingsWindow().catch((error) =>
+/** Open Settings — its own OS window, from any window. `category` deep-links a
+ *  nav panel (e.g. the titlebar 🌐 menu → 翻譯). */
+export function openSettings(category?: SettingsCategory): void {
+  openSettingsWindow(category).catch((error) =>
     log.error("settings: open window failed", { error: String(error) })
   );
 }

--- a/src/lib/settingsSync.ts
+++ b/src/lib/settingsSync.ts
@@ -1,5 +1,5 @@
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { useStore } from "./store";
+import { useStore, type SettingsCategory } from "./store";
 import { isTauri } from "./tauriEvents";
 import { log } from "./log";
 import type { Settings } from "./types";
@@ -7,25 +7,32 @@ import type { CloudAuth } from "./cloud/types";
 
 const SETTINGS_EVENT = "settings://updated";
 
+/** Deep-link broadcast for an ALREADY-open Settings window: the payload is the
+ *  nav category to jump to (a fresh window gets it via the URL hash instead). */
+export const SETTINGS_NAVIGATE_EVENT = "settings://navigate";
+
 /**
  * Open (or focus) the dedicated Settings window. It loads the same bundle at the
- * `#settings` hash, which main.tsx routes to <SettingsApp/>. Falls back to a hash
+ * `#settings` hash (optionally `#settings/<category>` to land on a specific nav
+ * panel), which main.tsx routes to <SettingsApp/>. Falls back to a hash
  * navigation when not running under Tauri (plain browser dev).
  */
-export async function openSettingsWindow(): Promise<void> {
+export async function openSettingsWindow(category?: SettingsCategory): Promise<void> {
+  const hash = category ? `settings/${category}` : "settings";
   if (!isTauri()) {
-    window.location.hash = "settings";
+    window.location.hash = hash;
     return;
   }
   const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
   const existing = await WebviewWindow.getByLabel("settings");
-  log.info("settings: open window", { existing: !!existing });
+  log.info("settings: open window", { existing: !!existing, category });
   if (existing) {
     await existing.setFocus();
+    if (category) await emit(SETTINGS_NAVIGATE_EVENT, category);
     return;
   }
   const win = new WebviewWindow("settings", {
-    url: "index.html#settings",
+    url: `index.html#${hash}`,
     title: "Parley Settings",
     width: 880,
     height: 760,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -168,10 +168,12 @@ const DEFAULT_SETTINGS: Settings = {
  * screen (except while a meeting owns it), so "accounts" and "library" are two
  * views of the same tree rather than two windows.
  *
- * "library" (the recordings grid) and "settings" used to be their own OS
- * windows. Two windows meant two sidebars — a company tree here, a folder tree
- * there — which is why the company a meeting was linked to and the folder it
- * saved into read as unrelated things even though the data layer pairs them 1:1.
+ * "library" (the recordings grid) used to be its own OS window. Two windows
+ * meant two sidebars — a company tree here, a folder tree there — which is why
+ * the company a meeting was linked to and the folder it saved into read as
+ * unrelated things even though the data layer pairs them 1:1. Settings is NOT
+ * a route: it is its own OS window (lib/nav.ts → openSettingsWindow), so
+ * tweaking a knob never navigates the shell away from what it was showing.
  */
 export type AppMode =
   | "home"
@@ -179,10 +181,9 @@ export type AppMode =
   | "live"
   | "study"
   | "accounts"
-  | "library"
-  | "settings";
+  | "library";
 
-/** Left-nav panels of the Settings route (see settings/SettingsApp.tsx). */
+/** Left-nav panels of the Settings window (see settings/SettingsApp.tsx). */
 export type SettingsCategory =
   | "basic"
   | "account"
@@ -587,12 +588,6 @@ interface ParleyState {
   /** Show the recordings library at `selection` (blocked while recording). */
   openLibrary: (selection: LibrarySelection) => void;
   librarySelection: LibrarySelection;
-  /** Show Settings as a route in this window (blocked while recording).
-   *  `category` deep-links a nav panel (e.g. the titlebar 🌐 menu → 翻譯). */
-  openSettings: (category?: SettingsCategory) => void;
-  /** One-shot deep-link target for the Settings route — SettingsApp consumes
-   *  (and clears) it on arrival, so later manual nav isn't overridden. */
-  settingsCategory: SettingsCategory | null;
   /** Go back to the recording that is already loaded. Navigating the tree away
    *  from a loaded recording used to strand it: nothing on screen still pointed
    *  at it, and only exitReplay (which THROWS IT AWAY) was reachable. */
@@ -655,7 +650,6 @@ export const useStore = create<ParleyState>()(
   persist(
     (set) => ({
       appMode: "home",
-      settingsCategory: null,
       accountsCompanyId: null,
       accountsFocus: "intel",
       librarySelection: { kind: "personal", folderId: null },
@@ -760,12 +754,6 @@ export const useStore = create<ParleyState>()(
   openLibrary: (librarySelection) =>
     set((s) =>
       isMeetingActive(s.meetingStatus) ? {} : { appMode: "library", librarySelection }
-    ),
-  openSettings: (category) =>
-    set((s) =>
-      isMeetingActive(s.meetingStatus)
-        ? {}
-        : { appMode: "settings", settingsCategory: category ?? null }
     ),
   showReplay: () => set((s) => (s.replay ? { appMode: "study" } : {})),
   setNegotiationField: (field, value) => set({ [field]: value }),

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -9,7 +9,7 @@ import { log } from "../lib/log";
 import { Check, Download, Loader2, LogIn, LogOut, Monitor, Moon, PlugZap, Plus, ScrollText, Sun, Trash2 } from "lucide-react";
 import { useStore } from "../lib/store";
 import { LANGUAGE_OPTIONS, useI18n, type TranslationKey } from "../i18n";
-import { broadcastSettings } from "../lib/settingsSync";
+import { broadcastSettings, SETTINGS_NAVIGATE_EVENT } from "../lib/settingsSync";
 import { signInWithGoogle, signOut, CloudError } from "../lib/cloud/client";
 import { CLOUD_ENABLED } from "../lib/flags";
 import { Flag } from "../components/ui/flag";
@@ -105,28 +105,42 @@ const NAV: {
   { id: "usage", labelKey: "settings.nav.usage", keywordsKey: "settings.kw.usage" },
 ];
 
+/** The nav panel a `#settings/<category>` deep-link hash asks for, if valid. */
+function categoryFromHash(): Category | null {
+  const seg = window.location.hash.replace(/^#settings\/?/, "");
+  return NAV.some((n) => n.id === seg) ? (seg as Category) : null;
+}
+
 /**
- * Settings. Renders both as its own OS window (`#settings`, still how a
- * SECONDARY window reaches it) and — since #195 — as a route inside the main
- * window's shell. `embedded` is the difference between the two: a route fills
- * the pane it was given and leaves the window chrome, the toaster and the
- * release-notes dialog to the shell that already owns them.
+ * Settings — its own OS window (`#settings`), opened from any window via
+ * lib/nav.ts. Deep-links land on a specific nav panel two ways: a fresh window
+ * reads the category off its URL hash; an already-open window gets it pushed
+ * over the `settings://navigate` event.
  */
-export function SettingsApp({ embedded = false }: Readonly<{ embedded?: boolean }> = {}) {
+export function SettingsApp() {
   const { t } = useI18n();
   useThemePreference();
 
   const settings = useStore((s) => s.settings);
   const updateSettings = useStore((s) => s.updateSettings);
-  const [cat, setCat] = useState<Category>("basic");
-  // Deep-link from another surface (openSettings("translate") etc): jump to
-  // the requested panel once, then clear so manual nav isn't overridden.
-  const requestedCat = useStore((s) => s.settingsCategory);
+  const [cat, setCat] = useState<Category>(() => categoryFromHash() ?? "basic");
   useEffect(() => {
-    if (!requestedCat) return;
-    setCat(requestedCat);
-    useStore.setState({ settingsCategory: null });
-  }, [requestedCat]);
+    if (!isTauri()) return;
+    // Guard the cleanup-beats-listen() race: if unmount wins, detach the
+    // listener the moment the promise resolves instead of leaving it attached.
+    let active = true;
+    let unlisten: (() => void) | undefined;
+    listen<Category>(SETTINGS_NAVIGATE_EVENT, (e) => {
+      if (NAV.some((n) => n.id === e.payload)) setCat(e.payload);
+    }).then((un) => {
+      if (active) unlisten = un;
+      else un();
+    }).catch((error) => log.warn("settings: navigate listener failed", { error: String(error) }));
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
   // Nav search (⑥): label OR translated keywords, so "金鑰"/"key" finds the
   // provider panel and "麥克風"/"mic" finds transcription.
   const [navQuery, setNavQuery] = useState("");
@@ -288,12 +302,8 @@ export function SettingsApp({ embedded = false }: Readonly<{ embedded?: boolean 
   }
 
   return (
-    <div
-      className={`flex bg-background text-foreground ${
-        embedded ? "min-h-0 flex-1" : "h-screen"
-      }`}
-    >
-      {!embedded && <Toaster />}
+    <div className="flex h-screen bg-background text-foreground">
+      <Toaster />
       {releaseNotes && (
         <ReleaseNotesDialog
           notes={releaseNotes}
@@ -477,9 +487,7 @@ export function SettingsApp({ embedded = false }: Readonly<{ embedded?: boolean 
                   patch({ onboarded: false, onboardingStep: 0 });
                   // The onboarding renders on the MAIN window — bring it forward
                   // and close this Settings window so it isn't hidden behind it.
-                  // Embedded, Settings IS the main window: onboarding already
-                  // covers it, so there is nothing to focus or close.
-                  if (embedded || !isTauri()) return;
+                  if (!isTauri()) return;
                   try {
                     const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
                     const { getCurrentWindow } = await import("@tauri-apps/api/window");


### PR DESCRIPTION
## What

Three UX complaints in one pass:

1. **Settings is its own OS window again.** Since #195 it rendered as a route inside the main shell, so opening it navigated the shell away from whatever it was showing. `openSettings` (lib/nav.ts) now always opens the dedicated `settings` window; the `appMode: "settings"` route, its store action, and `SettingsApp`'s `embedded` prop are removed.
2. **One settings entry instead of two.** The sidebar's bottom Settings row is gone; the titlebar gear is the single entry. Since a separate window never takes the screen from a live call, the gear (and the translate-menu deep-link) no longer lock during a meeting — History keeps its lock because it is still a route.
3. **Staged fade-in on Home.** Sections fade up in reading order (start → triage → recent), then the recent rows cascade at 40ms steps. `prefers-reduced-motion` disables it.

## How deep-links survive the window boundary

A fresh Settings window reads `#settings/<category>` off its URL hash; an already-open window gets the category pushed over a `settings://navigate` Tauri event (listener guarded against the cleanup-beats-listen race, cf. #204).

## Verified

- `bunx tsc --noEmit` and `bunx vitest run` (305 tests) both pass.
- Browser preview: Home entrance animation applies with the expected delays; `#settings/translate` lands on the 即時翻譯 panel; sidebar has no settings row; titlebar has exactly one gear.