### PR TITLE
[fix] desktop: send STT billing feature tag to the hosted relay

### DIFF
--- a/src/lib/meeting/start.ts
+++ b/src/lib/meeting/start.ts
@@ -72,7 +72,7 @@ async function openCaptureSession(settings: Settings, sttKey: string): Promise<v
       apiKey: sttKey,
       diarization: provider.diarization,
       inputDevice: settings.inputDevice,
-      relayUrl: sttRelayUrl(settings.transcriptionProvider),
+      relayUrl: sttRelayUrl(settings.transcriptionProvider, "meeting"),
       // Meeting translation (off → nulls): "me" runs through Gemini
       // live-translate; the voice goes out the translate output device.
       translateLanguage: translating ? settings.translateTargetLanguage : null,

--- a/src/lib/transcription/providers.ts
+++ b/src/lib/transcription/providers.ts
@@ -89,7 +89,17 @@ export function sttApiKey(settings: Settings, id: SttProviderId): string {
  * `sttApiKey`), so the vendor key never lives on the client. BYOK providers
  * connect straight to their vendor — no relay. Every streaming start command
  * (meeting AND voice typing) must pass this alongside the key.
+ *
+ * `feature` is the cloud's billing-attribution tag: the relay only records
+ * "meeting" | "voice_typing" | "realtime" (anything else is stored blank), so
+ * each start path must name itself. Rust uses the URL verbatim — the query
+ * param travels with it.
  */
-export function sttRelayUrl(id: SttProviderId): string | undefined {
-  return id === "parley" ? `${CLOUD_URL.replace(/^http/, "ws")}/stt/stream` : undefined;
+export function sttRelayUrl(
+  id: SttProviderId,
+  feature: "meeting" | "voice_typing" | "realtime",
+): string | undefined {
+  return id === "parley"
+    ? `${CLOUD_URL.replace(/^http/, "ws")}/stt/stream?feature=${feature}`
+    : undefined;
 }

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -259,7 +259,7 @@ async function startSession() {
     apiKey,
     languageHints: [],
     inputDevice: settings.inputDevice ?? null,
-    relayUrl: sttRelayUrl(provider),
+    relayUrl: sttRelayUrl(provider, "voice_typing"),
     maxDurationSecs: hosted ? HOSTED_VOICE_TYPING_MAX_SECONDS : null,
   });
   const shown = showOverlay().catch((error) =>


### PR DESCRIPTION
## Problem

The desktop app connects to the hosted STT relay with a bare `wss://api.parley.tw/stt/stream` — no `?feature=` — so ALL desktop hosted-STT usage (meetings and voice typing) lands in `stt_session` with an empty feature and can't be attributed in the usage ledger. iOS already sends the tag ([#226](https://github.com/pathorsAI/parley/pull/226) fixed its value).

## Fix

Rust connects to `relay_endpoint` verbatim, so no Rust plumbing is needed — the query param rides the URL:

- `sttRelayUrl(id, feature)` now requires a feature tag (typed to the cloud's whitelist `meeting | voice_typing | realtime`) and appends it to the relay URL.
- `meeting/start.ts` passes `"meeting"` (covers translate mode too — same start command).
- `voiceTyping/host.ts` passes `"voice_typing"`.

Making the parameter required means the next streaming start path can't silently ship unattributed.

## Verification

`bunx tsc --noEmit` clean, `bunx vitest run` 329/329 green. BYOK providers unaffected (`sttRelayUrl` still returns `undefined` for them).