### PR TITLE
[fix] ios: attribute keyboard dictation STT as voice_typing

### DIFF
--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -148,7 +148,10 @@ final class DictationCoordinator: ObservableObject {
         }
 
         let client = SttRelayClient(
-            options: .init(bearerToken: token, feature: "dictation")
+            // "voice_typing" is the cloud's whitelisted tag for this flow (the
+            // relay only attributes meeting | voice_typing | realtime; anything
+            // else is billed unattributed).
+            options: .init(bearerToken: token, feature: "voice_typing")
         ) { [weak self] event in
             Task { @MainActor in self?.handle(event) }
         }


### PR DESCRIPTION
## Problem

The keyboard-triggered dictation flow connects to the hosted STT relay with `feature: "dictation"` (`DictationCoordinator.swift`), but the cloud's `/stt/stream` route only attributes `meeting | voice_typing | realtime` — anything else is stored as an empty feature. iOS voice-typing STT usage is therefore billed with no feature attribution.

## Fix

One string: `"dictation"` → `"voice_typing"`, plus a comment pinning the whitelist so the next flow doesn't repeat this. `LiveView` already sends the correct `"meeting"`.

## Related (not fixed here)

The **desktop** app never sends `?feature=` at all (`sttRelayUrl()` in `src/lib/transcription/providers.ts` builds the URL bare), so desktop meeting *and* voice-typing usage is also unattributed. That needs plumbing through the Rust start commands — separate change.