### PR TITLE
[chore] iOS gets a release workflow, and a checklist that covers the keyboard

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,168 @@
+name: iOS Release
+
+# Archives the iPhone app and uploads it to App Store Connect / TestFlight.
+#
+# Separate from `release.yml` on purpose (design doc D5): the desktop app builds
+# on `v*.*.*` tags and ships a GitHub Release; iOS builds on `ios-v*` tags and
+# ships to TestFlight, where Apple — not this repo — decides what users get.
+#
+# Signing is Xcode-managed. The App Store Connect API key below is the same one
+# the desktop workflow uses for notarization; it is passed to both the archive
+# and the export so `-allowProvisioningUpdates` can mint profiles on a runner
+# that has never seen this team before.
+#
+#   git tag ios-v1.1 && git push origin ios-v1.1
+#
+# Every upload needs a CFBundleVersion App Store Connect has not seen. It comes
+# from `ios/App/project.yml`; the `build_number` input overrides it for a
+# re-upload without a commit (see ios/RELEASING.md).
+
+on:
+  push:
+    tags:
+      - "ios-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build, for example ios-v1.1"
+        required: true
+        type: string
+      build_number:
+        description: "Override CFBundleVersion (leave empty to use project.yml)"
+        required: false
+        type: string
+
+# Read-only: the deliverable goes to App Store Connect, not to a GitHub Release.
+permissions:
+  contents: read
+
+# Two archives racing to upload the same build number is a wasted 20 minutes and
+# a confusing error from Apple, not a merge conflict.
+concurrency:
+  group: ios-release
+  cancel-in-progress: false
+
+jobs:
+  testflight:
+    name: Archive and upload to TestFlight
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      # Pick the newest Xcode installed rather than pinning a runner image path,
+      # which Apple and GitHub both move. String Catalogs need 15, and the
+      # keyboard's App Intents need an 18 SDK to compile the @available branch,
+      # so fail loudly rather than producing a build with dictation missing.
+      - name: Select Xcode
+        run: |
+          newest="$(ls -d /Applications/Xcode*.app | sort -V | tail -1)"
+          echo "Using $newest"
+          sudo xcode-select -s "$newest"
+          xcodebuild -version
+          major="$(xcodebuild -version | head -1 | sed -E 's/Xcode ([0-9]+).*/\1/')"
+          if [ "$major" -lt 16 ]; then
+            echo "::error::Xcode $major is too old for this project (need 16+)"
+            exit 1
+          fi
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # The transcript core runs on macOS with no simulator, so it is cheap and
+      # there is no reason to ship a build whose segment logic is broken.
+      - name: Test ParleyKit
+        run: swift test --package-path ios/ParleyKit
+
+      - name: Override build number
+        if: inputs.build_number != ''
+        run: |
+          cd ios/App
+          sed -i '' -E "s/CFBundleVersion: \"[0-9]+\"/CFBundleVersion: \"${{ inputs.build_number }}\"/g" project.yml
+          grep -n 'CFBundleVersion' project.yml
+
+      - name: Generate project
+        run: cd ios/App && xcodegen generate
+
+      # A tag that disagrees with the plist ships the wrong thing under the right
+      # name, and it is only noticed once the build is sitting in TestFlight.
+      - name: Check the tag matches the marketing version
+        run: |
+          tag="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          want="${tag#ios-v}"
+          got="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' ios/App/Parley/Info.plist)"
+          build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' ios/App/Parley/Info.plist)"
+          echo "tag=$tag  version=$got  build=$build"
+          if [ "$want" != "$got" ]; then
+            echo "::error::tag $tag expects CFBundleShortVersionString $want, but the project says $got"
+            exit 1
+          fi
+
+      # `-authenticationKeyPath` needs a file. Written outside the workspace so
+      # it cannot be picked up by a later step or an artifact upload, and removed
+      # in an always() step below.
+      - name: Write the App Store Connect API key
+        env:
+          KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          if [ -z "$KEY_CONTENT" ]; then
+            echo "::error::APPLE_API_KEY_CONTENT is empty — see ios/RELEASING.md"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/asc"
+          chmod 700 "$RUNNER_TEMP/asc"
+          printf '%s' "$KEY_CONTENT" > "$RUNNER_TEMP/asc/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/asc/AuthKey.p8"
+
+      - name: Archive
+        run: |
+          cd ios/App
+          xcodebuild -project Parley.xcodeproj -scheme Parley \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Parley.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/asc/AuthKey.p8" \
+            -authenticationKeyID "${{ secrets.APPLE_API_KEY }}" \
+            -authenticationKeyIssuerID "${{ secrets.APPLE_API_ISSUER }}" \
+            archive
+
+      - name: Export and upload to App Store Connect
+        run: |
+          cd ios/App
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Parley.xcarchive" \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/asc/AuthKey.p8" \
+            -authenticationKeyID "${{ secrets.APPLE_API_KEY }}" \
+            -authenticationKeyIssuerID "${{ secrets.APPLE_API_ISSUER }}"
+
+      # Keep the symbols: a crash report from TestFlight is unreadable without
+      # the dSYMs from the exact archive that produced the build.
+      - name: Collect dSYMs
+        if: always()
+        run: |
+          if [ -d "$RUNNER_TEMP/Parley.xcarchive/dSYMs" ]; then
+            ditto -c -k --keepParent "$RUNNER_TEMP/Parley.xcarchive/dSYMs" "$RUNNER_TEMP/dSYMs.zip"
+          fi
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: parley-ios-${{ github.run_number }}
+          path: |
+            ${{ runner.temp }}/export/*.ipa
+            ${{ runner.temp }}/dSYMs.zip
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Remove the API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/asc"

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -2,22 +2,48 @@
 
 Parley iOS is the cloud companion for face-to-face meetings. It records the
 phone microphone, streams it through the hosted Parley relay, and syncs the
-Ogg recording plus transcript to the same account as the desktop app. It does
-not capture phone calls or other apps' audio.
+Ogg recording plus transcript to the same account as the desktop app. Since 1.1
+it also ships a voice-typing keyboard extension. It does not capture phone calls
+or other apps' audio.
 
-## Release build
+Already configured for the Pathors Apple team (`SXHVCQXJHZ`):
 
-Prerequisites already configured for the Pathors Apple team (`SXHVCQXJHZ`):
-
-- Bundle ID: `com.pathors.parley.ios`
+- Bundle IDs: `com.pathors.parley.ios`, `com.pathors.parley.ios.keyboard`
+- App Group: `group.com.pathors.parley.ios` (the app ↔ keyboard transcript handoff)
 - App Store Connect app: `Parley` (`6795031201`)
 - Sign in with Apple capability and hosted Better Auth Apple provider
 - Hosted login page: `https://api.parley.tw/sign-in`
 
-Each upload needs a new build number. `xcodegen generate` writes
-`App/Parley/Info.plist` from `App/project.yml`, so bump `CFBundleVersion` in
-**`App/project.yml`** — editing the plist alone is overwritten on the next
-generate. Keep the checked-in plist in step with it, then archive:
+## Release build
+
+**Preferred: tag and let CI do it.**
+
+```bash
+# bump CFBundleVersion in ios/App/project.yml first — see below
+git tag ios-v1.1 && git push origin ios-v1.1
+```
+
+[`ios-release.yml`](../.github/workflows/ios-release.yml) archives, exports, and
+uploads to TestFlight. It refuses to build if the tag disagrees with
+`CFBundleShortVersionString`, and keeps the `.ipa` and dSYMs as run artifacts —
+a TestFlight crash report is unreadable without the dSYMs from the exact archive
+that produced the build.
+
+It authenticates with the `APPLE_API_KEY_CONTENT` / `APPLE_API_KEY` /
+`APPLE_API_ISSUER` secrets, the same App Store Connect API key the desktop
+workflow notarizes with. If upload fails with a permissions error, that key's
+role is too narrow: create a new key with **App Manager** in App Store Connect →
+Users and Access → Integrations, and update those three secrets.
+
+**Build numbers.** Every upload needs a `CFBundleVersion` App Store Connect has
+not seen. `xcodegen generate` writes `App/Parley/Info.plist` from
+`App/project.yml`, so bump it in **`project.yml`** — editing the plist alone is
+overwritten on the next generate — and commit the regenerated plist with it.
+Both targets carry the number and both must move together. To re-upload without
+a commit, run the workflow manually with the `build_number` input.
+
+<details>
+<summary>Building and uploading by hand</summary>
 
 ```bash
 cd ios/App
@@ -31,43 +57,64 @@ xcodebuild -exportArchive -archivePath build/Parley.xcarchive \
 ```
 
 With an Xcode account signed in, the export uploads directly to App Store
-Connect. CI should use an App Store Connect API key with
-`-authenticationKeyPath`, `-authenticationKeyID`, and
-`-authenticationKeyIssuerID` instead of a GUI account.
+Connect.
+</details>
 
 ## Store metadata
 
-The canonical submission copy, privacy answers, review notes, and screenshot
-brief live in [`AppStore/`](AppStore/README.md). Keep this checklist concise;
-do not copy reviewer credentials into the repository.
+The canonical submission copy, privacy answers, review notes, and screenshots
+live in [`AppStore/`](AppStore/README.md), which has the ordered Connect
+checklist. Do not duplicate field values here and do not copy reviewer
+credentials into the repository.
 
-- **Support URL:** `https://parley.tw/support/`
-- **Privacy Policy URL:** `https://parley.tw/privacy/`
-- **Copyright:** `© 2026 Pathors AI`
-- **Screenshots:** upload 1–10 iPhone 6.5-inch PNG/JPEG screenshots without
-  alpha. Use an actual app session that shows live transcription, recording
-  library, and settings; do not use mocked desktop UI.
-- **App Privacy:** declare contact info (email), user content (audio recordings
-  and transcripts), and identifiers/account data. Mark the information as used
-  for app functionality; do not mark it as used for tracking.
+Two things in that checklist are easy to skip and expensive to skip:
 
-## Review notes
-
-Provide a working review account on the hosted email/password sign-in page and
-include this note:
-
-> Parley is a microphone-based, in-person meeting recorder. It does not record
-> phone calls or other app audio. The microphone starts only after the user taps
-> Start Recording and confirms they have consent from participants. Audio is
-> sent to the signed-in account's hosted transcription relay, and the completed
-> recording plus transcript sync to that account. Account deletion is available
-> in Settings → Account.
+- **English (U.S.) is the primary locale.** It is what every region without its
+  own localization sees. Connect restricts when primary language can change, so
+  it goes first.
+- **Screenshots are per-locale**, `AppStore/screenshots/en-US/` and
+  `zh-Hant/`, 1320×2868 (the 6.9-inch slot). Regenerate with
+  [`AppStore/capture-screenshots.sh`](AppStore/capture-screenshots.sh) whenever
+  the UI moves; it fails rather than shipping a blank or mis-sized frame.
 
 ## Before submission
 
-- [ ] Test hosted email/password, Google, and Apple login end-to-end on device.
-- [ ] Test microphone permission denial, background/lock-screen recording, an
-      interrupted network, and later queued-upload retry.
-- [ ] Verify personal folders, organization share/move, and account deletion.
-- [ ] Confirm the public privacy and support URLs load over HTTPS.
+Run on a real device, not only the simulator. Nothing below is covered by the
+unit tests.
+
+**Account and recording**
+
+- [ ] Hosted email/password, Google, and Apple sign-in end-to-end.
+- [ ] Microphone permission denial, and recovery after granting it in Settings.
+- [ ] Background and lock-screen recording survives; a phone call interrupts and
+      resumes cleanly.
+- [ ] Network dropped mid-recording → the finished recording queues, and
+      Settings → Sync retries it successfully.
+- [ ] Personal folders, organization share/move, and account deletion.
+
+**Voice keyboard (new in 1.1)**
+
+- [ ] Adding the keyboard in Settings → General → Keyboard, then enabling Full
+      Access.
+- [ ] **With Full Access off**, the keyboard still shows the explanation and a
+      working key row (globe, space, return, delete) — never a dead rectangle.
+      This is what guideline 4.4.1 review looks at.
+- [ ] Mic button → Parley records → the transcript types into the field you
+      started from, in a third-party app (Notes, Messages, Mail).
+- [ ] The Action Button intent starts dictation without bringing Parley forward.
+- [ ] A session left running stops itself at the 120-second cap.
+
+**Localization**
+
+- [ ] The app in both languages, switched via Settings → Parley → Language: no
+      English leaking into the Chinese build, no clipped or wrapped rows.
+- [ ] The keyboard's name in the system keyboard list is localized.
+
+**Public surfaces**
+
+- [ ] `https://parley.tw/privacy/` and `https://parley.tw/support/` load over
+      HTTPS, and the support page covers iOS in both languages.
+
+**Then**
+
 - [ ] Assign the processed TestFlight build and submit only after the above.


### PR DESCRIPTION
Two gaps in the way iOS ships.

## There was no iOS release workflow

Design doc D5 promised iOS its own `ios-v*` tag namespace and its own workflow. The tag namespace existed on paper; the workflow never did. `release.yml` fires on `v*.*.*` and is Tauri/macOS-only, so **every iPhone upload has been a manual archive from whichever Mac was nearby** — not reproducible, and not something a second person could do.

`ios-release.yml` archives, exports, and uploads to TestFlight on an `ios-v*` tag:

```bash
git tag ios-v1.1 && git push origin ios-v1.1
```

- **No new secret to provision.** It reuses `APPLE_API_KEY_CONTENT` / `APPLE_API_KEY` / `APPLE_API_ISSUER` — the App Store Connect API key the desktop workflow already notarizes with. If the upload 403s, that key's role is too narrow and needs App Manager; the failure mode is documented rather than guessed at.
- **Refuses a tag that lies.** `ios-v1.2` against a 1.1 plist ships the wrong thing under the right name, and it is only noticed once the build is in TestFlight.
- **Keeps the dSYMs.** A TestFlight crash report is unreadable without the symbols from the exact archive that produced the build.
- `permissions: contents: read` and a `concurrency` group — the deliverable goes to Apple, not to a GitHub Release, and two archives racing to upload the same build number is a wasted 20 minutes.
- Action SHAs pinned, matching the existing workflows.

## RELEASING.md had drifted from what the app is

It asked for **6.5-inch** screenshots (the sets are 6.9-inch and per-locale now), duplicated metadata that moved to `AppStore/`, and its pre-submission checklist had **no keyboard extension tests at all** — the entire 1.1 feature.

The additions worth calling out:

- **Full Access off must still leave a working key row.** That is precisely what guideline 4.4.1 review looks at, and it is the state nobody thinks to check because it is not how you use the thing.
- The transcript has to land in a **third-party** app, not in Parley.
- Both languages on device — none of that is covered by unit tests.

## Test

Workflow YAML parses; 13 steps, `ios-v*` trigger, `contents: read`. `actions/upload-artifact` SHA resolved against the API (v4.6.2). The archive path itself is exercised the first time a tag is pushed — a signed Release device build of both targets already succeeds locally with the existing provisioning profiles.