### PR TITLE
[fix] dictation keeps working while a recording is saved or transcribed

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -704,13 +704,22 @@ pub fn save_transcript(filename: String, contents: String) -> Result<String, Str
 
 /// Copy a recording's audio file to a user-chosen destination (the replay
 /// "Save audio…" action — the frontend picks `dst` via the save dialog).
+///
+/// Copied on a blocking worker rather than inline: a sync command runs on the
+/// main thread, where a multi-GB copy would freeze every window and stall every
+/// other command until it finished (see `save_history_entry`).
 #[tauri::command]
-pub fn export_recording(src: String, dst: String) -> Result<(), String> {
+pub async fn export_recording(src: String, dst: String) -> Result<(), String> {
     if !std::path::Path::new(&src).exists() {
         return Err(format!("source recording not found: {src}"));
     }
-    std::fs::copy(&src, &dst).map_err(|e| e.to_string())?;
-    Ok(())
+    tauri::async_runtime::spawn_blocking(move || {
+        std::fs::copy(&src, &dst)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("export task panicked: {e}"))?
 }
 
 /// Minimal percent-decoder for the loopback query (the token is encodeURIComponent'd).

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -59,8 +59,15 @@ pub struct HistoryRead {
 ///   - `compress = false` (live): the source is already an encoded temp `.ogg`,
 ///     so just move it into place.
 /// Returns the absolute entry directory.
+///
+/// `async` + `spawn_blocking` deliberately: a plain `#[tauri::command]` runs on
+/// the MAIN THREAD, and the `compress = true` branch decodes and re-encodes the
+/// whole source recording — over a minute of CPU for a long meeting. Every other
+/// command (and every window) queues behind the main thread while that runs, so
+/// saving an uploaded recording used to freeze the app outright — voice typing
+/// included, which is exactly when the user wants to dictate elsewhere.
 #[tauri::command]
-pub fn save_history_entry(
+pub async fn save_history_entry(
     app: AppHandle,
     id: String,
     summary_json: String,
@@ -69,7 +76,23 @@ pub fn save_history_entry(
     compress: bool,
 ) -> Result<String, String> {
     let dir = history_dir(&app)?.join(safe_id(&id));
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    tauri::async_runtime::spawn_blocking(move || {
+        write_entry(&dir, summary_json, meta_json, audio_source_path, compress)
+    })
+    .await
+    .map_err(|e| format!("history save task panicked: {e}"))?
+}
+
+/// The file-side of [`save_history_entry`], split out so it can run on a
+/// blocking worker. Synchronous by design; do not call it from the main thread.
+fn write_entry(
+    dir: &Path,
+    summary_json: String,
+    meta_json: String,
+    audio_source_path: Option<String>,
+    compress: bool,
+) -> Result<String, String> {
+    std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
 
     if let Some(src) = audio_source_path.filter(|s| !s.trim().is_empty()) {
         let src = PathBuf::from(src);

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -70,13 +70,19 @@ struct VtInner {
 /// `source: "voice-typing"` label (kept separate from meeting usage). A failed
 /// session raises `voicetyping://error`, which the overlay renders (voice
 /// typing has no other error surface — see `run_metered_session`).
+///
+/// `async` so it runs on the async runtime, NOT the main thread: dictation must
+/// stay usable while the app is busy with something else (saving, exporting,
+/// transcribing an upload), and a sync command would simply queue behind
+/// whatever main-thread work is in flight. Nothing here touches AppKit — the
+/// overlay/clipboard commands, which do, stay synchronous.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
-pub fn start_voice_typing(
+pub async fn start_voice_typing(
     app: AppHandle,
-    coord: State<MicCoordinator>,
-    tap: State<MicTap>,
-    state: State<VoiceTypingState>,
+    coord: State<'_, MicCoordinator>,
+    tap: State<'_, MicTap>,
+    state: State<'_, VoiceTypingState>,
     provider: String,
     api_key: String,
     model: Option<String>,
@@ -262,8 +268,15 @@ pub fn write_voice_history(app: AppHandle, content: String) -> Result<(), String
 /// direct-cancel safety net — abort the task once the flush window has long
 /// passed. Guarded by `seq` so a backstop from THIS session can never abort a
 /// newer one started during the grace.
+///
+/// `async` for the same reason as [`start_voice_typing`], with one extra: the
+/// `coord.stop` below joins the capture threads with a bounded grace, and doing
+/// that on the main thread hitched every window on every key release.
 #[tauri::command]
-pub fn stop_voice_typing(coord: State<MicCoordinator>, state: State<VoiceTypingState>) {
+pub async fn stop_voice_typing(
+    coord: State<'_, MicCoordinator>,
+    state: State<'_, VoiceTypingState>,
+) -> Result<(), String> {
     // Hard cut FIRST: stop forwarding audio to the STT session immediately so
     // nothing captured after release is transcribed, and its input closes now
     // for a prompt final flush — set before `coord.stop` so forwarding ceases
@@ -283,6 +296,7 @@ pub fn stop_voice_typing(coord: State<MicCoordinator>, state: State<VoiceTypingS
             }
         }
     });
+    Ok(())
 }
 
 /// Copy text to the system clipboard via the native pasteboard. Needed because

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -242,22 +242,32 @@ async function startSession() {
   clearTimeout(settleTimer);
   clearTimeout(hideTimer);
   clearTimeout(capTimer);
-  await showOverlay();
-  await emit("voicetyping://session", { phase: "start" });
   // The hosted "parley" plan caps a single dictation; BYOK is uncapped. Pass
   // the cap to the backend as a safety net (a hung webview can't stream the
   // paid relay forever) and mirror it with a frontend timer that finalizes
   // gracefully (delivering the transcript). null = no cap for BYOK.
   const hosted = provider === "parley";
+  // MIC FIRST, overlay second. Placing the overlay costs four round-trips to
+  // the app's main thread (cursor position → monitor list → setPosition →
+  // present), and the capture used to wait behind all of them — so roughly the
+  // first second of every dictation was never recorded, and any main-thread
+  // work elsewhere in the app stretched that window arbitrarily. The overlay
+  // webview is prewarmed and already subscribed, so it can be told the session
+  // started before its window is on screen and simply catch up.
+  const starting = invoke("start_voice_typing", {
+    provider,
+    apiKey,
+    languageHints: [],
+    inputDevice: settings.inputDevice ?? null,
+    relayUrl: sttRelayUrl(provider),
+    maxDurationSecs: hosted ? HOSTED_VOICE_TYPING_MAX_SECONDS : null,
+  });
+  const shown = showOverlay().catch((error) =>
+    log.warn("voice-typing: overlay show failed", { error: String(error) }),
+  );
+  await emit("voicetyping://session", { phase: "start" });
   try {
-    await invoke("start_voice_typing", {
-      provider,
-      apiKey,
-      languageHints: [],
-      inputDevice: settings.inputDevice ?? null,
-      relayUrl: sttRelayUrl(provider),
-      maxDurationSecs: hosted ? HOSTED_VOICE_TYPING_MAX_SECONDS : null,
-    });
+    await starting;
     log.info("voice-typing: session started", { provider });
     if (hosted) {
       capTimer = setTimeout(() => {
@@ -269,6 +279,10 @@ async function startSession() {
   } catch (e) {
     log.error("voice-typing: start failed", { error: String(e) });
     busy = false;
+    // The overlay is this failure's only surface, so let it finish coming up
+    // before the error is announced — it raced the start, and a message sent
+    // to a window that never appeared is a silent dead session.
+    await shown;
     await emit("voicetyping://session", { phase: "error", message: String(e) });
     scheduleHide();
   }


### PR DESCRIPTION
## What this changes

Voice typing no longer stops working while the app is saving, exporting, or transcribing a recording. Two independent causes, both fixed here:

1. **The main thread was being blocked for minutes at a time.** A `#[tauri::command]` without `async` runs on the main thread. `save_history_entry` is one of those, and its `compress = true` branch (the upload path) decodes and re-encodes the entire source recording inline. `export_recording` copies the whole audio file the same way. Both now run on a blocking worker, and `start_voice_typing` / `stop_voice_typing` became `async` so dictation can never queue behind main-thread work again.

2. **The mic waited for the overlay.** `startSession()` awaited `showOverlay()` before opening the microphone, and placing the overlay costs four round-trips to the main thread (cursor position → monitor list → `setPosition` → present). The mic now starts first.

The commands that genuinely need the main thread — overlay window ordering, the pasteboard, the synthetic ⌘V — stay synchronous.

## Why

Dictating into another app while Parley chews on a recording is exactly when voice typing is most useful, and it was precisely then that it died.

From a real session log, saving one uploaded 4.5 GB recording:

```
16:56:17  symphonia: stream is seekable with len=4518445732 bytes
16:57:27  history: saved entry …
```

Seventy seconds during which every IPC call queued behind the compress: `present_voice_overlay`, `start_voice_typing`, `stop_voice_typing`, `copy_to_clipboard`, `paste_to_frontmost`. Voice typing was not slow in that window — it was dead.

The second cause is subtler and was there all the time, not just under load. Every `fn down` in the log sits ~1 s ahead of its `voice-typing: session started`, so roughly the first second of every dictation was never captured; under main-thread contention that window stretched without bound. Two dictations attempted during an ingest billed 1.2 s and 1.15 s of audio for a 2 s and a 1 s hold, and both came back empty.

`stop_voice_typing` also joins the capture threads with a bounded grace, which on the main thread hitched every window on each key release. That is gone too.

## Known remaining coupling

The dictation host still runs on the main window's JS thread, so heavy webview work there (analysis re-renders, reading a recording into an upload buffer) can in principle still delay key handling. Fully isolating it means moving the host into the overlay window. There is no evidence yet that this is a real problem in practice, so it is deliberately out of scope.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (310 tests)
- [x] `cargo check`, `cargo clippy --all-targets`, `cargo test` (26 tests) pass
- [ ] Ran the app (`bun run tauri dev`) and exercised the change
- [ ] Added or updated tests
- [ ] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts` — no new strings

End-to-end confirmation needs a signed build: voice typing depends on Accessibility / Input Monitoring grants that are keyed to the binary's TCC identity, so a `tauri dev` build cannot exercise the push-to-talk path. The way to test it is to upload a long recording and dictate while it compresses and uploads.
