### PR TITLE
[fix] iOS: sign-in gate on launch, and a record button that is never dead

### DIFF
--- a/ios/App/Parley/AppState.swift
+++ b/ios/App/Parley/AppState.swift
@@ -17,6 +17,19 @@ final class AppState: NSObject, ObservableObject {
     @Published var signInError: String?
     @Published var pendingUploadCount = MeetingUploader.pendingCount
 
+    /// False only until the stored session has been read out of the Keychain —
+    /// which is synchronous, so this is true within the first frame. The root
+    /// view waits on it so a returning user never sees the sign-in wall flash by
+    /// before the app decides. It deliberately does NOT wait on the network.
+    @Published var bootstrapped = false
+
+    /// Whether this device holds a session token at all. Distinct from
+    /// `signedIn`, which additionally requires a successful `me()`: on a flaky
+    /// network `me()` fails but the session is deliberately kept (see
+    /// `refreshSession()`), and gating the UI on `signedIn` alone would show the
+    /// sign-in wall to someone who is already signed in and merely offline.
+    @Published private(set) var hasStoredSession = KeychainStore.get(AppState.tokenKey) != nil
+
     @AppStorage("theme") var themeRaw: String = AppTheme.system.rawValue
     /// JSON-encoded `SaveDestination` (mirror of desktop `defaultSaveLocation`).
     @AppStorage("defaultSaveLocation") private var defaultSaveRaw: String = ""
@@ -36,7 +49,12 @@ final class AppState: NSObject, ObservableObject {
             objectWillChange.send()
         }
     }
+    /// Identity is confirmed — cloud reads and uploads can be attempted.
     var signedIn: Bool { user != nil }
+
+    /// This device has an account. The gate and the record button use this, not
+    /// `signedIn`, so being offline is never mistaken for being signed out.
+    var hasAccount: Bool { user != nil || hasStoredSession }
 
     private(set) lazy var cloud = CloudClient {
         KeychainStore.get(AppState.tokenKey)
@@ -49,17 +67,28 @@ final class AppState: NSObject, ObservableObject {
     /// session so flaky connectivity never signs the user out.
     func refreshSession() async {
         pendingUploadCount = MeetingUploader.pendingCount
-        guard KeychainStore.get(Self.tokenKey) != nil else { return }
+
+        // Decide the gate from the Keychain alone, before any await: it is
+        // instant and always right about whether this device has an account.
+        // Waiting on `me()` first would park a returning user behind a spinner
+        // for as long as URLSession's timeout whenever the network is bad —
+        // exactly the condition where they most want to just hit record.
+        let token = KeychainStore.get(Self.tokenKey)
+        hasStoredSession = token != nil
+        bootstrapped = true
+        guard token != nil else { return }
+
         do {
             user = try await cloud.me()
-            if user == nil { KeychainStore.delete(Self.tokenKey) }
+            if user == nil { clearStoredToken() }
             await loadAccountExtras()
             await syncPendingUploads()
         } catch let err as CloudError where err.isAuthExpired {
-            KeychainStore.delete(Self.tokenKey)
+            clearStoredToken()
             user = nil
         } catch {
-            // offline — keep the session
+            // Offline or the server is unreachable: keep the session. The token
+            // is still good, so `hasAccount` stays true and the app stays usable.
         }
     }
 
@@ -89,21 +118,61 @@ final class AppState: NSObject, ObservableObject {
                     return
                 }
                 guard let callbackURL else { return }
-                do {
-                    let token = try CloudClient.token(fromCallback: callbackURL)
-                    KeychainStore.set(token, for: Self.tokenKey)
-                    self.user = try await self.cloud.me()
-                    await self.loadAccountExtras()
-                    await self.syncPendingUploads()
-                } catch {
-                    self.signInError = "登入失敗：\(error.localizedDescription)"
-                }
+                await self.completeSignIn(callbackURL: callbackURL)
             }
         }
         session.presentationContextProvider = self
         session.prefersEphemeralWebBrowserSession = false
         webAuth = session
         session.start()
+    }
+
+    /// Turn the `parley://auth/cb?token=…` handoff into a live session.
+    ///
+    /// The three failure modes are deliberately not collapsed: a malformed
+    /// callback never had a token to keep, an expired one must be discarded (it
+    /// would leave the app looking signed in while every call 401s), and a
+    /// network error right after a good handoff must NOT discard it — the
+    /// session is real and `refreshSession()` will confirm it later.
+    private func completeSignIn(callbackURL: URL) async {
+        let token: String
+        do {
+            token = try CloudClient.token(fromCallback: callbackURL)
+        } catch {
+            signInError = signInFailureMessage(error)
+            return
+        }
+        storeToken(token)
+
+        do {
+            user = try await cloud.me()
+        } catch let err as CloudError where err.isAuthExpired {
+            clearStoredToken()
+            signInError = "登入沒有完成，請再試一次。"
+            return
+        } catch {
+            signInError = signInFailureMessage(error)
+            return
+        }
+        guard user != nil else {
+            clearStoredToken()
+            signInError = "登入沒有完成，請再試一次。"
+            return
+        }
+        await loadAccountExtras()
+        await syncPendingUploads()
+    }
+
+    /// Sign-in copy a person can act on. `localizedDescription` on a
+    /// `CloudError` is the raw response body, which is not something to show.
+    private func signInFailureMessage(_ error: Error) -> String {
+        if let cloudError = error as? CloudError {
+            // status 0 = the callback itself was malformed (no token / an
+            // ?error= from the page), not an HTTP status worth showing.
+            if cloudError.status == 0 { return "登入沒有完成，請再試一次。" }
+            return "登入失敗（伺服器回應 \(cloudError.status)）。請稍後再試一次。"
+        }
+        return "連線不穩，登入沒有完成。請確認網路後再試一次。"
     }
 
     func signOut() async {
@@ -126,16 +195,30 @@ final class AppState: NSObject, ObservableObject {
     }
 
     private func clearLocalSession() {
-        KeychainStore.delete(Self.tokenKey)
+        clearStoredToken()
         user = nil
         quota = nil
         orgs = []
     }
 
+    // The Keychain is the source of truth for the token; `hasStoredSession`
+    // mirrors it for SwiftUI. Every write goes through these two so the mirror
+    // cannot drift out of sync with the Keychain and strand the UI.
+
+    private func storeToken(_ token: String) {
+        KeychainStore.set(token, for: Self.tokenKey)
+        hasStoredSession = true
+    }
+
+    private func clearStoredToken() {
+        KeychainStore.delete(Self.tokenKey)
+        hasStoredSession = false
+    }
+
     #if DEBUG
         /// Dev-only shortcut for testing a session minted by the desktop build.
         func adoptToken(_ token: String) async {
-            KeychainStore.set(token.trimmingCharacters(in: .whitespacesAndNewlines), for: Self.tokenKey)
+            storeToken(token.trimmingCharacters(in: .whitespacesAndNewlines))
             await refreshSession()
         }
     #endif

--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/Parley/LibraryView.swift
+++ b/ios/App/Parley/LibraryView.swift
@@ -25,9 +25,7 @@ struct LibraryView: View {
         NavigationStack {
             Group {
                 if !app.signedIn {
-                    ContentUnavailableView(
-                        "尚未登入", systemImage: "icloud.slash",
-                        description: Text("到「設定 → 帳號」登入後，這裡會列出你在雲端的錄音。"))
+                    unavailable
                 } else {
                     list
                 }
@@ -39,6 +37,19 @@ struct LibraryView: View {
             .refreshable { await load() }
             .task(id: "\(scope ?? "personal")-\(app.signedIn)") { await load() }
         }
+    }
+
+    /// The library is the account's cloud recordings, so it needs a confirmed
+    /// session — not just a stored token. Holding a token but failing `me()`
+    /// means offline, which is a different message from being signed out.
+    private var unavailable: some View {
+        let title: String = app.hasAccount ? "暫時連不上雲端" : "尚未登入"
+        let detail: String =
+            app.hasAccount
+            ? "網路恢復後會自動載入你的錄音。"
+            : "到「設定 → 帳號」登入後，這裡會列出你在雲端的錄音。"
+        return ContentUnavailableView(
+            title, systemImage: "icloud.slash", description: Text(detail))
     }
 
     // MARK: scope switcher (desktop sidebar, phone-sized)

--- a/ios/App/Parley/LiveView.swift
+++ b/ios/App/Parley/LiveView.swift
@@ -69,7 +69,7 @@ struct LiveView: View {
             Image(systemName: "waveform")
                 .font(.title2)
                 .foregroundStyle(Theme.mutedForeground)
-            Text(app.signedIn ? "按下錄音，把手機放在桌上收整個房間。" : "登入後即可即時轉錄——設定 → 帳號。")
+            Text(app.hasAccount ? "按下錄音，把手機放在桌上收整個房間。" : "重新登入後即可繼續錄音。")
                 .font(.subheadline)
                 .foregroundStyle(Theme.mutedForeground)
                 .multilineTextAlignment(.center)
@@ -88,32 +88,49 @@ struct LiveView: View {
                     .multilineTextAlignment(.center)
             }
             Button(action: toggle) {
-                Label(
-                    store.isRecording ? "結束會議" : "開始錄音",
-                    systemImage: store.isRecording ? "stop.circle.fill" : "record.circle"
-                )
-                .font(.body.weight(.medium))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .foregroundStyle(store.isRecording ? Color.white : Theme.primaryForeground)
+                Label(buttonTitle, systemImage: buttonIcon)
+                    .font(.body.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .foregroundStyle(store.isRecording ? Color.white : Theme.primaryForeground)
             }
             .buttonStyle(.borderedProminent)
             .tint(store.isRecording ? Theme.recording : Theme.primary)
-            .disabled(!store.isRecording && !app.signedIn)
-            if !store.isRecording && !app.signedIn {
-                Text("請先到「設定」登入，錄音才會安全同步到你的雲端帳號。")
+            if !store.isRecording && !app.hasAccount {
+                Text("登入已過期。按上面的按鈕重新登入，就能繼續錄音。")
                     .font(.caption)
                     .foregroundStyle(Theme.mutedForeground)
+                    .multilineTextAlignment(.center)
             }
         }
         .padding(16)
     }
 
+    /// The button says what pressing it will actually do, so the signed-out case
+    /// reads as a next step rather than a broken control.
+    private var buttonTitle: String {
+        if store.isRecording { return "結束會議" }
+        return app.hasAccount ? "開始錄音" : "重新登入以開始錄音"
+    }
+
+    private var buttonIcon: String {
+        if store.isRecording { return "stop.circle.fill" }
+        return app.hasAccount ? "record.circle" : "person.crop.circle"
+    }
+
+    /// The record button is never disabled. Before this, a signed-out launch put
+    /// a permanently greyed-out 開始錄音 on screen with no way to act on it — the
+    /// bug App Review reported. A button that can't be pressed teaches nothing;
+    /// one that opens sign-in does.
     private func toggle() {
         if store.isRecording {
             Task { await stop() }
-        } else {
+        } else if app.hasAccount {
             showRecordingConsent = true
+        } else {
+            // The gate in RootView normally keeps this unreachable, but a
+            // session can expire while the app is open and on this screen.
+            app.signIn()
         }
     }
 

--- a/ios/App/Parley/OnboardingView.swift
+++ b/ios/App/Parley/OnboardingView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// First run. Recording on the phone streams through the account's hosted
+/// transcription relay and syncs to that account, so there is nothing useful to
+/// do before signing in — the previous build let people through to a Recording
+/// tab whose button was permanently disabled, which is what App Review found
+/// (submission 9ebcfa58, guideline 2.1(a)).
+///
+/// So the account comes first, and this screen has to earn it: say what the app
+/// does, what signing in buys, and what it costs, before asking. Per
+/// `docs/design/pricing.md` P3/P4 there is no anonymous trial — the free tier is
+/// the trial, and this screen is the whole distance between opening the app and
+/// being able to record.
+struct OnboardingView: View {
+    @EnvironmentObject private var app: AppState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // The pitch scrolls; the sign-in button does not. At the largest
+            // Dynamic Type sizes this content is taller than an iPhone, and the
+            // one control that matters must never be the part pushed off screen.
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 24)
+                    header
+                    Spacer(minLength: 28)
+                    VStack(alignment: .leading, spacing: 22) {
+                        ForEach(Self.points, id: \.title) { point in
+                            pointRow(point)
+                        }
+                    }
+                    .frame(maxWidth: 420)
+                    Spacer(minLength: 24)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 28)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+
+            callToAction
+                .padding(.horizontal, 28)
+                .padding(.top, 8)
+                .padding(.bottom, 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.background)
+    }
+
+    // MARK: header
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "waveform")
+                .font(.system(size: 34, weight: .regular))
+                .foregroundStyle(Theme.foreground)
+                .accessibilityHidden(true)
+            Text("Parley")
+                .font(.largeTitle.weight(.semibold))
+                .foregroundStyle(Theme.foreground)
+            Text("面對面會議的口袋錄音機——邊錄邊出逐字稿，講完就在雲端。")
+                .font(.subheadline)
+                .foregroundStyle(Theme.mutedForeground)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: what you get
+
+    private struct Point {
+        let icon: String
+        let title: String
+        let detail: String
+    }
+
+    private static let points: [Point] = [
+        Point(
+            icon: "record.circle",
+            title: "把手機放桌上就能錄",
+            detail: "收整個房間的聲音，自動分辨不同說話者。"),
+        Point(
+            icon: "text.bubble",
+            title: "即時轉錄，不必自備 API key",
+            detail: "登入後就用我們代管的轉錄服務，免費額度足夠日常使用。"),
+        Point(
+            icon: "icloud",
+            title: "錄音與逐字稿同步到你的帳號",
+            detail: "手機錄的會議，桌面版打開就能做深度分析。"),
+    ]
+
+    private func pointRow(_ point: Point) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: point.icon)
+                .font(.title3)
+                .frame(width: 28)
+                .foregroundStyle(Theme.foreground)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(point.title)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(Theme.foreground)
+                Text(point.detail)
+                    .font(.footnote)
+                    .foregroundStyle(Theme.mutedForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: sign in
+
+    private var callToAction: some View {
+        VStack(spacing: 12) {
+            Button {
+                app.signIn()
+            } label: {
+                HStack(spacing: 8) {
+                    if app.signingIn { ProgressView().tint(Theme.primaryForeground) }
+                    Text(app.signingIn ? "登入中…" : "登入或註冊")
+                        .font(.body.weight(.semibold))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .foregroundStyle(Theme.primaryForeground)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Theme.primary)
+            .disabled(app.signingIn)
+
+            if let error = app.signInError {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(Theme.destructive)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text("支援信箱密碼、Google 與 Apple 登入。開始錄音前，Parley 一定會先請你確認已取得所有與會者同意。")
+                .font(.caption)
+                .foregroundStyle(Theme.mutedForeground)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Link("隱私權政策", destination: URL(string: "https://parley.tw/privacy/")!)
+                .font(.caption)
+        }
+        .frame(maxWidth: 420)
+    }
+}
+
+/// Shown for the one moment between launch and the first `refreshSession()`
+/// returning. Without it a returning user sees the sign-in wall flash by before
+/// the stored session is confirmed.
+struct LaunchView: View {
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "waveform")
+                .font(.system(size: 30))
+                .foregroundStyle(Theme.mutedForeground)
+                .accessibilityHidden(true)
+            ProgressView()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.background)
+        .accessibilityLabel("正在載入 Parley")
+    }
+}

--- a/ios/App/Parley/ParleyApp.swift
+++ b/ios/App/Parley/ParleyApp.swift
@@ -6,17 +6,42 @@ struct ParleyApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TabView {
-                LiveView()
-                    .tabItem { Label("錄音", systemImage: "record.circle") }
-                LibraryView()
-                    .tabItem { Label("錄音庫", systemImage: "rectangle.stack") }
-                SettingsView()
-                    .tabItem { Label("設定", systemImage: "gearshape") }
-            }
-            .environmentObject(app)
-            .preferredColorScheme(app.theme.colorScheme)
-            .task { await app.refreshSession() }
+            RootView()
+                .environmentObject(app)
+                .preferredColorScheme(app.theme.colorScheme)
+                .task { await app.refreshSession() }
+        }
+    }
+}
+
+/// Three states, one decision: still checking the stored session, no account
+/// yet, or in. Everything behind the tab bar needs an account to do anything —
+/// recording streams through the account's hosted transcription relay, and the
+/// library *is* that account's cloud recordings — so the sign-in gate is the
+/// app's entrance rather than a prompt buried in Settings.
+struct RootView: View {
+    @EnvironmentObject private var app: AppState
+
+    var body: some View {
+        if !app.bootstrapped {
+            LaunchView()
+        } else if app.hasAccount {
+            MainTabs()
+        } else {
+            OnboardingView()
+        }
+    }
+}
+
+struct MainTabs: View {
+    var body: some View {
+        TabView {
+            LiveView()
+                .tabItem { Label("錄音", systemImage: "record.circle") }
+            LibraryView()
+                .tabItem { Label("錄音庫", systemImage: "rectangle.stack") }
+            SettingsView()
+                .tabItem { Label("設定", systemImage: "gearshape") }
         }
     }
 }

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -23,6 +23,11 @@ struct SettingsView: View {
                 if app.signedIn {
                     saveDestinationSection
                     usageSection
+                }
+                // Sync reads only on-device state, so it stays available while
+                // offline — that is exactly when someone needs to see that a
+                // finished recording is queued rather than lost.
+                if app.hasAccount {
                     syncSection
                 }
                 appearanceSection
@@ -82,6 +87,12 @@ struct SettingsView: View {
                         .font(.caption)
                         .foregroundStyle(Theme.destructive)
                 }
+            } else if app.hasAccount {
+                // Signed in, but `me()` hasn't come back — offline, or the
+                // server is unreachable. The session is deliberately kept, so
+                // say that instead of showing a sign-in button that implies the
+                // account is gone.
+                unreachableAccountRow
             } else {
                 signInForm
             }
@@ -104,6 +115,19 @@ struct SettingsView: View {
             Text("同步")
         } footer: {
             Text("網路中斷、伺服器暫時無回應或額度不足時，手機會保留完成的錄音，直到同步成功。")
+        }
+    }
+
+    @ViewBuilder
+    private var unreachableAccountRow: some View {
+        Label("目前連不上伺服器，帳號資訊稍後會自動更新。", systemImage: "wifi.exclamationmark")
+            .font(.subheadline)
+            .foregroundStyle(Theme.warning)
+        Button("重新整理") {
+            Task { await app.refreshSession() }
+        }
+        Button("登出", role: .destructive) {
+            Task { await app.signOut() }
         }
     }
 

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -23,7 +23,7 @@ targets:
       properties:
         CFBundleDisplayName: Parley
         CFBundleShortVersionString: "1.0"
-        CFBundleVersion: "3"
+        CFBundleVersion: "4"
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: Parley listens to the meeting to transcribe and coach it live. Audio goes only to the transcription provider tied to your account.
         UIBackgroundModes: [audio]

--- a/ios/AppStore/README.md
+++ b/ios/AppStore/README.md
@@ -7,8 +7,9 @@ record in sync whenever product data practices change.
 
 ## Submission order
 
-1. In **Distribution**, create iOS version `1.0` and select build `1.0 (3)`
-   after it finishes processing.
+1. In **Distribution**, create iOS version `1.0` and select build `1.0 (4)`
+   after it finishes processing. Build 3 was rejected — see the previous-review
+   section of [`review-notes.md`](review-notes.md).
 2. Apply [`metadata/zh-Hant.md`](metadata/zh-Hant.md) to the primary locale.
 3. Apply [`privacy-label.md`](privacy-label.md) in **App Privacy**, including
    the privacy-policy URL. Publish the label before submission.

--- a/ios/AppStore/review-notes.md
+++ b/ios/AppStore/review-notes.md
@@ -31,15 +31,36 @@ Google or Apple identity.
 > hosted transcription relay for live transcription, then syncs the completed
 > recording and transcript to that account.
 >
-> To test: sign in with the supplied email/password account, tap Recording,
-> confirm the consent message, and allow microphone access. Speak near the
-> device, then tap End Meeting. Open Library to view the saved recording. In
-> Settings, the reviewer can verify System/Light/Dark appearance, sync status,
-> privacy/support links, and account deletion. Account deletion is available in
-> Settings → Account → Delete Account.
+> To test: the app opens on a welcome screen with a single 登入或註冊 (Sign in
+> or register) button. Tap it, sign in with the supplied email/password account
+> on the page that opens, and the app goes straight to the Recording tab. Tap
+> 開始錄音 (Start Recording), confirm the consent message, and allow microphone
+> access. Speak near the device, then tap 結束會議 (End Meeting). Open Library to
+> view the saved recording. In Settings, the reviewer can verify System/Light/Dark
+> appearance, sync status, privacy/support links, and account deletion. Account
+> deletion is available in Settings → Account → Delete Account.
 >
 > If the test network is unavailable, the completed recording remains in an
 > on-device pending-upload queue and can be retried from Settings → Sync.
+
+## Responses to previous review feedback
+
+Submission 9ebcfa58 (version 1.0 build 3) was rejected under guideline 2.1(a)
+for two bugs. Both are fixed in build 4:
+
+- **"An error occurred when we tapped the login button."** The hosted sign-in
+  page the app opens returned HTTP 404. The three `/sign-in*` routes had been
+  deleted from the backend as collateral in an unrelated refactor; nothing in
+  the app had changed. The routes are restored, covered by an automated test,
+  and verified in production before resubmitting.
+- **"開始錄音 was disabled and not functional."** The Start Recording button was
+  disabled whenever no account was signed in — which, because of the bug above,
+  was every reviewer. The app now opens on a sign-in screen that explains why an
+  account is needed, so the tab bar is only reached with a usable account, and
+  the record button is never disabled: if a session expires while the app is
+  open, pressing it reopens sign-in instead of doing nothing.
+
+Before resubmitting, confirm `https://api.parley.tw/sign-in` returns HTTP 200.
 
 ## Export compliance
 

--- a/ios/AppStore/screenshots/README.md
+++ b/ios/AppStore/screenshots/README.md
@@ -24,9 +24,14 @@ customer, and no real meeting data was used. Speakers are labelled 我 /
 客戶窗口 via the app's own speaker-naming feature. Regenerate with
 `scratchpad/seed-demo.mjs` against the review account.
 
-Four frames satisfy submission (App Store Connect requires at least one). Two
+The four frames are all signed-in states, so build 4's sign-in gate does not
+invalidate them — they still match what the app shows once an account is in.
+
+Four frames satisfy submission (App Store Connect requires at least one). Three
 more would complete the story and are worth grabbing on the next pass:
 
+- **welcome / sign-in** — build 4's first screen, the app's actual first
+  impression and the one frame nothing in the current set covers.
 - **consent + live recording** — tap Start Recording to show the consent sheet,
   confirm, then capture the red recording state with the level meter.
 - **save destination** — Settings → Default save location with the picker open.

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -14,8 +14,10 @@ Prerequisites already configured for the Pathors Apple team (`SXHVCQXJHZ`):
 - Sign in with Apple capability and hosted Better Auth Apple provider
 - Hosted login page: `https://api.parley.tw/sign-in`
 
-Each upload needs a new build number. Update `CFBundleVersion` in
-`App/Parley/Info.plist`, then generate and archive:
+Each upload needs a new build number. `xcodegen generate` writes
+`App/Parley/Info.plist` from `App/project.yml`, so bump `CFBundleVersion` in
+**`App/project.yml`** — editing the plist alone is overwritten on the next
+generate. Keep the checked-in plist in step with it, then archive:
 
 ```bash
 cd ios/App


### PR DESCRIPTION
## What this changes

The iOS app now opens on a sign-in screen instead of a tab bar it cannot use, and `開始錄音` is never disabled — if a session expires while the app is open, pressing it reopens sign-in instead of doing nothing. Build 4.

## Why

App Review rejected 1.0 (3) under guideline 2.1(a) (submission `9ebcfa58`) for two bugs. They share one cause.

The hosted `/sign-in` page the app opens returned **404** — a backend regression, fixed separately in `pathorsAI/parley-internal#41`. Because sign-in could not succeed, no reviewer ever had an account, and `LiveView` disabled the record button whenever `!app.signedIn`. What review saw was an app whose one visible control was greyed out, with nothing explaining why and no way to act on it.

The disabled state was the deeper mistake. Recording streams through the account's hosted transcription relay and the library *is* that account's cloud recordings, so there is genuinely nothing to do before signing in — but the app opened on a screen that implied otherwise and then refused.

## How

- `RootView` gates on the account. No account → an onboarding screen that says what the app does and what signing in gives you, then asks. Per `docs/design/pricing.md` P3/P4 there is no anonymous trial: the free tier *is* the trial, so this screen is the whole distance between opening the app and recording.
- The record button is never disabled, and its label says what pressing it will actually do.

Two robustness fixes fall out of gating on auth state rather than on a network result:

- **`hasAccount` (a stored token) is now distinct from `signedIn` (a confirmed `me()`).** `refreshSession()` already kept the session through network errors on purpose, so gating on `signedIn` would have shown the sign-in wall to a signed-in user who was merely offline. The gate is also decided *before any `await`* — waiting on `me()` would park a returning user behind a spinner for URLSession's full timeout on a bad network, which is exactly when they most want to just hit record. Settings and Library now distinguish "offline" from "signed out", and Sync stays visible offline, which is when a queued recording matters most.
- **Sign-in handles its three failure modes separately** instead of showing `error.localizedDescription` (for a `CloudError`, that is the raw response body). A malformed callback never had a token; an expired one is discarded; a network error right after a good handoff keeps it, because that session is real.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (310 tests, 36 files)
- [ ] Ran the app — **not done, and worth stating plainly: this PR was written without a Swift toolchain, so the Swift is reviewed by hand, not compiled.** Please run `xcodegen generate && xcodebuild` before trusting it.
- [ ] Added or updated tests — the iOS target has no test host; `ParleyKit` tests are unaffected
- [x] i18n — not applicable: this touches no `src/i18n/messages.ts`. iOS strings are inline zh-TW, matching the rest of `ios/App/Parley`

Both TypeScript checks are green but neither exercises this change; the diff is Swift and Markdown only.

## Screenshots

None — the onboarding screen has not been rendered on a device. `ios/AppStore/screenshots/README.md` now lists it as the frame worth capturing next; the four checked-in frames are all signed-in states, so they stay valid.

## Merge order

`pathorsAI/parley-internal#41` must deploy **first**. This app change is useless while `/sign-in` still returns 404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUewFnYW9hDmAZvzp14db7)_