### PR TITLE
[fix] the save picker was the last place still selling folders as customers

### DIFF
--- a/src/components/SaveDestinationPicker.tsx
+++ b/src/components/SaveDestinationPicker.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { FolderClosed } from "lucide-react";
 import { Combobox, type ComboGroup } from "@/components/ui/combobox";
-import { syncEnabled as cloudSyncEnabled } from "../lib/cloud/client";
 import { listMyOrgs } from "../lib/cloud/orgs";
 import type { CloudOrg } from "../lib/cloud/types";
-import { listCloudFolders, listOrgFolders, type CloudFolder } from "../lib/cloud/folders";
-import { listLocalFolders, listenForFoldersUpdated, type Folder as LocalFolder } from "../lib/history/folders";
+import { listOrgFolders, type CloudFolder } from "../lib/cloud/folders";
 import { useI18n } from "../i18n";
 import { log } from "../lib/log";
 import type { DefaultSaveLocation } from "../lib/types";
@@ -33,9 +31,16 @@ const parse = (v: string): DefaultSaveLocation => {
 };
 
 /**
- * Where finished meetings save: a personal folder (or root), or an org folder.
+ * Where finished meetings save: the personal root, or an org folder.
  * Shared by Settings (the fallback default) and the pre-flight screen's
- * "save somewhere else" override, so the folder/org loading logic lives once.
+ * "save somewhere else" override, so the org loading logic lives once.
+ *
+ * Personal NAMED folders are deliberately not offered (#211): the customer
+ * picked one field above decides personal filing, and this picker listing the
+ * same folders was the last surviving "second answer" — the exact two-controls
+ * split the refactor removed everywhere else. A legacy personal-folder value
+ * still resolves (resolveLocation), it just can't be chosen anew; the startup
+ * normalization rewrites stored ones to the root.
  */
 export function SaveDestinationPicker({
   value,
@@ -50,38 +55,8 @@ export function SaveDestinationPicker({
   compact?: boolean;
 }>) {
   const { t } = useI18n();
-  const [personal, setPersonal] = useState<LocalFolder[]>(() => listLocalFolders());
   const [orgs, setOrgs] = useState<CloudOrg[]>([]);
   const [orgFolders, setOrgFolders] = useState<Record<string, CloudFolder[]>>({});
-
-  // Personal folders: prefer the cloud list when sync is on (cross-device truth).
-  useEffect(() => {
-    async function loadPersonalFolders() {
-      if (!syncOn || !cloudSyncEnabled()) {
-        setPersonal(listLocalFolders());
-        return;
-      }
-      try {
-        const cloud = await listCloudFolders();
-        setPersonal(cloud.map((f) => ({ id: f.id, name: f.name, createdAt: f.createdAt })));
-      } catch {
-        setPersonal(listLocalFolders());
-      }
-    }
-    loadPersonalFolders().catch((error) =>
-      log.warn("save-dest: personal folders load failed", { error: String(error) })
-    );
-  }, [syncOn]);
-
-  // Reflect personal-folder create/rename/delete done in the History window live.
-  useEffect(() => {
-    const un = listenForFoldersUpdated(() => setPersonal(listLocalFolders()));
-    return () => {
-      un.then((fn) => fn()).catch((error) =>
-        log.warn("save-dest: folder listener cleanup failed", { error: String(error) })
-      );
-    };
-  }, []);
 
   // Org folders only matter for an org default, which needs sync on.
   useEffect(() => {
@@ -120,13 +95,7 @@ export function SaveDestinationPicker({
     const g: ComboGroup[] = [
       {
         label: personalLabel,
-        options: [
-          { value: "personal", label: label(personalLabel, root, true) },
-          ...personal.map((f) => ({
-            value: `personal:${f.id}`,
-            label: label(personalLabel, f.name, false),
-          })),
-        ],
+        options: [{ value: "personal", label: label(personalLabel, root, true) }],
       },
     ];
     if (syncOn) {
@@ -144,7 +113,7 @@ export function SaveDestinationPicker({
       }
     }
     return g;
-  }, [personal, orgs, orgFolders, syncOn, root, compact, t]);
+  }, [orgs, orgFolders, syncOn, root, compact, t]);
 
   return (
     <Combobox

--- a/src/lib/accounts/store.ts
+++ b/src/lib/accounts/store.ts
@@ -577,12 +577,31 @@ export function initAccounts(): void {
       try {
         const { migrateCompanyFolders } = await import("./folders");
         migrateCompanyFolders();
-        // Pairing first, THEN the recordings: the backfill reads
-        // Company.folderId, so it has to run after every company has one.
-        const { migrateEntryOwners } = await import("../history/history");
-        migrateEntryOwners().catch((e) =>
+        // Strict order: pairing → twin dedupe → owner backfill. Dedupe wants
+        // the pairing done (the survivor prefers the company-paired folder);
+        // the backfill reads Company.folderId AND should see the merged
+        // registry, not twins about to be deleted.
+        const { migrateDuplicateFolders, migrateEntryOwners } = await import(
+          "../history/history"
+        );
+        await migrateDuplicateFolders().catch((e) =>
+          log.warn("accounts: folder dedupe failed", { error: String(e) })
+        );
+        await migrateEntryOwners().catch((e) =>
           log.warn("accounts: recording owner backfill failed", { error: String(e) })
         );
+        // A personal-FOLDER default save predates #211 (the customer decides
+        // personal filing now; the default only matters for customer-less
+        // meetings, which by definition go to the root). Normalize so the
+        // picker — which no longer offers personal folders — shows the truth.
+        const { useStore } = await import("../store");
+        const loc = useStore.getState().settings.defaultSaveLocation;
+        if (loc.scope === "personal" && loc.folderId) {
+          useStore.getState().updateSettings({
+            defaultSaveLocation: { scope: "personal", folderId: null },
+          });
+          log.info("accounts: personal-folder default save normalized to root");
+        }
       } catch (e) {
         log.warn("accounts: folder migration failed", { error: String(e) });
       }

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -21,8 +21,9 @@ import { log } from "../log";
 import { CLOUD_ENABLED } from "../flags";
 import { markDirty } from "../cloud/syncState";
 import { CLOUD_URL, cloudFetch, cloudToken, syncEnabled } from "../cloud/client";
-import { listLocalFolders } from "./folders";
-import { buildOwnershipIndex, ownerBackfill } from "../library/scope";
+import { deleteLocalFolder, emitFoldersUpdated, listLocalFolders } from "./folders";
+import { deleteCloudFolder } from "../cloud/folders";
+import { buildOwnershipIndex, ownerBackfill, planFolderDedupe } from "../library/scope";
 import { rediarizeSegments } from "../speakers/postDiarize";
 import { translate } from "../../i18n/messages";
 import type { ReplaySession } from "../replay/types";
@@ -697,6 +698,77 @@ export async function setEntryFolder(id: string, folderId: string | null): Promi
   });
   log.info("history: entry folder set", { id, folderId });
   pushToCloud(id); // sync the new folderId (best-effort; gated by the sync toggle)
+}
+
+/**
+ * Upgrade dedupe (#211 follow-up): merge same-name personal folder twins.
+ *
+ * The plan comes from {@link planFolderDedupe} (see its comment for how the
+ * twins came to exist). This applies it: repoint every recording filed in a
+ * twin onto the survivor, delete the twins locally, and delete them in the
+ * cloud so the mirror-down in reloadFolders doesn't resurrect them next
+ * launch. When sync is off the cloud delete no-ops and the twins WILL come
+ * back from the mirror after sign-in — which is fine, because this runs every
+ * startup and converges the next time around.
+ *
+ * Runs after the company↔folder pairing (the survivor prefers the paired
+ * folder) and before the owner backfill (which should see the merged mapping).
+ * Like the backfill: idempotent, no flag, no cloud push of entries (a push
+ * re-uploads audio).
+ */
+export async function migrateDuplicateFolders(): Promise<number> {
+  if (!isTauri()) return 0;
+  const merges = planFolderDedupe(listLocalFolders(), useAccounts.getState().companies);
+  if (!merges.length) return 0;
+  const survivorOf = new Map<string, string>();
+  for (const m of merges) for (const twin of m.twinIds) survivorOf.set(twin, m.canonicalId);
+
+  let moved = 0;
+  try {
+    for (const summary of await listHistory()) {
+      const target = summary.folderId ? survivorOf.get(summary.folderId) : undefined;
+      if (!target) continue;
+      try {
+        const { meta } = await invoke<HistoryReadResult>("read_history_entry", {
+          id: summary.id,
+        });
+        const updated: HistoryEntry = { ...meta, folderId: target };
+        await invoke("save_history_entry", {
+          id: summary.id,
+          summaryJson: JSON.stringify(buildSummary(updated)),
+          metaJson: JSON.stringify(updated),
+          audioSourcePath: null, // leave the recording untouched
+          compress: false,
+        });
+        moved++;
+      } catch (e) {
+        log.warn("history: folder dedupe failed for entry", {
+          id: summary.id,
+          error: String(e),
+        });
+      }
+    }
+  } catch (e) {
+    log.warn("history: folder dedupe sweep failed", { error: String(e) });
+    return moved;
+  }
+
+  // Recordings are safely off the twins — now the twins can go.
+  for (const [twin] of survivorOf) {
+    deleteLocalFolder(twin);
+    if (CLOUD_ENABLED) {
+      deleteCloudFolder(twin).catch((e) =>
+        log.warn("history: twin folder cloud delete failed", { twin, error: String(e) })
+      );
+    }
+  }
+  await emitFoldersUpdated().catch(() => {});
+  if (moved) await emitHistoryUpdated();
+  log.info("history: folder dedupe complete", {
+    merged: merges.map((m) => ({ name: m.name, twins: m.twinIds.length })),
+    movedRecordings: moved,
+  });
+  return moved;
 }
 
 /**

--- a/src/lib/library/scope.test.ts
+++ b/src/lib/library/scope.test.ts
@@ -7,6 +7,7 @@ import {
   nodeKey,
   ownerBackfill,
   ownerNode,
+  planFolderDedupe,
   recordingsOfCompany,
   type FiledRecording,
   type LibraryNode,
@@ -164,6 +165,50 @@ describe("ownerBackfill", () => {
       })
       .map((e) => nodeKey(ownerNode(e, idx)));
     expect(after).toEqual(before);
+  });
+});
+
+describe("planFolderDedupe", () => {
+  const f = (id: string, name: string, createdAt: number) => ({ id, name, createdAt });
+
+  it("merges same-name twins into the company-paired folder", () => {
+    const merges = planFolderDedupe(
+      [f("old", "台數科", 1), f("paired", "台數科", 2)],
+      [{ id: "co", folderId: "paired" }]
+    );
+    expect(merges).toEqual([{ canonicalId: "paired", twinIds: ["old"], name: "台數科" }]);
+  });
+
+  it("falls back to the oldest when no company claims the name", () => {
+    const merges = planFolderDedupe([f("b", "測試", 2), f("a", "測試", 1)], []);
+    expect(merges).toEqual([{ canonicalId: "a", twinIds: ["b"], name: "測試" }]);
+  });
+
+  it("skips a name claimed by more than one company", () => {
+    // Two same-named companies: merging on the name would move recordings
+    // between customers.
+    const merges = planFolderDedupe(
+      [f("x", "台哥大", 1), f("y", "台哥大", 2)],
+      [
+        { id: "co1", folderId: "x" },
+        { id: "co2", folderId: "y" },
+      ]
+    );
+    expect(merges).toEqual([]);
+  });
+
+  it("leaves unique names and blank names alone", () => {
+    expect(planFolderDedupe([f("a", "Ai3", 1), f("b", "東森", 2), f("c", " ", 3)], [])).toEqual(
+      []
+    );
+  });
+
+  it("handles a 3-way clone group", () => {
+    const merges = planFolderDedupe(
+      [f("a", "Ai3", 3), f("b", "Ai3", 1), f("c", "Ai3", 2)],
+      []
+    );
+    expect(merges).toEqual([{ canonicalId: "b", twinIds: ["a", "c"], name: "Ai3" }]);
   });
 });
 

--- a/src/lib/library/scope.ts
+++ b/src/lib/library/scope.ts
@@ -154,6 +154,64 @@ export function ownerBackfill(entry: FiledRecording, idx: OwnershipIndex): strin
   return idx.folderOwner.get(folderId) ?? null;
 }
 
+/** One same-name folder group the dedupe migration should merge. */
+export interface FolderMerge {
+  /** The folder that survives. */
+  canonicalId: string;
+  /** Folders whose recordings move to the canonical, then get deleted. */
+  twinIds: string[];
+  name: string;
+}
+
+export interface DedupeFolderRef {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
+/**
+ * Which same-name personal folders to merge, and into which survivor.
+ *
+ * The registry can genuinely hold two folders per name: the pre-file registry
+ * era let a dev and a packaged instance each mint their own ids, and the cloud
+ * mirror kept both (see the history/folders.ts header). ensureCompanyFolder
+ * then adopts ONE of them by name — the twin lives on, shows up beside it in
+ * every folder list, and splits the company's recordings across two ids.
+ *
+ * The survivor is the company-paired folder when the group has exactly one;
+ * otherwise the oldest. A group where SEVERAL companies claim folders of the
+ * same name is skipped outright — that's two same-named companies, and merging
+ * their filing on a name match would move recordings between customers.
+ */
+export function planFolderDedupe(
+  folders: readonly DedupeFolderRef[],
+  companies: readonly CompanyRef[]
+): FolderMerge[] {
+  const paired = new Set(
+    companies.map((c) => c.folderId).filter((id): id is string => !!id)
+  );
+  const byName = new Map<string, DedupeFolderRef[]>();
+  for (const f of folders) {
+    const key = f.name.trim();
+    if (!key) continue;
+    byName.set(key, [...(byName.get(key) ?? []), f]);
+  }
+  const merges: FolderMerge[] = [];
+  for (const [name, group] of byName) {
+    if (group.length < 2) continue;
+    const pairedInGroup = group.filter((f) => paired.has(f.id));
+    if (pairedInGroup.length > 1) continue; // two same-named companies — hands off
+    const canonical =
+      pairedInGroup[0] ?? [...group].sort((a, b) => a.createdAt - b.createdAt)[0];
+    merges.push({
+      canonicalId: canonical.id,
+      twinIds: group.filter((f) => f.id !== canonical.id).map((f) => f.id),
+      name,
+    });
+  }
+  return merges;
+}
+
 // ── Org scope ───────────────────────────────────────────────────────────────
 // A shared org has folders and no companies, so its tree keeps the plain
 // folder rule. Nothing here is used by the personal tree.


### PR DESCRIPTION
## What this changes

Two upgrade wounds left visible after #212, both reported from a real install the moment it updated:

1. **Pre-flight still showed two choosers.** The save-destination picker ("save somewhere else" + the Settings default) still listed every personal folder, so the meeting screen offered a customer picker *and* a folder picker — the exact split #211 removed everywhere else. Personal options are now the root only; orgs keep their folders (an org has no companies). A legacy personal-folder default still resolves, and a startup normalization rewrites it to the root so the picker shows the truth.
2. **Every folder appeared twice.** The registry genuinely held same-name twins from the dev/packaged dual-instance id ping-pong (documented in `history/folders.ts`); `ensureCompanyFolder` adopts only one of each pair. A new startup dedupe merges them: recordings repointed onto the survivor (company-paired preferred, else oldest), twins deleted locally **and in the cloud** — the mirror-down in `reloadFolders` would otherwise resurrect them next launch. Groups where several companies claim the same name are skipped: merging those on a name match would move recordings between customers.

Migration order is now pairing → dedupe → owner backfill, so the backfill sees the merged registry.

## Why

Follow-up to #211 / #212 — the refactor's own screen was contradicting it.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (327 tests, +5 for `planFolderDedupe`: paired-survivor, oldest fallback, same-named-companies skip, 3-way clone group)
- [x] Ran the app: opened pre-flight → 改存別處 → the dropdown offers 個人 ·（根目錄）only, no personal folders
- [x] Added or updated tests
- [x] No new user-facing strings

## Screenshots

Dropdown after the change: one 個人 option (root), org groups when signed in.