### PR TITLE
[feature] MCP external-analysis surface: recording-level write-back for external AI analysts

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -594,7 +594,8 @@ fn tools() -> Vec<Value> {
                     "quotes": { "type": "array", "items": { "type": "string" } },
                     "evalIds": { "type": "array", "items": { "type": "string" } },
                     "resolved": { "type": "boolean" },
-                    "resolution": { "type": "string" }
+                    "resolution": { "type": "string" },
+                    "author": { "type": "string" }
                 },
                 "required": ["id"]
             }),
@@ -610,14 +611,19 @@ fn tools() -> Vec<Value> {
             "List saved recordings (history)",
             "List the user's locally saved recordings (the personal history library), \
              newest first, as summary cards: { id, title, source, createdAt, durationMs, \
-             speakerCount, findingsCount, actionItemsCount, hasAudio, snippet, folderId }. \
-             Optional text query filters by title + transcript snippet. Org-shared \
-             recordings live in the cloud — list those with list_org_recordings.",
+             speakerCount, findingsCount, actionItemsCount, hasAudio, analyzed?, snippet, \
+             folderId }. `analyzed` mirrors the entry's pipeline-complete flag (absent on \
+             cards saved before it existed = state unknown). Optional text query filters by \
+             title + transcript snippet; `since` keeps only recordings created at/after that \
+             epoch-ms timestamp — the cheap way for an external analyst to poll for new \
+             recordings. Org-shared recordings live in the cloud — list those with \
+             list_org_recordings.",
             json!({
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "Case-insensitive text filter over title + snippet." },
                     "folderId": { "type": "string", "description": "Only recordings in this personal folder (get ids from list_folders)." },
+                    "since": { "type": "number", "description": "Only recordings with createdAt >= this epoch-ms timestamp." },
                     "limit": { "type": "number", "description": "Max results (default 50)." }
                 }
             }),
@@ -646,6 +652,74 @@ fn tools() -> Vec<Value> {
                     "title": { "type": "string" }
                 },
                 "required": ["id", "title"]
+            }),
+        ),
+        tool(
+            "update_recording_meta",
+            "Update a saved recording's meeting frame",
+            "Update a saved recording's FRAME by id: `meetingType` (free-form scenario id; \
+             'sales' is the built-in default scenario), `meetingContext` (free text), and/or \
+             `speakerNames` (merged per key, e.g. {\"them-1\": \"Jamie\"}; an empty string \
+             removes that custom name). Use this to fix a misclassified meeting type or a \
+             wrong speaker mapping so later reads and analysis get the right frame. Applied \
+             by the app (which also syncs to cloud); waits for the app to confirm.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "meetingType": { "type": "string", "description": "Scenario id (free-form; built-in default is 'sales')." },
+                    "meetingContext": { "type": "string", "description": "Free-text meeting context." },
+                    "speakerNames": {
+                        "type": "object",
+                        "description": "Speaker-key → display-name patch, merged per key (empty string removes). Keys look like 'me-1' / 'them-1' / 'mix-2' — see speakerNames on get_recording.",
+                        "additionalProperties": { "type": "string" }
+                    }
+                },
+                "required": ["id"]
+            }),
+        ),
+        tool(
+            "set_recording_analysis",
+            "Write analysis results onto a saved recording",
+            "The write-back surface for an EXTERNAL analyst: write analysis results onto a \
+             saved recording by id. Each provided field REPLACES that whole field — \
+             `findings` (timeline markers; stamp `author`, e.g. 'claude', so they stay \
+             distinguishable from Parley's own pass), `actionItems`, `brief` (markdown \
+             debrief), `analyzed` (mark the recording analyzed so list_recordings filtering \
+             can skip it). Omitted fields are left untouched. Read get_recording FIRST and \
+             carry forward anything worth keeping — findings you omit from the new list are \
+             gone. If the recording is open in replay the UI updates immediately. Applied by \
+             the app (which also syncs to cloud); waits for the app to confirm.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "findings": {
+                        "type": "array",
+                        "description": "Full replacement findings list (see finding fields).",
+                        "items": finding_schema()
+                    },
+                    "actionItems": {
+                        "type": "array",
+                        "description": "Full replacement action-item list.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string", "description": "Stable id; omit to mint a new one." },
+                                "text": { "type": "string", "description": "The concrete next step / follow-up." },
+                                "rationale": { "type": "string", "description": "Why it matters." },
+                                "done": { "type": "boolean" },
+                                "linkedEventId": { "type": "string", "description": "The finding this derives from, if any." },
+                                "atMs": { "type": "number", "description": "Seek target on the recording, if any." },
+                                "severity": { "type": "string", "enum": ["info", "warn", "critical"] }
+                            },
+                            "required": ["text"]
+                        }
+                    },
+                    "brief": { "type": "string", "description": "Markdown debrief / meeting notes (the 重點 brief)." },
+                    "analyzed": { "type": "boolean", "description": "Mark the analysis pipeline complete for this recording." }
+                },
+                "required": ["id"]
             }),
         ),
         tool(
@@ -866,7 +940,8 @@ fn finding_schema() -> Value {
             "quotes": { "type": "array", "items": { "type": "string" }, "description": "Supporting verbatim quotes." },
             "evalIds": { "type": "array", "items": { "type": "string" }, "description": "Matching evaluation ids (for source=eval)." },
             "resolved": { "type": "boolean", "description": "True when ME later addressed/defused this moment." },
-            "resolution": { "type": "string", "description": "One line on how ME handled it (only when resolved)." }
+            "resolution": { "type": "string", "description": "One line on how ME handled it (only when resolved)." },
+            "author": { "type": "string", "description": "Which analyst wrote this marker (e.g. 'claude'); omit for Parley's own pass." }
         },
         "required": ["atMs", "side", "severity", "title", "detail"]
     })
@@ -996,6 +1071,14 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
                 }),
             )
             .await?
+        }
+        "update_recording_meta" => {
+            required_str(&args, "id")?; // frontend validates the rest of the patch
+            call_frontend(state, "update_recording_meta", args).await?
+        }
+        "set_recording_analysis" => {
+            required_str(&args, "id")?; // frontend normalizes findings/actionItems
+            call_frontend(state, "set_recording_analysis", args).await?
         }
         "list_folders" => call_frontend(state, "list_folders", json!({})).await?,
         "import_transcript" => {
@@ -1357,6 +1440,7 @@ fn list_recordings(history_dir: &std::path::Path, args: &Value) -> anyhow::Resul
         .trim()
         .to_lowercase();
     let folder = args.get("folderId").and_then(Value::as_str);
+    let since = args.get("since").and_then(Value::as_i64).unwrap_or(0);
     let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(50) as usize;
 
     let mut items: Vec<Value> = Vec::new();
@@ -1372,6 +1456,9 @@ fn list_recordings(history_dir: &std::path::Path, args: &Value) -> anyhow::Resul
                 if v.get("folderId").and_then(Value::as_str) != Some(folder) {
                     continue;
                 }
+            }
+            if since > 0 && v.get("createdAt").and_then(Value::as_i64).unwrap_or(0) < since {
+                continue;
             }
             if !query.is_empty() {
                 let title = v.get("title").and_then(Value::as_str).unwrap_or("");
@@ -1421,6 +1508,9 @@ fn get_recording(history_dir: &std::path::Path, id: &str) -> anyhow::Result<Valu
         "meetingType",
         "meetingContext",
         "folderId",
+        "companyId",
+        "threadId",
+        "analyzed",
     ] {
         if let Some(v) = meta.get(key) {
             if !v.is_null() {

--- a/src/lib/history/history.test.ts
+++ b/src/lib/history/history.test.ts
@@ -31,6 +31,12 @@ function entry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {
 }
 
 describe("buildSummary", () => {
+  it("mirrors the analyzed flag onto the summary card (absent stays absent)", () => {
+    expect(buildSummary(entry({ analyzed: true })).analyzed).toBe(true);
+    expect(buildSummary(entry({ analyzed: false })).analyzed).toBe(false);
+    expect(buildSummary(entry()).analyzed).toBeUndefined();
+  });
+
   it("counts distinct speakers by source+speaker, ignoring empty-text turns", () => {
     const s = buildSummary(
       entry({

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -27,7 +27,7 @@ import { buildOwnershipIndex, ownerBackfill, planFolderDedupe } from "../library
 import { rediarizeSegments } from "../speakers/postDiarize";
 import { translate } from "../../i18n/messages";
 import type { ReplaySession } from "../replay/types";
-import type { TranscriptSegment } from "../types";
+import type { ActionItem, TimelineEvent, TranscriptSegment } from "../types";
 import type { HistoryEntry, HistoryEntrySummary } from "./types";
 
 const HISTORY_UPDATED_EVENT = "history://updated";
@@ -67,6 +67,7 @@ export function buildSummary(entry: HistoryEntry): HistoryEntrySummary {
     findingsCount: entry.findings.length,
     actionItemsCount: entry.actionItems.length,
     hasAudio: entry.audio != null,
+    analyzed: entry.analyzed,
     snippet: snippetOf(entry),
     folderId: entry.folderId ?? null,
     companyId: entry.companyId ?? null,
@@ -686,6 +687,131 @@ export async function setEntryFolder(id: string, folderId: string | null): Promi
   });
   log.info("history: entry folder set", { id, folderId });
   pushToCloud(id); // sync the new folderId (best-effort; gated by the sync toggle)
+}
+
+// ── External-analyst writes (MCP) ────────────────────────────────────────────
+
+/** The frame fields an MCP client may retarget on a saved recording. */
+export interface EntryMetaPatch {
+  meetingType?: string;
+  meetingContext?: string;
+  /** Merged per key into the existing map; an empty-string value removes the
+   *  custom name for that key (same semantics as the store's setSpeakerName). */
+  speakerNames?: Record<string, string>;
+}
+
+/**
+ * Patch a saved recording's FRAME — scenario (meetingType), free-text context,
+ * speaker display names — without touching its analysis. This is how an MCP
+ * client fixes a misclassified meeting (e.g. an office hour analyzed as a sales
+ * call) or a wrong speaker mapping, so every later read gets the right frame.
+ * Same read-modify-write as {@link persistStudyOutputs}; the open replay's
+ * store is synced so the UI reflects the fix immediately.
+ */
+export async function updateEntryMeta(id: string, patch: EntryMetaPatch): Promise<HistoryEntry> {
+  const { meta } = await invoke<HistoryReadResult>("read_history_entry", { id });
+  const speakerNames = patch.speakerNames
+    ? mergeSpeakerNames(meta.speakerNames ?? {}, patch.speakerNames)
+    : meta.speakerNames;
+  const updated: HistoryEntry = {
+    ...meta,
+    ...(patch.meetingType !== undefined ? { meetingType: patch.meetingType } : {}),
+    ...(patch.meetingContext !== undefined ? { meetingContext: patch.meetingContext } : {}),
+    speakerNames,
+  };
+  await invoke("save_history_entry", {
+    id,
+    summaryJson: JSON.stringify(buildSummary(updated)),
+    metaJson: JSON.stringify(updated),
+    audioSourcePath: null, // leave the recording untouched
+    compress: false,
+  });
+  const s = useStore.getState();
+  if (s.loadedHistoryId === id) {
+    if (patch.meetingType !== undefined) s.setMeetingType(patch.meetingType);
+    if (patch.meetingContext !== undefined) s.setMeetingContext(patch.meetingContext);
+    for (const [key, name] of Object.entries(patch.speakerNames ?? {})) s.setSpeakerName(key, name);
+  }
+  await emitHistoryUpdated(id);
+  pushToCloud(id); // best-effort; gated by the sync toggle
+  log.info("history: entry meta updated", {
+    id,
+    meetingType: updated.meetingType ?? null,
+    speakerKeys: Object.keys(patch.speakerNames ?? {}).length,
+  });
+  return updated;
+}
+
+/** Empty-string values remove the key; everything else overwrites it. */
+function mergeSpeakerNames(
+  current: Record<string, string>,
+  patch: Record<string, string>,
+): Record<string, string> {
+  const next = { ...current };
+  for (const [key, name] of Object.entries(patch)) {
+    if (name.trim()) next[key] = name.trim();
+    else delete next[key];
+  }
+  return next;
+}
+
+/** The analysis fields an MCP client may replace on a saved recording. */
+export interface EntryAnalysisPatch {
+  findings?: TimelineEvent[];
+  actionItems?: ActionItem[];
+  brief?: string | null;
+  analyzed?: boolean;
+}
+
+/**
+ * Write analysis results onto a saved recording — the write-back surface for an
+ * EXTERNAL analyst (an MCP client doing its own pass over the transcript).
+ * Each provided field replaces that whole field; omitted fields are untouched,
+ * so a brief write can't clobber findings and vice versa. The rebuilt
+ * summary.json keeps the library card's counts (and the `analyzed` flag other
+ * clients filter on) honest. Syncs the open replay's store so the timeline
+ * re-renders immediately.
+ */
+export async function setEntryAnalysis(
+  id: string,
+  patch: EntryAnalysisPatch,
+): Promise<{ id: string; findings: number; actionItems: number; brief: boolean; analyzed: boolean | null }> {
+  const { meta } = await invoke<HistoryReadResult>("read_history_entry", { id });
+  const updated: HistoryEntry = {
+    ...meta,
+    ...(patch.findings ? { findings: patch.findings } : {}),
+    ...(patch.actionItems ? { actionItems: patch.actionItems } : {}),
+    ...(patch.brief !== undefined ? { brief: patch.brief } : {}),
+    ...(patch.analyzed !== undefined ? { analyzed: patch.analyzed } : {}),
+  };
+  await invoke("save_history_entry", {
+    id,
+    summaryJson: JSON.stringify(buildSummary(updated)),
+    metaJson: JSON.stringify(updated),
+    audioSourcePath: null, // leave the recording untouched
+    compress: false,
+  });
+  const s = useStore.getState();
+  if (s.loadedHistoryId === id) {
+    if (patch.findings) s.setFindings(patch.findings);
+    if (patch.actionItems) s.setActionItems(patch.actionItems);
+    if (patch.brief !== undefined) s.setBrief(patch.brief);
+  }
+  await emitHistoryUpdated(id);
+  pushToCloud(id); // best-effort; gated by the sync toggle
+  log.info("history: entry analysis written externally", {
+    id,
+    findings: updated.findings.length,
+    actionItems: updated.actionItems.length,
+    brief: !!updated.brief,
+  });
+  return {
+    id,
+    findings: updated.findings.length,
+    actionItems: updated.actionItems.length,
+    brief: !!updated.brief,
+    analyzed: updated.analyzed ?? null,
+  };
 }
 
 /**

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -91,6 +91,10 @@ export interface HistoryEntrySummary {
    *  field existed simply omit it (the card then hides the action-item stat). */
   actionItemsCount?: number;
   hasAudio: boolean;
+  /** Mirrors {@link HistoryEntry.analyzed} so an MCP client can find
+   *  not-yet-analyzed recordings from the cheap list alone. Optional: summaries
+   *  written before this field existed omit it (state unknown). */
+  analyzed?: boolean;
   /** First spoken line of the transcript, for a preview. */
   snippet: string;
   /** Accounts link, for the company page's meeting timeline. */

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useStore } from "./store";
 import { isTauri } from "./tauriEvents";
-import type { EvalDef, TimelineEvent } from "./types";
+import type { ActionItem, EvalDef, TimelineEvent } from "./types";
 import type { ClaimCategory } from "./accounts/types";
 
 /**
@@ -78,6 +78,32 @@ function normalizeFinding(raw: unknown): TimelineEvent | null {
     detail,
     resolved: typeof o.resolved === "boolean" ? o.resolved : undefined,
     resolution: typeof o.resolution === "string" ? o.resolution : undefined,
+    quotes: Array.isArray(o.quotes) ? o.quotes.map(String).filter(Boolean) : undefined,
+    author: typeof o.author === "string" && o.author.trim() ? o.author.trim() : undefined,
+  };
+}
+
+/**
+ * Coerce a loosely-shaped action item (from an MCP client) into a valid
+ * {@link ActionItem}. Returns null when there is no text to act on.
+ */
+function normalizeActionItem(raw: unknown): ActionItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const text = typeof o.text === "string" ? o.text.trim() : "";
+  if (!text) return null;
+  const severity =
+    o.severity === "info" || o.severity === "warn" || o.severity === "critical"
+      ? o.severity
+      : undefined;
+  return {
+    id: typeof o.id === "string" && o.id ? o.id : crypto.randomUUID(),
+    text,
+    rationale: typeof o.rationale === "string" ? o.rationale : "",
+    done: o.done === true,
+    linkedEventId: typeof o.linkedEventId === "string" && o.linkedEventId ? o.linkedEventId : null,
+    atMs: Number.isFinite(o.atMs) ? Number(o.atMs) : null,
+    severity,
   };
 }
 
@@ -173,6 +199,57 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       const s = useStore.getState();
       if (s.loadedHistoryId === id) s.renameReplay(title);
       return { id, title };
+    }
+    case "update_recording_meta": {
+      // Fix a saved recording's FRAME (scenario / context / speaker names) so
+      // later reads and analysis passes get the right picture — the repair path
+      // for a misclassified meeting or a wrong me/them speaker mapping.
+      const id = argStr(a.id);
+      if (!id) throw new Error("id is required");
+      const { updateEntryMeta } = await import("./history/history");
+      const patch: import("./history/history").EntryMetaPatch = {};
+      if (typeof a.meetingType === "string") patch.meetingType = a.meetingType;
+      if (typeof a.meetingContext === "string") patch.meetingContext = a.meetingContext;
+      if (a.speakerNames && typeof a.speakerNames === "object" && !Array.isArray(a.speakerNames)) {
+        const names: Record<string, string> = {};
+        for (const [key, name] of Object.entries(a.speakerNames)) names[key] = argStr(name);
+        patch.speakerNames = names;
+      }
+      if (!Object.keys(patch).length) {
+        throw new Error("nothing to update — pass meetingType, meetingContext and/or speakerNames");
+      }
+      const updated = await updateEntryMeta(id, patch);
+      return {
+        id,
+        meetingType: updated.meetingType ?? null,
+        meetingContext: updated.meetingContext ?? "",
+        speakerNames: updated.speakerNames ?? {},
+      };
+    }
+    case "set_recording_analysis": {
+      // External-analyst write-back: replace whole analysis fields on a saved
+      // recording. Normalization mirrors the live finding path so an MCP payload
+      // can never write an invalid shape to disk.
+      const id = argStr(a.id);
+      if (!id) throw new Error("id is required");
+      const { setEntryAnalysis } = await import("./history/history");
+      const patch: import("./history/history").EntryAnalysisPatch = {};
+      if (Array.isArray(a.findings)) {
+        patch.findings = a.findings
+          .map(normalizeFinding)
+          .filter((f): f is TimelineEvent => f !== null);
+      }
+      if (Array.isArray(a.actionItems)) {
+        patch.actionItems = a.actionItems
+          .map(normalizeActionItem)
+          .filter((i): i is ActionItem => i !== null);
+      }
+      if (typeof a.brief === "string") patch.brief = a.brief;
+      if (typeof a.analyzed === "boolean") patch.analyzed = a.analyzed;
+      if (!Object.keys(patch).length) {
+        throw new Error("nothing to write — pass findings, actionItems, brief and/or analyzed");
+      }
+      return await setEntryAnalysis(id, patch);
     }
     case "move_recording_to_folder": {
       const id = argStr(a.id);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -146,6 +146,12 @@ export interface TimelineEvent {
   resolved?: boolean;
   /** One short line on HOW ME handled it — present only when {@link resolved}. */
   resolution?: string;
+  /** Supporting verbatim quotes from the transcript. */
+  quotes?: string[];
+  /** Which analyst wrote this marker: absent = Parley's own pipeline; an MCP
+   *  client stamps its agent name (e.g. "claude") so external and built-in
+   *  findings stay distinguishable side by side. */
+  author?: string;
 }
 
 /** A meeting to-do / agenda item to make sure gets covered. */


### PR DESCRIPTION
## What this changes

Adds the MCP write-back surface that lets an external AI analyst (e.g. a Claude Code session) own the analysis of saved recordings while Parley stays the capture/transcribe/replay layer:

- **`update_recording_meta`** — patch a saved recording's frame by id: `meetingType` (scenario id), `meetingContext`, and `speakerNames` (merged per key; empty string removes a custom name). This is the repair path for a misclassified meeting (e.g. an office hour analyzed as a sales call) or a wrong me/them speaker mapping.
- **`set_recording_analysis`** — replace whole analysis fields on a saved recording by id: `findings`, `actionItems`, `brief` (markdown debrief), and the `analyzed` flag. Omitted fields stay untouched; payloads are normalized by the frontend before hitting disk; the open replay syncs immediately; cloud push rides the existing lifecycle.
- **`list_recordings`** gains a `since` filter (createdAt >= epoch ms) and the summary cards now mirror the entry's `analyzed` flag, so an external analyst can poll cheaply for new, not-yet-analyzed recordings.
- **`TimelineEvent`** gains `author` (which analyst wrote a marker — external passes stamp e.g. "claude", Parley's own pass omits it) and `quotes`. `quotes` was already advertised in the MCP finding schema but missing from the TS type, so quotes sent by MCP clients were silently dropped by `normalizeFinding` — fixed.
- **`get_recording`** additionally returns `analyzed`, `companyId`, `threadId`.

Both new tools ride the existing `call_frontend` RPC so writes go through the frontend's read-modify-write + cloud-sync path (same as `rename_recording`), never raw file writes behind the app's back.

## Why

The external-AI analysis loop (transcribe in Parley → analyze in an AI app over MCP → write conclusions back) currently dead-ends at write-back: findings tools only touch the *loaded session*, and meeting type / speaker mapping / brief / action items are read-only over MCP. In practice Parley's built-in pass can misread a meeting (a mentoring office hour classified as `sales`, the user mapped to `them-1`) with no way to correct it from outside.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (330 tests)
- [x] `cargo check` + `cargo clippy` clean in `src-tauri`
- [ ] Ran the app (`bun run tauri dev`) and exercised the change
- [x] Added or updated tests
- [ ] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts` (no user-facing strings — MCP surface only)

End-to-end exercise against a real recording (rename + meta fix + external findings/brief write on an existing office-hour recording) planned right after this lands in a release build.