### PR TITLE
[chore] ios: bump to 1.2 (build 7)

### DIFF
--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -34,8 +34,8 @@ targets:
       path: Parley/Info.plist
       properties:
         CFBundleDisplayName: Parley
-        CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "6"
+        CFBundleShortVersionString: "1.2"
+        CFBundleVersion: "7"
         UILaunchScreen: {}
         # Localized in Parley/InfoPlist.xcstrings; this is the fallback value.
         NSMicrophoneUsageDescription: Parley records the meeting in the room so it can transcribe it live. Audio goes only to the transcription provider tied to your account.
@@ -70,8 +70,8 @@ targets:
       properties:
         # Localized in ../Keyboard/InfoPlist.xcstrings; this is the fallback.
         CFBundleDisplayName: Parley Voice
-        CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "6"
+        CFBundleShortVersionString: "1.2"
+        CFBundleVersion: "7"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.keyboard-service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).KeyboardViewController

--- a/ios/README.md
+++ b/ios/README.md
@@ -4,7 +4,7 @@ Native SwiftUI companion app — real-time AI coaching for **in-person** meeting
 
 Lives in the main repo as `ios/` alongside the desktop app, `website/`, `virtual-mic/`, and `mcp/`. The cloud backend stays in the private parley-internal repo; this app talks to it only through the public sync contract.
 
-**Status: 1.1, in App Store review.** The app records in-person meetings, transcribes them live through the hosted relay, syncs them to the account, and ships a voice-typing keyboard extension. `ParleyKit` holds the transcript core, ported line-for-line from the desktop's Rust with matching unit tests:
+**Status: 1.1 on the App Store; 1.2 in preparation.** The app records in-person meetings, transcribes them live through the hosted relay, syncs them to the account, and ships a voice-typing keyboard extension. `ParleyKit` holds the transcript core, ported line-for-line from the desktop's Rust with matching unit tests:
 
 - `SegmentBuilder` — speaker-run accumulation, stable segment ids, partial/final tail semantics (port of `src-tauri/src/transcription/common.rs`)
 - `SonioxProtocol` + `SonioxStreamParser` — the Soniox realtime wire protocol as spoken through Parley's hosted STT relay (`wss://api.parley.tw/stt/stream`): config frame without vendor key, `keepalive`/`finalize` control frames, `<end>`/`<fin>` endpoint markers, error frames


### PR DESCRIPTION
Version bump for the iOS App Store release that ships the voice-keyboard dictation fix (#222). `CFBundleShortVersionString` 1.1 → 1.2, `CFBundleVersion` 6 → 7 for both the app and keyboard targets. README status updated (1.1 is live; 1.2 in prep).