### PR TITLE
[fix] the voice keyboard now feels like a keyboard

### DIFF
--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -35,7 +35,7 @@ targets:
       properties:
         CFBundleDisplayName: Parley
         CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "5"
+        CFBundleVersion: "6"
         UILaunchScreen: {}
         # Localized in Parley/InfoPlist.xcstrings; this is the fallback value.
         NSMicrophoneUsageDescription: Parley records the meeting in the room so it can transcribe it live. Audio goes only to the transcription provider tied to your account.
@@ -71,7 +71,7 @@ targets:
         # Localized in ../Keyboard/InfoPlist.xcstrings; this is the fallback.
         CFBundleDisplayName: Parley Voice
         CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "5"
+        CFBundleVersion: "6"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.keyboard-service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).KeyboardViewController

--- a/ios/Keyboard/Info.plist
+++ b/ios/Keyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -1,14 +1,23 @@
 import SwiftUI
 
-/// The Parley keyboard's face. Deliberately spare: a big dictation control, a
-/// one-line preview of what the app is hearing, and a minimal key row so the
-/// keyboard still does something useful without Full Access (App Review 4.4.1).
+/// The Parley keyboard's face: a status line that shows the session is alive, a
+/// preview of the words not yet inserted, one large dictation control, and a
+/// minimal key row so the keyboard still types without Full Access (App Review
+/// 4.4.1).
+///
+/// Everything here is presentation only — no audio, no transcript history — so
+/// the extension stays well under the jetsam limit keyboard processes run
+/// against.
 struct KeyboardRootView: View {
     @ObservedObject var bridge: KeyboardBridge
     @Environment(\.openURL) private var openURL
 
+    /// The host field's appearance, not the system's: a dark-themed app puts a
+    /// dark keyboard on screen even in light mode.
+    var dark: Bool
+
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 8) {
             if bridge.hasFullAccess {
                 dictationArea
             } else {
@@ -16,44 +25,85 @@ struct KeyboardRootView: View {
             }
             keyRow
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity)
-        .frame(height: 216)
+        .padding(.horizontal, 4)
+        .padding(.top, 6)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(KBTheme.canvas(dark))
     }
 
     // MARK: dictation
 
     private var dictationArea: some View {
         VStack(spacing: 8) {
-            Text(bridge.listening ? preview : String(localized: "Tap the mic and talk — your words land right here"))
-                .font(.callout)
-                .foregroundStyle(bridge.listening ? Color.primary : Color.secondary)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity, minHeight: 40, alignment: .center)
-                .padding(.horizontal, 10)
-
-            Button(action: toggle) {
-                HStack(spacing: 10) {
-                    Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
-                        .font(.title3)
-                    Text(bridge.listening ? "Stop" : "Voice typing")
-                        .font(.body.weight(.semibold))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .foregroundStyle(.white)
-                .background(
-                    RoundedRectangle(cornerRadius: 14)
-                        .fill(bridge.listening ? Color.red : Color.accentColor))
-            }
-            .buttonStyle(.plain)
+            statusLine
+            preview
+            micButton
         }
     }
 
-    private var preview: String {
-        bridge.partial.isEmpty ? String(localized: "Listening…") : bridge.partial
+    /// A live indicator beats a static word: three bars that keep moving say the
+    /// app on the other side of the App Group is still listening, which is the
+    /// one thing a person cannot otherwise tell from inside another app.
+    private var statusLine: some View {
+        HStack(spacing: 7) {
+            if bridge.listening {
+                PulseBars(color: KBTheme.accent)
+                Text("Listening…")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(KBTheme.accent)
+            } else {
+                Image(systemName: "mic")
+                    .font(.caption)
+                    .foregroundStyle(KBTheme.inkSoft(dark))
+                Text("Tap to talk — your words land at the cursor")
+                    .font(.caption)
+                    .foregroundStyle(KBTheme.inkSoft(dark))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+        }
+        .frame(height: 16)
+        .animation(.easeInOut(duration: 0.2), value: bridge.listening)
+    }
+
+    /// The tentative tail — the words the app has heard but not yet settled.
+    /// Settled text is already in the document, so echoing it here would only
+    /// duplicate what the person can see behind the keyboard.
+    private var preview: some View {
+        Text(bridge.partial.isEmpty ? " " : bridge.partial)
+            .font(.callout)
+            .foregroundStyle(KBTheme.ink(dark).opacity(0.75))
+            .lineLimit(2)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(height: 52)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(KBTheme.well(dark)))
+            .padding(.horizontal, 4)
+            .animation(.easeOut(duration: 0.15), value: bridge.partial)
+    }
+
+    private var micButton: some View {
+        PressableButton(action: toggle) { pressed in
+            HStack(spacing: 9) {
+                Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                Text(bridge.listening ? "Stop" : "Voice typing")
+                    .font(.system(size: 17, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                    .fill(bridge.listening ? KBTheme.recording : KBTheme.accent)
+                    .brightness(pressed ? -0.08 : 0))
+        }
+        .padding(.horizontal, 4)
     }
 
     private func toggle() {
@@ -71,53 +121,107 @@ struct KeyboardRootView: View {
 
     // MARK: no Full Access
 
+    /// Without Full Access the keyboard has no network and no App Group, so
+    /// dictation cannot run. The key row below still types — the keyboard is
+    /// never a dead brick — and this explains the one switch that unlocks it.
     private var fullAccessNotice: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: 5) {
             Image(systemName: "mic.slash")
-                .font(.title2)
-                .foregroundStyle(.secondary)
+                .font(.title3)
+                .foregroundStyle(KBTheme.inkSoft(dark))
             Text("Voice typing needs Full Access")
-                .font(.callout.weight(.medium))
-            Text(
-                "Settings › General › Keyboard › Parley, then turn on Allow Full Access. Your voice goes to your Parley account to be transcribed, which is why it's needed."
-            )
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(KBTheme.ink(dark))
+            Text("Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(KBTheme.inkSoft(dark))
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 18)
         }
-        .frame(maxWidth: .infinity, minHeight: 96)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: minimal keys — keeps the keyboard functional without Full Access
 
     private var keyRow: some View {
         HStack(spacing: 6) {
-            key(system: "globe") { bridge.nextKeyboard() }
+            key(system: "globe", width: 46) { bridge.nextKeyboard() }
             key(text: "space", wide: true) { bridge.space() }
-            key(system: "return") { bridge.newline() }
-            key(system: "delete.left") { bridge.backspace() }
+            key(system: "return", width: 60) { bridge.newline() }
+            key(system: "delete.left", width: 46) { bridge.backspace() }
         }
-        .frame(height: 46)
+        .frame(height: 44)
+        .padding(.horizontal, 3)
     }
 
     private func key(
-        text: String? = nil, system: String? = nil, wide: Bool = false,
+        text: String? = nil, system: String? = nil,
+        width: CGFloat? = nil, wide: Bool = false,
         action: @escaping () -> Void
     ) -> some View {
-        Button(action: action) {
+        PressableButton(action: action) { pressed in
             Group {
-                if let system { Image(systemName: system) }
-                else { Text(text ?? "") }
+                if let system {
+                    Image(systemName: system).font(.system(size: 18, weight: .regular))
+                } else {
+                    Text(text ?? "").font(.system(size: 15))
+                }
             }
-            .font(.body)
-            .foregroundStyle(Color.primary)
-            .frame(maxWidth: wide ? .infinity : 52, maxHeight: .infinity)
+            .foregroundStyle(KBTheme.ink(dark))
+            .frame(maxWidth: wide ? .infinity : width, maxHeight: .infinity)
             .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(.secondarySystemBackground)))
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(pressed ? KBTheme.keyPressed(dark) : KBTheme.key(dark))
+                    .shadow(color: .black.opacity(dark ? 0 : 0.28), radius: 0, x: 0, y: 1))
         }
-        .buttonStyle(.plain)
+        .frame(maxWidth: wide ? .infinity : width)
+    }
+}
+
+/// A button that reports its own pressed state, so keys and the mic control can
+/// darken under the finger the way system keys do. `.buttonStyle(.plain)` alone
+/// gives no feedback at all, which is what made the keys feel dead.
+private struct PressableButton<Content: View>: View {
+    let action: () -> Void
+    @ViewBuilder var content: (Bool) -> Content
+
+    var body: some View {
+        Button(action: action) { EmptyView() }
+            .buttonStyle(PressStyle(content: content))
+    }
+
+    private struct PressStyle<C: View>: ButtonStyle {
+        @ViewBuilder var content: (Bool) -> C
+        func makeBody(configuration: Configuration) -> some View {
+            content(configuration.isPressed)
+                .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+        }
+    }
+}
+
+/// Three bars that keep breathing while the app is listening. Deliberately not
+/// a level meter: the audio lives in the container app, and streaming real
+/// levels across the App Group at frame rate would cost far more than the
+/// reassurance is worth. It says "still running", and nothing it can't know.
+private struct PulseBars: View {
+    let color: Color
+    @State private var animating = false
+
+    var body: some View {
+        HStack(spacing: 2.5) {
+            ForEach(0..<3, id: \.self) { i in
+                Capsule()
+                    .fill(color)
+                    .frame(width: 2.5, height: animating ? 12 : 4)
+                    .animation(
+                        .easeInOut(duration: 0.5)
+                            .repeatForever()
+                            .delay(Double(i) * 0.15),
+                        value: animating)
+            }
+        }
+        .frame(height: 14)
+        .onAppear { animating = true }
     }
 }

--- a/ios/Keyboard/KeyboardTheme.swift
+++ b/ios/Keyboard/KeyboardTheme.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import UIKit
+
+/// The keyboard's palette.
+///
+/// The extension can't reach the app target's `Theme`, and it must not follow
+/// the *system* appearance either: a keyboard follows the appearance of the
+/// field it is typing into (`UITextDocumentProxy.keyboardAppearance`), which a
+/// dark-themed host app sets to `.dark` even while iOS is in light mode. Every
+/// color here therefore takes the resolved appearance explicitly rather than
+/// reading the trait collection.
+enum KBTheme {
+    /// Parley's accent, matching the app's design tokens.
+    static let accent = Color(red: 0.04, green: 0.52, blue: 1.0)
+    static let recording = Color(red: 0.90, green: 0.27, blue: 0.24)
+
+    static func canvas(_ dark: Bool) -> Color {
+        dark ? Color(white: 0.11) : Color(red: 0.82, green: 0.84, blue: 0.86)
+    }
+
+    /// Key cap — deliberately lighter than the canvas in both appearances, the
+    /// way system keys read.
+    static func key(_ dark: Bool) -> Color {
+        dark ? Color(white: 0.28) : .white
+    }
+
+    static func keyPressed(_ dark: Bool) -> Color {
+        dark ? Color(white: 0.38) : Color(white: 0.85)
+    }
+
+    static func ink(_ dark: Bool) -> Color {
+        dark ? .white : Color(white: 0.08)
+    }
+
+    static func inkSoft(_ dark: Bool) -> Color {
+        dark ? Color(white: 0.62) : Color(white: 0.38)
+    }
+
+    /// Surface behind the transcript preview.
+    static func well(_ dark: Bool) -> Color {
+        dark ? Color(white: 0.16) : Color(white: 0.94)
+    }
+}

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -23,12 +23,19 @@ final class KeyboardViewController: UIInputViewController {
     /// session is a leftover from a previous dictation and is ignored.
     private var session = ""
     private var insertedCount = 0
+    private var host: UIHostingController<KeyboardRootView>?
+
+    /// A keyboard has no intrinsic height — without this it collapses to the
+    /// system minimum and the layout looks broken. 258 leaves room for the
+    /// status line, the preview well, the mic control, and the key row without
+    /// crowding, and sits in the same band as the system keyboard.
+    private static let preferredHeight: CGFloat = 258
 
     override func viewDidLoad() {
         super.viewDidLoad()
         bridge.controller = self
 
-        let root = UIHostingController(rootView: KeyboardRootView(bridge: bridge))
+        let root = UIHostingController(rootView: makeRoot())
         root.view.backgroundColor = .clear
         addChild(root)
         view.addSubview(root.view)
@@ -40,6 +47,14 @@ final class KeyboardViewController: UIInputViewController {
             root.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         root.didMove(toParent: self)
+        self.host = root
+
+        // Priority just below required: the system still gets to shrink the
+        // keyboard in a compact-height (landscape) layout rather than fighting
+        // an unsatisfiable constraint.
+        let height = view.heightAnchor.constraint(equalToConstant: Self.preferredHeight)
+        height.priority = .defaultHigh
+        height.isActive = true
 
         // The app fires this when the transcript grows; we also drain on every
         // appearance in case the keyboard was suspended through the notification.
@@ -53,7 +68,30 @@ final class KeyboardViewController: UIInputViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         bridge.hasFullAccess = hasFullAccess
+        refreshAppearance()
         drainDownlink()
+    }
+
+    /// A keyboard follows the appearance of the *field* it is typing into, not
+    /// the system's: a dark-themed host app asks for a dark keyboard even while
+    /// iOS is in light mode. `textInputMode` changes as the user moves between
+    /// fields, so this is re-read whenever the keyboard comes back.
+    override func textDidChange(_ textInput: UITextInput?) {
+        super.textDidChange(textInput)
+        refreshAppearance()
+    }
+
+    private func refreshAppearance() {
+        let dark = textDocumentProxy.keyboardAppearance == .dark
+        if host?.rootView.dark != dark {
+            host?.rootView = makeRoot(dark: dark)
+        }
+    }
+
+    private func makeRoot(dark: Bool? = nil) -> KeyboardRootView {
+        KeyboardRootView(
+            bridge: bridge,
+            dark: dark ?? (textDocumentProxy.keyboardAppearance == .dark))
     }
 
     // MARK: dictation control (called from SwiftUI)

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -102,6 +102,28 @@
           }
         }
       }
+    },
+    "Tap to talk — your words land at the cursor": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按一下就能說，說的話會落在游標位置"
+          }
+        }
+      }
+    },
+    "Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定 › 一般 › 鍵盤 › 鍵盤 › Parley → 允許完整取用權限。你的語音會送到 Parley 帳號進行轉錄。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
Reworks the voice keyboard UI (feedback from dogfooding: it looked flat and dead) and bumps the iOS build to 6 so the release can carry the fix.

## The problems

- Hard-coded 216pt height inside SwiftUI, fighting the edge-pinned host constraints.
- A static "Listening…" line — no sign the session on the other side of the App Group was actually alive.
- `.buttonStyle(.plain)` keys with zero press feedback; flat equal-width caps.
- Colors followed the **system** appearance, so a dark-themed host app got a light keyboard in light mode.

## The fix

- **Live pulse**: a three-bar indicator that keeps breathing while listening; the mic control turns into a red **Stop**. Deliberately not a level meter — the audio lives in the container app, and streaming real levels across the App Group per-frame would cost far more than the reassurance is worth. It says "still running", nothing it can't know.
- **Press feedback**: a custom `ButtonStyle` darkens keys and the mic under the finger.
- **Right appearance**: follows the host field's `keyboardAppearance` (re-read on `textDidChange`), not the system — a dark app gets a dark keyboard even in light mode. New `KBTheme` centralizes the palette since the extension can't reach the app's `Theme`.
- **Layout**: a settled 258pt height constraint (`.defaultHigh`, so landscape can still compress) replaces the internal 216; the transcript preview sits in its own rounded well at a fixed height so it never jumps.
- Minimal key row (globe / space / return / delete) unchanged in function — still types without Full Access (4.4.1).
- zh-Hant added for the two reworded strings.

## Verification

- `xcodebuild` app + keyboard extension → **BUILD SUCCEEDED** (iPhone 17 Pro sim).
- 1:1 layout preview of all four states (listening / idle / light pressed / no-Full-Access) reviewed.
- Not yet run on device — the live feel should be confirmed once on TestFlight.

Bumps `CFBundleVersion` to 6 for the 1.1 release build.
