### PR TITLE
[fix] voice keyboard dictates in place instead of stranding you in the app

### DIFF
--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ParleyKit
 import SwiftUI
+import UIKit
 
 /// Drives a keyboard-triggered dictation session inside the app, and hands the
 /// transcript back to the keyboard through the App Group.
@@ -35,7 +36,14 @@ final class DictationCoordinator: ObservableObject {
     private var capture: AudioCapture?
     private var relay: SttRelayClient?
     private var capTimer: Task<Void, Never>?
-    private var stopObserver: DarwinObserver?
+    /// Persistent uplink listener (armed for the process's whole life): stop
+    /// requests for the running session, and — the no-jump path — start
+    /// requests from a keyboard while this process is awake in the background.
+    private var requestObserver: DarwinObserver?
+    /// Keeps the process awake ~30 s after a session ends so an immediate
+    /// re-tap of the keyboard's mic starts over the Darwin channel with no
+    /// app switch. `.invalid` when no window is open.
+    private var lingerTask: UIBackgroundTaskIdentifier = .invalid
 
     /// Flatten the diarized segment stream to plain text: non-tail segments are
     /// settled runs (`mix-0`, `mix-1`, …) kept by id in arrival order; `mix-tail`
@@ -47,14 +55,17 @@ final class DictationCoordinator: ObservableObject {
     /// quota. The backstop stops the mic; the tail still flushes.
     private let maxSeconds: UInt64 = 120
 
-    private init() {}
+    private init() {
+        armRequestObserver()
+    }
 
     // MARK: entry points
 
     /// Start from the keyboard's `parley://dictate?session=…`.
     func begin(session: String) async {
         // A fresh open for the session the keyboard just wrote. If the same
-        // session is already running (double-delivery of the URL), ignore.
+        // session is already running (double-delivery of the URL, or the
+        // Darwin start raced the URL), ignore.
         if active && session == self.session { return }
         if active { await stop() }
         self.session = session
@@ -62,10 +73,15 @@ final class DictationCoordinator: ObservableObject {
         let host = DictationChannel.readUplink()?.hostBundleID
         await launch()
 
-        // Only offer the jump-back when the host resolved AND this iOS still
-        // honors it. On success `HostReturn` sends us to the background; the
-        // audio session keeps the mic alive (UIBackgroundModes: audio).
-        if state == .listening, let host, HostReturn.canReturn {
+        // Only offer the jump-back when the host resolved, this iOS still
+        // honors it, AND the app actually came forward (the URL path). A
+        // session started over the Darwin channel never left the host app, so
+        // there is nothing to return from. On success `HostReturn` sends us to
+        // the background; the audio session keeps the mic alive
+        // (UIBackgroundModes: audio).
+        if state == .listening, let host, HostReturn.canReturn,
+            UIApplication.shared.applicationState == .active
+        {
             returnableHost = host
             HostReturn.attempt(bundleID: host)
         } else {
@@ -87,6 +103,7 @@ final class DictationCoordinator: ObservableObject {
     // MARK: engine
 
     private func launch() async {
+        endLinger()  // the live audio session keeps the process awake from here
         errorMessage = nil
         runs = []
         committed = ""
@@ -94,6 +111,25 @@ final class DictationCoordinator: ObservableObject {
         state = .starting
         active = true
         publish()
+
+        #if DEBUG
+            // ScreenshotDemo: fake the session so the whole flow can be
+            // experienced (and captured) with no account, mic, or network.
+            // Only the transcript source is faked — the App Group hand-off,
+            // keyboard insertion, and stop path are the production code.
+            if ScreenshotDemo.servesFixtures {
+                state = .listening
+                publish()
+                armCap()
+                // The real path stays awake through the live audio session;
+                // the fake one has no audio, so it needs background-task time
+                // or iOS suspends the app the moment the user swipes back and
+                // the stream (and the Darwin channel) freezes.
+                beginLinger()
+                demoTask = Task { [weak self] in await self?.streamDemoTranscript() }
+                return
+            }
+        #endif
 
         // The keyboard reaches the app only for signed-in users (it never sees
         // the token — recording and the relay are the app's job), but a session
@@ -142,17 +178,24 @@ final class DictationCoordinator: ObservableObject {
 
         state = .listening
         publish()
-        armStopObserver()
         armCap()
     }
 
-    /// Listen for the keyboard's stop request (its ⏹ button) while recording.
-    private func armStopObserver() {
-        stopObserver = DarwinObserver(DictationChannel.upNote) { [weak self] in
+    /// The uplink channel, listened to for the process's whole life:
+    ///   - stop: the keyboard's ⏹ for the running session.
+    ///   - start: a keyboard minted a new session while this process happens
+    ///     to be awake (foreground, or lingering in the background right after
+    ///     a session). Starting here means the user never leaves their app —
+    ///     the keyboard only falls back to `parley://dictate` when this note
+    ///     lands on nobody (see `KeyboardViewController.startDictation`).
+    private func armRequestObserver() {
+        requestObserver = DarwinObserver(DictationChannel.upNote) { [weak self] in
             Task { @MainActor in
-                guard let self, self.active else { return }
-                if DictationChannel.readUplink()?.stopRequested == true {
-                    await self.stop()
+                guard let self, let up = DictationChannel.readUplink() else { return }
+                if up.stopRequested {
+                    if self.active, up.session == self.session { await self.stop() }
+                } else if !up.session.isEmpty, up.session != self.session {
+                    await self.begin(session: up.session)
                 }
             }
         }
@@ -190,6 +233,10 @@ final class DictationCoordinator: ObservableObject {
 
     func stop() async {
         guard active else { return }
+        #if DEBUG
+            demoTask?.cancel()
+            demoTask = nil
+        #endif
         capTimer?.cancel()
         capTimer = nil
         capture?.stop()
@@ -205,7 +252,6 @@ final class DictationCoordinator: ObservableObject {
 
     private func finishUp() {
         relay = nil
-        stopObserver = nil
         state = .done
         // Fold the last partial into the committed text so nothing said right
         // before the endpoint is dropped from what the keyboard inserts.
@@ -215,6 +261,7 @@ final class DictationCoordinator: ObservableObject {
         }
         publish()
         active = false
+        beginLinger()
     }
 
     private func fail(_ message: String) {
@@ -224,9 +271,29 @@ final class DictationCoordinator: ObservableObject {
         capTimer = nil
         capture?.stop()
         capture = nil
-        stopObserver = nil
         publish()
         active = false
+        beginLinger()
+    }
+
+    // MARK: background linger
+
+    /// With the audio session closed the system suspends this process within
+    /// seconds, and a suspended process can't hear the keyboard's next start
+    /// note — the user would get bounced through the app again. ~30 s of
+    /// background-task time covers the common "stop, think, dictate again"
+    /// beat with no app switch.
+    private func beginLinger() {
+        endLinger()
+        lingerTask = UIApplication.shared.beginBackgroundTask(withName: "dictation-relaunch") {
+            [weak self] in self?.endLinger()
+        }
+    }
+
+    private func endLinger() {
+        guard lingerTask != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(lingerTask)
+        lingerTask = .invalid
     }
 
     /// Mirror the live state into the downlink the keyboard reads.
@@ -243,4 +310,51 @@ final class DictationCoordinator: ObservableObject {
         if active { await stop() }
         active = false
     }
+
+    #if DEBUG
+        private var demoTask: Task<Void, Never>?
+
+        /// Feed the scripted transcript through the same
+        /// committed/partial/publish path the relay events drive, at roughly
+        /// speaking pace. Whatever is left as the tail when the user stops is
+        /// folded in by `finishUp`, exactly like a real session.
+        private func streamDemoTranscript() async {
+            // Real STT takes a beat before the first words settle (connect +
+            // actually speaking). Matching it also means text never lands in
+            // the sliver between the mic tap and the app switch, where a
+            // dying keyboard's insertText silently goes nowhere.
+            try? await Task.sleep(for: .milliseconds(1500))
+            var settled = ""
+            var tail = ""
+            for piece in ScreenshotDemo.dictationScript {
+                guard !Task.isCancelled, active else { return }
+                tail += piece
+                if tail.count >= 9 {
+                    settled += tail
+                    tail = ""
+                }
+                committed = settled
+                partial = tail
+                micLevel = Float.random(in: 0.08...0.45)
+                publish()
+                try? await Task.sleep(for: .milliseconds(200))
+            }
+            micLevel = 0.1
+        }
+
+        /// ScreenshotDemo (`parley://demo/dictation`): the stranded-listening
+        /// state — no host to bounce back to, so the screen shows the swipe
+        /// guide — with a fixture transcript. No mic, no relay, no account.
+        func seedDemoListening(committed: String, partial: String) {
+            guard ScreenshotDemo.isActive else { return }
+            session = "demo"
+            self.committed = committed
+            self.partial = partial
+            errorMessage = nil
+            micLevel = 0.15
+            returnableHost = nil
+            state = .listening
+            active = true
+        }
+    #endif
 }

--- a/ios/App/Parley/DictationView.swift
+++ b/ios/App/Parley/DictationView.swift
@@ -1,34 +1,44 @@
 import SwiftUI
 
-/// The screen the app shows while a keyboard-triggered dictation is live.
+/// The hand-off screen shown while a keyboard-triggered dictation is live.
+///
+/// Deliberately *not* a transcription screen. Dictation is experienced in the
+/// keyboard — the transcript streams into the Parley keyboard and lands at the
+/// cursor of the app the user was typing in. This screen exists only because
+/// the mic has to open in the app process, so the user briefly lands here; its
+/// one job is to send them back. Showing a live transcript here taught people
+/// the wrong model ("I talk on this screen, then paste"), so it doesn't.
 ///
 /// Two shapes, decided by `HostReturn.canReturn`:
-///   - Older iOS: the app has already bounced the user back to their app, so
-///     this is only seen briefly (or if they switch back to Parley). It shows
-///     the live transcript and a stop control.
-///   - iOS 26.4+: the automatic jump-back is gone, so this screen owns the
-///     hand-off — it teaches the one gesture that replaces it (swipe right on
-///     the home bar) and reassures that talking still works from the other app.
+///   - Older iOS: the app has already bounced the user back automatically, so
+///     this is only glimpsed in passing.
+///   - iOS 26.4+: the automatic jump-back is gone; the headline is the swipe
+///     gesture, and the guide sits at the very bottom, pointing at the real
+///     home indicator it wants swiped.
 struct DictationView: View {
     @ObservedObject var coordinator = DictationCoordinator.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @AppStorage("dictationSwipeGuideSeen") private var guideSeen = false
+
+    /// The user is stranded here and has to swipe back themselves.
+    private var needsManualReturn: Bool {
+        coordinator.returnableHost == nil
+            && (coordinator.state == .starting || coordinator.state == .listening)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Divider().overlay(Theme.border)
-            transcript
-            Divider().overlay(Theme.border)
+            Spacer()
+            status
+            Spacer()
             footer
         }
+        .frame(maxWidth: .infinity)
         .background(Theme.background)
-        .onDisappear { guideSeen = true }
     }
 
-    // MARK: header — state + level
+    // MARK: status — icon + the one instruction
 
-    private var header: some View {
+    private var status: some View {
         VStack(spacing: 14) {
             ZStack {
                 Circle()
@@ -52,6 +62,8 @@ struct DictationView: View {
             Text(statusTitle)
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(Theme.foreground)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
             Text(statusSubtitle)
                 .font(.subheadline)
                 .foregroundStyle(Theme.mutedForeground)
@@ -59,9 +71,6 @@ struct DictationView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 32)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 40)
-        .padding(.bottom, 24)
     }
 
     private var pulse: CGFloat {
@@ -76,7 +85,12 @@ struct DictationView: View {
         }
     }
 
+    /// The headline is whatever the user must do next. Stranded here, that is
+    /// the swipe back — "Listening…" would be answering the wrong question.
     private var statusTitle: String {
+        if needsManualReturn {
+            return String(localized: "Swipe back to your app")
+        }
         switch coordinator.state {
         case .starting: return String(localized: "Getting ready…")
         case .listening: return String(localized: "Listening…")
@@ -90,80 +104,47 @@ struct DictationView: View {
         if coordinator.state == .error {
             return coordinator.errorMessage ?? String(localized: "Please try again.")
         }
-        // The manual hand-off only matters while the app is actually the thing
-        // on screen, i.e. when auto-return didn't (or couldn't) fire.
-        if coordinator.returnableHost == nil {
+        if needsManualReturn {
             return String(
                 localized:
-                    "Speak and the words go straight into the field you were typing in. Swipe right on the home bar to get back to that app."
+                    "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen."
             )
         }
         return String(localized: "You're back in your app — just talk.")
     }
 
-    // MARK: transcript preview
+    // MARK: footer — only the swipe guide, hugging the home indicator
 
-    private var transcript: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
-                if coordinator.committed.isEmpty && coordinator.partial.isEmpty {
-                    Text("Waiting for you to speak…")
-                        .font(.body)
-                        .foregroundStyle(Theme.mutedForeground)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, 20)
-                } else {
-                    (Text(coordinator.committed).foregroundStyle(Theme.foreground)
-                        + Text(coordinator.partial).foregroundStyle(Theme.mutedForeground))
-                        .font(.body)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-            .padding(20)
-        }
-        .frame(maxHeight: .infinity)
-    }
-
-    // MARK: footer — swipe guide + stop
-
+    /// No stop control here on purpose: stopping (like everything else about
+    /// dictation) belongs to the keyboard's red ⏹. This screen never competes
+    /// with the keyboard for the session — its whole vocabulary is "go back".
     private var footer: some View {
-        VStack(spacing: 16) {
-            if coordinator.returnableHost == nil && !guideSeen
-                && coordinator.state == .listening
-            {
+        VStack(spacing: 14) {
+            // Last element on the screen, right above the real home indicator,
+            // and shown on every stranded session — a gesture nobody has ever
+            // performed isn't learned from one viewing.
+            if needsManualReturn {
                 SwipeBackGuide(animated: !reduceMotion)
             }
-            Button {
-                Task {
-                    await coordinator.stop()
-                    await coordinator.dismiss()
-                }
-            } label: {
-                Label(
-                    coordinator.state == .listening ? "Stop and insert" : "Done",
-                    systemImage: "stop.circle.fill"
-                )
-                .font(.body.weight(.medium))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .foregroundStyle(.white)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(Theme.recording)
         }
-        .padding(20)
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
     }
 }
 
 /// The one gesture that replaces auto-return on iOS 26.4+: an arrow sweeping
-/// right across a stand-in for the home indicator. Loops until the user has
-/// seen it once.
+/// right across a stand-in for the home indicator, drawn directly above the
+/// real one so the guide points at the thing it means.
 private struct SwipeBackGuide: View {
     let animated: Bool
     @State private var go = false
 
     var body: some View {
         VStack(spacing: 10) {
+            Text("Swipe right on the bar below")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Theme.foreground)
             ZStack(alignment: .leading) {
                 Capsule()
                     .fill(Theme.muted)
@@ -172,7 +153,8 @@ private struct SwipeBackGuide: View {
                 Image(systemName: "arrow.right")
                     .font(.footnote.weight(.bold))
                     .foregroundStyle(Theme.primary)
-                    .offset(x: go ? 120 : 0)
+                    .offset(x: go ? 150 : 0)
+                    .opacity(go ? 0 : 1)
                     .animation(
                         animated
                             ? .easeInOut(duration: 1.1).repeatForever(autoreverses: false)
@@ -180,12 +162,9 @@ private struct SwipeBackGuide: View {
                         value: go)
             }
             .frame(height: 20)
-            .frame(maxWidth: 180)
-            Text("Swipe right to go back")
-                .font(.caption)
-                .foregroundStyle(Theme.mutedForeground)
+            .frame(maxWidth: 220)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 10)
         .padding(.horizontal, 16)
         .frame(maxWidth: .infinity)
         .background(

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -1704,23 +1704,6 @@
         }
       }
     },
-    "Speak and the words go straight into the field you were typing in. Swipe right on the home bar to get back to that app.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speak and the words go straight into the field you were typing in. Swipe right on the home bar to get back to that app."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "說話就會即時打進剛才的輸入框。在底部橫條上往右滑，回到剛才的 App。"
-          }
-        }
-      }
-    },
     "Start Parley voice typing right where you are, without switching apps.": {
       "extractionState": "manual",
       "localizations": {
@@ -1772,23 +1755,6 @@
         }
       }
     },
-    "Stop and insert": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop and insert"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "結束並插入文字"
-          }
-        }
-      }
-    },
     "Support & feedback": {
       "extractionState": "manual",
       "localizations": {
@@ -1806,19 +1772,34 @@
         }
       }
     },
-    "Swipe right to go back": {
-      "extractionState": "manual",
+    "Swipe back to your app": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Swipe right to go back"
+            "value": "Swipe back to your app"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "往右滑，回到剛才的 App"
+            "value": "滑回剛才的 App"
+          }
+        }
+      }
+    },
+    "Swipe right on the bar below": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swipe right on the bar below"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在下面的橫條上往右滑"
           }
         }
       }
@@ -2214,23 +2195,6 @@
         }
       }
     },
-    "Waiting for you to speak…": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for you to speak…"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "等你開口……"
-          }
-        }
-      }
-    },
     "When the network drops, the server goes quiet, or you run out of quota, the phone holds on to finished recordings until they sync.": {
       "extractionState": "manual",
       "localizations": {
@@ -2414,6 +2378,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "語音要送到你的 Parley 帳號轉錄，需要這項權限才能運作。"
+          }
+        }
+      }
+    },
+    "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "說話的內容會直接顯示在 Parley 鍵盤上、即時打進游標處——這個畫面不會顯示任何東西。"
           }
         }
       }

--- a/ios/App/Parley/ScreenshotDemo.swift
+++ b/ios/App/Parley/ScreenshotDemo.swift
@@ -22,7 +22,8 @@
     ///     xcrun simctl launch <device> com.pathors.parley.ios -ParleyDemo signedIn
     ///     xcrun simctl openurl <device> parley://demo/library
     ///
-    /// Routes: `record`, `library`, `transcript`, `keyboard`, `settings`.
+    /// Routes: `record`, `library`, `transcript`, `keyboard`, `settings`,
+    /// `dictation`.
     @MainActor
     final class ScreenshotDemo: ObservableObject {
         static let shared = ScreenshotDemo()
@@ -66,6 +67,14 @@
                 tab = .settings
                 focusKeyboardSection = true
             case "settings": tab = .settings
+            case "dictation":
+                // The keyboard hand-off screen in its stranded-listening state
+                // (manual swipe-back, the iOS 26.4+ regime).
+                DictationCoordinator.shared.seedDemoListening(
+                    committed: Self.t(
+                        "Hi Anna, just wanted to let you know that my new number is ",
+                        "安納你好，跟你說一聲我的新電話號碼是"),
+                    partial: Self.t("four zero eight", "零九一二"))
             default: return false
             }
             return true
@@ -80,6 +89,28 @@
         }
 
         private static func t(_ en: String, _ zh: String) -> String { isChinese ? zh : en }
+
+        // MARK: dictation fixture
+
+        /// The dictation transcript, pre-chunked roughly the way the relay
+        /// settles text. `DictationCoordinator.streamDemoTranscript` plays it
+        /// back at speaking pace.
+        static var dictationScript: [String] {
+            let text = t(
+                "Hi Anna, just wanted to let you know that my new number is 0912 345 678. Talk soon!",
+                "嗨 Anna，跟你說一聲我的新電話號碼是 0912345678，之後再聊！")
+            var chunks: [String] = []
+            var current = ""
+            for ch in text {
+                current.append(ch)
+                if current.count >= 3 {
+                    chunks.append(current)
+                    current = ""
+                }
+            }
+            if !current.isEmpty { chunks.append(current) }
+            return chunks
+        }
 
         // MARK: account fixtures
 

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
-/// The Parley keyboard's face: a status line that shows the session is alive, a
-/// preview of the words not yet inserted, one large dictation control, and a
-/// minimal key row so the keyboard still types without Full Access (App Review
-/// 4.4.1).
+/// The Parley keyboard's face, in the shape dictation keyboards have settled
+/// on (Typeless, Wispr Flow): a brand mark and a delete key on top, one large
+/// mic pill in the middle under a short status caption, and a minimal
+/// space/return/globe row at the bottom so the keyboard still types without
+/// Full Access (App Review 4.4.1).
 ///
 /// Everything here is presentation only — no audio, no transcript history — so
 /// the extension stays well under the jetsam limit keyboard processes run
@@ -17,165 +18,162 @@ struct KeyboardRootView: View {
     var dark: Bool
 
     var body: some View {
-        VStack(spacing: 8) {
-            if bridge.hasFullAccess {
-                dictationArea
-            } else {
-                fullAccessNotice
+        VStack(spacing: 0) {
+            topBar
+            Spacer(minLength: 6)
+            caption
+            Spacer(minLength: 12)
+            micPill
+            Spacer(minLength: 12)
+            // Only devices without the system's own input switcher (next to
+            // the home indicator) get a globe here — everyone else already has
+            // one right below the keyboard, and a second would be noise.
+            if bridge.needsGlobe {
+                HStack {
+                    circleKey(system: "globe") { bridge.nextKeyboard() }
+                    Spacer()
+                }
             }
-            keyRow
         }
-        .padding(.horizontal, 4)
-        .padding(.top, 6)
-        .padding(.bottom, 4)
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(KBTheme.canvas(dark))
     }
 
-    // MARK: dictation
+    // MARK: top bar — brand + delete
 
-    private var dictationArea: some View {
-        VStack(spacing: 8) {
-            statusLine
-            preview
-            micButton
+    private var topBar: some View {
+        HStack {
+            HStack(spacing: 5) {
+                Image(systemName: "waveform")
+                    .font(.footnote.weight(.semibold))
+                Text(verbatim: "Parley")
+                    .font(.footnote.weight(.semibold))
+            }
+            .foregroundStyle(KBTheme.inkSoft(dark))
+            Spacer()
+            circleKey(system: "delete.left") { bridge.backspace() }
         }
+        .frame(height: 38)
     }
 
-    /// A live indicator beats a static word: three bars that keep moving say the
-    /// app on the other side of the App Group is still listening, which is the
-    /// one thing a person cannot otherwise tell from inside another app.
-    private var statusLine: some View {
-        HStack(spacing: 7) {
-            if bridge.listening {
-                PulseBars(color: KBTheme.accent)
-                Text("Listening…")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(KBTheme.accent)
+    // MARK: caption — the state line above the mic
+
+    /// One fixed-height slot so the layout never jumps between states: the
+    /// Full Access explainer, the idle prompt, the listening indicator, or the
+    /// tentative tail (the words heard but not yet settled — settled text is
+    /// already in the document behind the keyboard, so it is never echoed).
+    private var caption: some View {
+        Group {
+            if !bridge.hasFullAccess {
+                VStack(spacing: 3) {
+                    Text("Voice typing needs Full Access")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(KBTheme.ink(dark))
+                    Text("Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.")
+                        .font(.caption2)
+                        .foregroundStyle(KBTheme.inkSoft(dark))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 12)
+                }
+            } else if let error = bridge.errorText, !bridge.listening {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(KBTheme.recording)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+            } else if bridge.listening && !bridge.partial.isEmpty {
+                Text(bridge.partial)
+                    .font(.callout)
+                    .foregroundStyle(KBTheme.ink(dark).opacity(0.8))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+            } else if bridge.listening {
+                HStack(spacing: 7) {
+                    PulseBars(color: KBTheme.recording)
+                    Text("Listening…")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(KBTheme.recording)
+                }
             } else {
-                Image(systemName: "mic")
-                    .font(.caption)
+                Text("Tap to speak")
+                    .font(.subheadline)
                     .foregroundStyle(KBTheme.inkSoft(dark))
-                Text("Tap to talk — your words land at the cursor")
-                    .font(.caption)
-                    .foregroundStyle(KBTheme.inkSoft(dark))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.85)
             }
         }
-        .frame(height: 16)
-        .animation(.easeInOut(duration: 0.2), value: bridge.listening)
+        .frame(height: 48)
+        .frame(maxWidth: .infinity)
+        .animation(.easeInOut(duration: 0.15), value: bridge.listening)
+        .animation(.easeOut(duration: 0.15), value: bridge.partial)
     }
 
-    /// The tentative tail — the words the app has heard but not yet settled.
-    /// Settled text is already in the document, so echoing it here would only
-    /// duplicate what the person can see behind the keyboard.
-    private var preview: some View {
-        Text(bridge.partial.isEmpty ? " " : bridge.partial)
-            .font(.callout)
-            .foregroundStyle(KBTheme.ink(dark).opacity(0.75))
-            .lineLimit(2)
-            .multilineTextAlignment(.leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(height: 52)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(KBTheme.well(dark)))
-            .padding(.horizontal, 4)
-            .animation(.easeOut(duration: 0.15), value: bridge.partial)
-    }
+    // MARK: the mic pill
 
-    private var micButton: some View {
+    private var micPill: some View {
         PressableButton(action: toggle) { pressed in
-            HStack(spacing: 9) {
-                Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
-                    .font(.system(size: 17, weight: .semibold))
-                Text(bridge.listening ? "Stop" : "Voice typing")
-                    .font(.system(size: 17, weight: .semibold))
-            }
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 50)
-            .background(
-                RoundedRectangle(cornerRadius: 13, style: .continuous)
-                    .fill(bridge.listening ? KBTheme.recording : KBTheme.accent)
-                    .brightness(pressed ? -0.08 : 0))
+            Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(micInk)
+                .frame(width: 150, height: 52)
+                .background(
+                    Capsule().fill(micFill).brightness(pressed ? -0.08 : 0))
         }
-        .padding(.horizontal, 4)
+        .disabled(!bridge.hasFullAccess)
+        .accessibilityLabel(
+            bridge.listening
+                ? Text("Stop dictation") : Text("Start dictation"))
+    }
+
+    /// Idle: the Typeless-style ink pill — near-black on a light canvas, white
+    /// on a dark one. Recording: the shared recording red. Disabled (no Full
+    /// Access): a key-colored pill so it reads inert.
+    private var micFill: Color {
+        if !bridge.hasFullAccess { return KBTheme.key(dark) }
+        if bridge.listening { return KBTheme.recording }
+        return dark ? .white : Color(white: 0.10)
+    }
+
+    private var micInk: Color {
+        if !bridge.hasFullAccess { return KBTheme.inkSoft(dark) }
+        if bridge.listening { return .white }
+        return dark ? Color(white: 0.10) : .white
     }
 
     private func toggle() {
         if bridge.listening {
             bridge.stop()
-        } else if let url = bridge.prepare() {
-            // SwiftUI's openURL is the path that still opens the container app
-            // from a keyboard on iOS 18+. If the system declines, fall back to
-            // the responder-chain walk for older releases.
-            openURL(url) { accepted in
-                if !accepted { bridge.fallbackOpen(url) }
-            }
-        }
-    }
-
-    // MARK: no Full Access
-
-    /// Without Full Access the keyboard has no network and no App Group, so
-    /// dictation cannot run. The key row below still types — the keyboard is
-    /// never a dead brick — and this explains the one switch that unlocks it.
-    private var fullAccessNotice: some View {
-        VStack(spacing: 5) {
-            Image(systemName: "mic.slash")
-                .font(.title3)
-                .foregroundStyle(KBTheme.inkSoft(dark))
-            Text("Voice typing needs Full Access")
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(KBTheme.ink(dark))
-            Text("Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.")
-                .font(.caption)
-                .foregroundStyle(KBTheme.inkSoft(dark))
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 18)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    // MARK: minimal keys — keeps the keyboard functional without Full Access
-
-    private var keyRow: some View {
-        HStack(spacing: 6) {
-            key(system: "globe", width: 46) { bridge.nextKeyboard() }
-            key(text: "space", wide: true) { bridge.space() }
-            key(system: "return", width: 60) { bridge.newline() }
-            key(system: "delete.left", width: 46) { bridge.backspace() }
-        }
-        .frame(height: 44)
-        .padding(.horizontal, 3)
-    }
-
-    private func key(
-        text: String? = nil, system: String? = nil,
-        width: CGFloat? = nil, wide: Bool = false,
-        action: @escaping () -> Void
-    ) -> some View {
-        PressableButton(action: action) { pressed in
-            Group {
-                if let system {
-                    Image(systemName: system).font(.system(size: 18, weight: .regular))
-                } else {
-                    Text(text ?? "").font(.system(size: 15))
+        } else {
+            // The bridge tries the no-jump start first; the completion only
+            // fires when the app really has to come forward. SwiftUI's openURL
+            // is the path that still opens the container app from a keyboard
+            // on iOS 18+; the responder-chain walk covers older releases.
+            bridge.start { url in
+                guard let url else { return }
+                openURL(url) { accepted in
+                    if !accepted { bridge.fallbackOpen(url) }
                 }
             }
-            .foregroundStyle(KBTheme.ink(dark))
-            .frame(maxWidth: wide ? .infinity : width, maxHeight: .infinity)
-            .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(pressed ? KBTheme.keyPressed(dark) : KBTheme.key(dark))
-                    .shadow(color: .black.opacity(dark ? 0 : 0.28), radius: 0, x: 0, y: 1))
         }
-        .frame(maxWidth: wide ? .infinity : width)
+    }
+
+    // MARK: key shapes
+
+    private func circleKey(system: String, action: @escaping () -> Void) -> some View {
+        PressableButton(action: action) { pressed in
+            Image(systemName: system)
+                .font(.system(size: 16, weight: .regular))
+                .foregroundStyle(KBTheme.ink(dark))
+                .frame(width: 44, height: 38)
+                .background(
+                    Capsule()
+                        .fill(pressed ? KBTheme.keyPressed(dark) : KBTheme.key(dark))
+                        .shadow(
+                            color: .black.opacity(dark ? 0 : 0.28),
+                            radius: 0, x: 0, y: 1))
+        }
     }
 }
 

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -26,10 +26,12 @@ final class KeyboardViewController: UIInputViewController {
     private var host: UIHostingController<KeyboardRootView>?
 
     /// A keyboard has no intrinsic height — without this it collapses to the
-    /// system minimum and the layout looks broken. 258 leaves room for the
-    /// status line, the preview well, the mic control, and the key row without
-    /// crowding, and sits in the same band as the system keyboard.
-    private static let preferredHeight: CGFloat = 258
+    /// system minimum and the layout looks broken. The taller variant makes
+    /// room for the globe row that only exists on devices where the system
+    /// doesn't draw its own input switcher next to the home indicator.
+    private var preferredHeight: CGFloat {
+        needsInputModeSwitchKey ? 252 : 216
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,7 +54,7 @@ final class KeyboardViewController: UIInputViewController {
         // Priority just below required: the system still gets to shrink the
         // keyboard in a compact-height (landscape) layout rather than fighting
         // an unsatisfiable constraint.
-        let height = view.heightAnchor.constraint(equalToConstant: Self.preferredHeight)
+        let height = view.heightAnchor.constraint(equalToConstant: preferredHeight)
         height.priority = .defaultHigh
         height.isActive = true
 
@@ -68,6 +70,10 @@ final class KeyboardViewController: UIInputViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         bridge.hasFullAccess = hasFullAccess
+        // Only devices where the system doesn't draw its own switcher beside
+        // the home indicator need a globe inside the keyboard (4.4.1 — the
+        // user must always have a way out of this keyboard).
+        bridge.needsGlobe = needsInputModeSwitchKey
         refreshAppearance()
         drainDownlink()
     }
@@ -96,12 +102,22 @@ final class KeyboardViewController: UIInputViewController {
 
     // MARK: dictation control (called from SwiftUI)
 
-    /// Prepare a session: mint an id, capture the host app for the app's
-    /// auto-return, and publish the request. Returns the URL the SwiftUI view
-    /// should open (its `openURL` action is the path that still works on iOS
-    /// 18+); `openContainerApp` is the older-system fallback.
-    func prepareDictation() -> URL? {
-        guard hasFullAccess else { return nil }
+    /// How long the keyboard waits for the app to acknowledge a start request
+    /// before falling back to opening the app. An awake app publishes the
+    /// `starting` downlink within milliseconds of the Darwin note; a suspended
+    /// or dead app never will, and the only thing that can wake it is the URL.
+    private static let startAckWindow: Duration = .milliseconds(700)
+
+    /// Start a session, preferring the path with no app switch: publish the
+    /// request to the App Group (which posts the uplink note) and wait briefly
+    /// for the app to acknowledge by publishing our session's downlink. The
+    /// app hears the note whenever it is awake — foreground, or lingering in
+    /// the background right after a previous dictation — and starts the mic
+    /// there, so the user never leaves the app they're typing in. Only when
+    /// the ack never comes does `completion` hand back the `parley://dictate`
+    /// URL for the visible round trip.
+    func startDictation(completion: @escaping (URL?) -> Void) {
+        guard hasFullAccess else { return }
         session = UUID().uuidString
         insertedCount = 0
         DictationChannel.writeUplink(
@@ -112,7 +128,21 @@ final class KeyboardViewController: UIInputViewController {
                 insertedCount: 0))
         bridge.listening = true
         bridge.partial = ""
-        return DictationChannel.startURL(session: session)
+        bridge.errorText = nil
+
+        let target = session
+        Task { @MainActor [weak self] in
+            let deadline = ContinuousClock.now + Self.startAckWindow
+            while ContinuousClock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(80))
+                guard let self, self.session == target else { return }
+                if DictationChannel.readDownlink()?.session == target {
+                    return  // acked — the app is recording, nobody moved
+                }
+            }
+            guard let self, self.session == target else { return }
+            completion(DictationChannel.startURL(session: target))
+        }
     }
 
     /// Ask the app to stop and flush the tail. The app is running during
@@ -127,12 +157,41 @@ final class KeyboardViewController: UIInputViewController {
         bridge.listening = false
     }
 
+    /// How old a downlink may be and still get adopted by a keyboard that
+    /// didn't mint its session. Sessions are hard-capped at 120 s (the app's
+    /// `maxSeconds`), and every segment and state change re-stamps the file, so
+    /// anything older is a leftover — a crashed app's frozen `listening` file
+    /// or a long-finished transcript that would land in the wrong field.
+    private static let adoptionWindow: TimeInterval = 150
+
     /// Read the transcript the app has published and insert whatever is new.
     /// Idempotent: `insertedCount` is the high-water mark, so a keyboard that
     /// was killed and relaunched mid-session never re-inserts settled text.
     private func drainDownlink() {
-        guard hasFullAccess, let d = DictationChannel.readDownlink(), d.session == session
-        else { return }
+        guard hasFullAccess, let d = DictationChannel.readDownlink() else { return }
+
+        // Adopt a session this process didn't mint. iOS kills the keyboard
+        // almost every time the user bounces to the app, so on the way back the
+        // downlink belongs to a session the (relaunched) keyboard has never
+        // heard of — refusing it is what made returning feel dead. (This also
+        // covers Action Button sessions, which no keyboard minted.)
+        //
+        // A foreign downlink is adopted only when it answers the *standing*
+        // uplink request and is fresh. The uplink match is what makes this
+        // safe: it proves the high-water mark in that uplink belongs to this
+        // very session, so nothing already inserted can re-insert — and a
+        // keyboard that just minted a new session (its uplink carries the new
+        // id) can never resurrect the previous transcript. Errors are never
+        // adopted; the message belongs on the app's screen, not in a field.
+        if d.session != session {
+            guard d.state != .error,
+                let at = d.updatedAt,
+                Date().timeIntervalSince(at) < Self.adoptionWindow,
+                DictationChannel.readUplink()?.session == d.session
+            else { return }
+            session = d.session
+            insertedCount = 0
+        }
 
         // A relaunched keyboard restores its position from the uplink it wrote.
         if insertedCount == 0, let up = DictationChannel.readUplink(), up.session == session {
@@ -153,9 +212,15 @@ final class KeyboardViewController: UIInputViewController {
         switch d.state {
         case .starting, .listening: bridge.listening = true
         case .finishing: bridge.listening = true
-        case .done, .error:
+        case .done:
             bridge.listening = false
             bridge.partial = ""
+        case .error:
+            bridge.listening = false
+            bridge.partial = ""
+            // Surface the app's failure where the user actually is. Swallowing
+            // it (the old behavior) read as "the mic button does nothing".
+            bridge.errorText = d.errorMessage ?? String(localized: "Couldn't start. Try again.")
         }
     }
 
@@ -178,8 +243,6 @@ final class KeyboardViewController: UIInputViewController {
 
     // MARK: minimal keys (called from SwiftUI)
 
-    func insertSpace() { textDocumentProxy.insertText(" ") }
-    func insertNewline() { textDocumentProxy.insertText("\n") }
     func deleteBackward() { textDocumentProxy.deleteBackward() }
     func switchKeyboard() { advanceToNextInputMode() }
 }
@@ -193,14 +256,22 @@ final class KeyboardBridge: ObservableObject {
     @Published var hasFullAccess = false
     @Published var listening = false
     @Published var partial = ""
+    /// The app's failure for the last session (sign-in, mic permission,
+    /// connection), shown in the caption slot until the next start.
+    @Published var errorText: String?
+    /// Whether this device needs a globe inside the keyboard (no system
+    /// switcher next to the home indicator).
+    @Published var needsGlobe = false
 
-    /// Mint the session and return the URL for the SwiftUI `openURL` action.
-    func prepare() -> URL? { controller?.prepareDictation() }
+    /// Start a session. `completion` fires only when the app has to be opened
+    /// (the no-jump Darwin start wasn't acknowledged) with the URL for the
+    /// SwiftUI `openURL` action.
+    func start(completion: @escaping (URL?) -> Void) {
+        controller?.startDictation(completion: completion)
+    }
     /// Older-iOS fallback when `openURL` reports the app didn't open.
     func fallbackOpen(_ url: URL) { controller?.openContainerApp(url) }
     func stop() { controller?.stopDictation() }
-    func space() { controller?.insertSpace() }
-    func newline() { controller?.insertNewline() }
     func backspace() { controller?.deleteBackward() }
     func nextKeyboard() { controller?.switchKeyboard() }
 }

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -1,6 +1,22 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Couldn't start. Try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't start. Try again."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒能啟動，再試一次。"
+          }
+        }
+      }
+    },
     "Listening…": {
       "extractionState": "manual",
       "localizations": {
@@ -18,70 +34,61 @@
         }
       }
     },
-    "Settings › General › Keyboard › Parley, then turn on Allow Full Access. Your voice goes to your Parley account to be transcribed, which is why it's needed.": {
+    "Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings › General › Keyboard › Parley, then turn on Allow Full Access. Your voice goes to your Parley account to be transcribed, which is why it's needed."
-          }
-        },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "設定 › 一般 › 鍵盤 › Parley，開啟「允許完整取用權限」。語音要送到 Parley 帳號轉錄，所以需要這項權限。"
+            "value": "設定 › 一般 › 鍵盤 › 鍵盤 › Parley → 允許完整取用權限。你的語音會送到 Parley 帳號進行轉錄。"
           }
         }
       }
     },
-    "Stop": {
-      "extractionState": "manual",
+    "Start dictation": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stop"
+            "value": "Start dictation"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "結束"
+            "value": "開始語音輸入"
           }
         }
       }
     },
-    "Tap the mic and talk — your words land right here": {
-      "extractionState": "manual",
+    "Stop dictation": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap the mic and talk — your words land right here"
+            "value": "Stop dictation"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "按下麥克風開始說話，文字會直接打在這裡"
+            "value": "停止語音輸入"
           }
         }
       }
     },
-    "Voice typing": {
-      "extractionState": "manual",
+    "Tap to speak": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Voice typing"
+            "value": "Tap to speak"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "語音輸入"
+            "value": "點一下開始說話"
           }
         }
       }
@@ -99,28 +106,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "語音輸入需要「完整取用權限」"
-          }
-        }
-      }
-    },
-    "Tap to talk — your words land at the cursor": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "按一下就能說，說的話會落在游標位置"
-          }
-        }
-      }
-    },
-    "Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定 › 一般 › 鍵盤 › 鍵盤 › Parley → 允許完整取用權限。你的語音會送到 Parley 帳號進行轉錄。"
           }
         }
       }

--- a/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
@@ -52,6 +52,11 @@ public enum DictationChannel {
         public var partial: String
         public var state: State
         public var errorMessage: String?
+        /// When the app last wrote this file (stamped by `writeDownlink`).
+        /// Optional so files written before the field existed still decode. The
+        /// keyboard uses it to bound how long a finished session's tail is still
+        /// worth inserting after a relaunch (see `KeyboardViewController`).
+        public var updatedAt: Date?
 
         public enum State: String, Codable, Sendable {
             case starting, listening, finishing, done, error
@@ -59,18 +64,22 @@ public enum DictationChannel {
 
         public init(
             session: String, committed: String = "", partial: String = "",
-            state: State = .starting, errorMessage: String? = nil
+            state: State = .starting, errorMessage: String? = nil,
+            updatedAt: Date? = nil
         ) {
             self.session = session
             self.committed = committed
             self.partial = partial
             self.state = state
             self.errorMessage = errorMessage
+            self.updatedAt = updatedAt
         }
     }
 
     public static func writeDownlink(_ value: Downlink) {
-        write(value, to: "dictation-down.json")
+        var stamped = value
+        stamped.updatedAt = Date()
+        write(stamped, to: "dictation-down.json")
         post(downNote)
     }
 


### PR DESCRIPTION
## What this changes

Reworks the voice-typing keyboard so dictation is experienced **in the keyboard**, not in the app. The mic button used to open Parley and strand the user on a transcription-looking screen, and returning to their app inserted nothing. Now the app is a pure hand-off ("swipe back"), the transcript streams onto the keyboard and lands at the cursor, and a stop→restart no longer bounces through the app at all.

## Why

Two problems, reported from device use:

1. **Returning to the app inserted nothing.** iOS almost always kills the keyboard extension the moment the user jumps to Parley. On the way back, a *fresh* keyboard process had an empty `session` and `drainDownlink()` refused every downlink whose session id it hadn't minted itself — so the transcript flowed through the App Group while the keyboard sat dead. This also silently broke Action Button dictation (whose session no keyboard ever mints).
2. **The mental model was wrong.** The app screen showed a live transcript and "just talk" copy, teaching people "I talk here, then paste". Dictation should happen where you type.

## How it works

- **Session adoption** (`KeyboardViewController.drainDownlink`): a relaunched keyboard adopts a foreign session when it answers the standing uplink request and is fresh (new `Downlink.updatedAt`, bounded by the 120 s session cap). The uplink match guarantees the high-water `insertedCount` belongs to that session, so nothing already inserted re-inserts. Errors are never adopted.
- **No-jump restart**: `startDictation` publishes the request to the App Group + posts the Darwin note and waits ~700 ms for the app to ack (publish the session's downlink). An awake app — foreground, or lingering in the background right after a session — starts the mic there and the user never leaves their app. The app holds a ~30 s `beginBackgroundTask` window after each session so the common "stop, think, dictate again" beat is app-switch-free. Only an unacked start opens `parley://dictate`.
- **Keyboard face** reshaped to the dictation-keyboard norm (brand, delete, one mic pill, "Tap to speak"). Dropped the redundant space/return row; the in-keyboard globe now shows only on devices without the system's own input switcher (4.4.1 — the user must always have a way out).
- **App screen** is now a hand-off only: no transcript, no stop control, just "swipe back" with the swipe guide hugging the real home indicator, shown every session. Stopping lives on the keyboard's red button.
- App-side failures (sign-in, mic permission, connection) now surface in the keyboard caption instead of being swallowed as "the mic button does nothing".
- DEBUG-only demo route `parley://demo/dictation` streams a fixture transcript through the real committed/partial/publish path, so the whole flow can be exercised (and captured) with no account, mic, or network.

## How it was verified

- [x] `swift test` in `ParleyKit` passes (19 tests)
- [x] Built for the simulator and drove the full flow live: enabled the keyboard with Full Access, and in Messages confirmed swipe-back → keyboard streams text to the cursor → stop → re-tap mic **stays in the app** and continues. Verified the uplink high-water mark prevents re-insertion.
- [x] New user-facing strings added to **both** `en` and `zh-Hant` in the app and keyboard `Localizable.xcstrings`

## Screenshots

Keyboard (idle): brand + delete on top, one dark "Tap to speak" mic pill, no redundant key row. While listening the caption shows the partial tail; app failures show in red. The app hand-off screen shows only "Swipe back to your app" with the guide above the home indicator — no transcript, no stop button. (Captured live in simulator during verification.)
