### PR TITLE
[fix] release: cut from main explicitly instead of pushing HEAD

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -116,6 +116,28 @@ function ensureCleanWorktree() {
   }
 }
 
+/**
+ * A release must sit on top of what main already has. Cutting one from a
+ * worktree is normal here (main is often checked out elsewhere), so instead of
+ * demanding a branch NAME this requires HEAD to be origin/main's commit: the
+ * version bump then lands on main, and the tag points at released code.
+ * Without it the bump commits onto whatever branch is checked out and the final
+ * push is rejected as non-fast-forward, stranding a local tag and a bump commit
+ * off main — which has happened twice.
+ */
+function ensureOnMain() {
+  run("git", ["fetch", "origin", "main", "--quiet"]);
+  const head = output("git", ["rev-parse", "HEAD"]);
+  const main = output("git", ["rev-parse", "origin/main"]);
+  if (head !== main) {
+    console.error("Release requires HEAD to be exactly origin/main (releases are cut from main).");
+    console.error(`  HEAD:        ${head}`);
+    console.error(`  origin/main: ${main}`);
+    console.error("Fix with: git fetch origin main && git reset --hard origin/main");
+    process.exit(1);
+  }
+}
+
 const { versionArg, message, notesFile } = parseArgs(process.argv.slice(2));
 
 if (!versionArg || (!message && !notesFile)) {
@@ -149,6 +171,7 @@ if (process.env.DRY_RUN === "1") {
 }
 
 ensureCleanWorktree();
+ensureOnMain();
 
 packageJson.version = nextVersion;
 writeJson("package.json", packageJson);
@@ -179,7 +202,10 @@ run("git", [
 ]);
 run("git", ["commit", "-m", `Release ${tag}`]);
 run("git", ["tag", "-a", tag, "-m", releaseNotes]);
-run("git", ["push", "origin", "HEAD"]);
+// Explicit destination: HEAD may be a worktree branch that merely POINTS at
+// main's commit (see ensureOnMain), and a bare `push origin HEAD` would then
+// target that branch instead of main.
+run("git", ["push", "origin", "HEAD:main"]);
 run("git", ["push", "origin", tag]);
 
 console.log(`Released ${tag}. GitHub Actions will build the app and attach bundles to the draft release.`);


### PR DESCRIPTION
## What this changes

`bun run release` now (a) requires HEAD to be exactly `origin/main`'s commit before it writes anything, and (b) pushes the bump commit with `HEAD:main` rather than a bare `HEAD`.

## Why

Releases here are normally cut from a **worktree** — `main` is usually checked out somewhere else (another worktree or an editor's), so `git checkout main` fails and you end up running the release from a feature branch that happens to be at main's commit. In that state `git push origin HEAD` targets *that branch*, not main: the version bump and the annotated tag land off main, the push is rejected as non-fast-forward, and the script exits half-done — tag created locally, nothing pushed. Recovering means hand-running `git push origin HEAD:main && git push origin <tag>`.

This happened on both v0.22.9 and v0.22.10. The new guard fails fast with the exact recovery command instead:

```
Release requires HEAD to be exactly origin/main (releases are cut from main).
  HEAD:        9e1850e...
  origin/main: b7874b1...
Fix with: git fetch origin main && git reset --hard origin/main
```

Requiring the *commit* rather than a branch name keeps the worktree workflow working, which is the point — the invariant that matters is "this release is what main has", not which ref is checked out.

## How it was verified

- [x] `node --check scripts/release.mjs` passes
- [x] `DRY_RUN=1 bun run release patch` still previews correctly
- [x] Negative test: an extra commit on top of main → guard rejects with the message above and writes nothing
- [ ] `bunx tsc --noEmit` / `bunx vitest run` — not applicable, build script only (unchanged by this PR)