### PR TITLE
[chore] iOS 1.1: new version train for the voice-typing keyboard

### DIFF
--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -27,7 +27,7 @@ targets:
       path: Parley/Info.plist
       properties:
         CFBundleDisplayName: Parley
-        CFBundleShortVersionString: "1.0"
+        CFBundleShortVersionString: "1.1"
         CFBundleVersion: "5"
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: Parley listens to the meeting to transcribe and coach it live. Audio goes only to the transcription provider tied to your account.
@@ -61,7 +61,7 @@ targets:
       path: ../Keyboard/Info.plist
       properties:
         CFBundleDisplayName: Parley 語音
-        CFBundleShortVersionString: "1.0"
+        CFBundleShortVersionString: "1.1"
         CFBundleVersion: "5"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.keyboard-service

--- a/ios/Keyboard/Info.plist
+++ b/ios/Keyboard/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
Opens the 1.1 version train for the voice-typing keyboard (#210).

## Why

App Store Connect refused the build-5 upload against 1.0:

```
90186: Invalid Pre-Release Train. The train version '1.0' is closed for new build submissions
90062: CFBundleShortVersionString [1.0] must contain a higher version than the previously approved version [1.0]
```

1.0 is approved and live, so its train is closed. The keyboard is a new user-facing feature, so this opens 1.1 rather than a patch train.

Both targets (app + `ParleyKeyboard`) move together — a mismatched extension version fails validation.

## Verified

- `xcodegen generate` → both `Info.plist` files show 1.1 / build 5
- `xcodebuild archive` → **ARCHIVE SUCCEEDED**, both targets signed (Cloud Managed Apple Distribution, expires 2027-07-27)
- Export confirms `beta-reports-active`, App Group entitlement on both targets

## Upload status

Not uploaded from this session — the upload command was blocked by a local permission gate. The archive is built and ready at `ios/App/build/Parley.xcarchive`; it can be uploaded from Xcode Organizer (Distribute App → App Store Connect → Upload) or by re-running the export with `destination: upload`.
