### PR TITLE
[fix] timeline: hover card no longer clipped; clicking a dot scrolls its finding into view

### DIFF
--- a/src/components/analysis/AnalysisTimeline.tsx
+++ b/src/components/analysis/AnalysisTimeline.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { RefreshCw, Sparkles } from "lucide-react";
 import { formatClock } from "../../lib/store";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,114 @@ const dotClass = (e: TimelineEvent) => (e.resolved ? RESOLVED_DOT : SEVERITY_DOT
 
 /** A marker is "near" the playhead within this window (ms). */
 const NEAR_MS = 4000;
+
+/** Hover-card width and the gap it keeps from the window edge / its dot (px). */
+const CARD_W = 256;
+const EDGE_GAP = 8;
+
+/**
+ * Place the hover card next to a dot in VIEWPORT coordinates.
+ *
+ * The card is portaled to the body and positioned `fixed`, because the timeline
+ * lives inside `overflow-hidden` ancestors (StudyScreen's column) that clipped
+ * the old absolutely-positioned card — the reason it appeared cut off near the
+ * window edges. Positioning it here means we own collision handling: clamp x
+ * into the viewport, and flip to whichever side of the dot has room.
+ */
+export function cardPosition(
+  dot: { left: number; right: number; top: number; bottom: number; width: number },
+  cardH: number,
+  preferBelow: boolean,
+  viewport: { width: number; height: number } = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  },
+) {
+  const { width: vw, height: vh } = viewport;
+  const x = Math.min(
+    Math.max(EDGE_GAP, dot.left + dot.width / 2 - CARD_W / 2),
+    vw - CARD_W - EDGE_GAP,
+  );
+  const above = dot.top - cardH - EDGE_GAP;
+  const below = dot.bottom + EDGE_GAP;
+  const fitsBelow = below + cardH <= vh - EDGE_GAP;
+  const fitsAbove = above >= EDGE_GAP;
+  const useBelow = preferBelow ? fitsBelow || !fitsAbove : !fitsAbove && fitsBelow;
+  return { left: x, top: useBelow ? below : Math.max(EDGE_GAP, above) };
+}
+
+/** The hover card itself — measures once mounted, then places itself. */
+function FindingHoverCard({
+  event,
+  anchor,
+  preferBelow,
+  timeLabel,
+  extraLabel,
+  evalNames,
+}: Readonly<{
+  event: TimelineEvent;
+  anchor: DOMRect;
+  preferBelow: boolean;
+  timeLabel: string;
+  extraLabel: string;
+  evalNames: Map<string, string>;
+}>) {
+  const { t } = useI18n();
+  const ref = useRef<HTMLDivElement>(null);
+  // Start off-screen: the first paint measures, the layout effect places it —
+  // so the card never flashes at the wrong spot.
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  useLayoutEffect(() => {
+    const h = ref.current?.offsetHeight ?? 0;
+    setPos(cardPosition(anchor, h, preferBelow));
+  }, [anchor, preferBelow, event.id]);
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="pointer-events-none fixed z-50 rounded-md border bg-popover px-2 py-1.5 text-left text-[11px] leading-snug text-popover-foreground shadow-md"
+      style={{
+        width: CARD_W,
+        left: pos?.left ?? -9999,
+        top: pos?.top ?? -9999,
+        visibility: pos ? "visible" : "hidden",
+      }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+          {timeLabel} {formatClock(event.atMs)}
+        </span>
+        {event.source === "extra" && (
+          <span className="rounded bg-muted px-1 text-[9px] text-muted-foreground">
+            {extraLabel}
+          </span>
+        )}
+      </div>
+      <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className={cn("size-1.5 rounded-full", dotClass(event))} />
+          {event.resolved ? t("timeline.resolved") : t(`timeline.sev.${event.severity}` as const)}
+        </span>
+        {event.source === "eval" && (event.evalIds?.length ?? 0) > 0 && (
+          <span className="line-clamp-1">
+            {t("timeline.evalLabel")}:{" "}
+            {(event.evalIds ?? []).map((id) => evalNames.get(id) ?? id).join(", ")}
+          </span>
+        )}
+      </div>
+      <div className="mt-0.5 line-clamp-2 font-medium text-popover-foreground">{event.title}</div>
+      {/* Clamped: the card is a glance, not the finding. The full detail and
+       *  resolution are one click away in the findings list beside it. */}
+      <div className="mt-0.5 line-clamp-3 text-muted-foreground">{event.detail}</div>
+      {event.resolved && event.resolution && (
+        <div className="mt-0.5 line-clamp-2 text-emerald-500">
+          {t("timeline.resolvedHow")}: {event.resolution}
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+}
 
 interface AnalysisTimelineProps {
   findings: TimelineEvent[];
@@ -63,7 +172,9 @@ export function AnalysisTimeline({
   stale,
 }: Readonly<AnalysisTimelineProps>) {
   const { t } = useI18n();
-  const [hovered, setHovered] = useState<string | null>(null);
+  // The hovered dot AND where it is on screen: the hover card is portaled out
+  // of the timeline (see FindingHoverCard), so it needs viewport coordinates.
+  const [hovered, setHovered] = useState<HoveredDot | null>(null);
 
   const { them, me } = useMemo(
     () => ({
@@ -196,14 +307,20 @@ export function AnalysisTimeline({
   );
 }
 
+/** Which dot the pointer is on, plus its on-screen box for the portaled card. */
+interface HoveredDot {
+  id: string;
+  rect: DOMRect;
+}
+
 interface LaneProps {
   label: string;
   events: TimelineEvent[];
   axisMaxMs: number;
   playheadMs?: number;
   selectedId?: string | null;
-  hovered: string | null;
-  setHovered: (id: string | null) => void;
+  hovered: HoveredDot | null;
+  setHovered: (dot: HoveredDot | null) => void;
   onSelect: (event: TimelineEvent) => void;
   extraLabel: string;
   tooltipTime: string;
@@ -225,10 +342,12 @@ function Lane({
   tooltipTime,
   tooltipBelow = false,
 }: Readonly<LaneProps>) {
-  const { t } = useI18n();
   const evalNames = useEvalNames();
   const playheadPct =
     playheadMs !== undefined && axisMaxMs > 0 ? Math.max(0, Math.min(1, playheadMs / axisMaxMs)) : null;
+  // Both lanes share one hovered id; only the lane that owns that dot draws the
+  // card, so hovering the other lane's dot can't render a stray second copy.
+  const hoveredEvent = hovered ? events.find((e) => e.id === hovered.id) : undefined;
   return (
     <div className="flex items-center gap-2">
       <span className="w-16 shrink-0 truncate text-right text-[10px] text-muted-foreground">{label}</span>
@@ -243,14 +362,16 @@ function Lane({
         {events.map((e) => {
           const pct = axisMaxMs > 0 ? Math.max(0, Math.min(1, e.atMs / axisMaxMs)) : 0;
           const near = playheadMs !== undefined && Math.abs(e.atMs - playheadMs) <= NEAR_MS;
-          const isHovered = hovered === e.id;
+          const isHovered = hovered?.id === e.id;
           const isSelected = selectedId === e.id;
           return (
             <button
               key={e.id}
               type="button"
               onClick={() => onSelect(e)}
-              onMouseEnter={() => setHovered(e.id)}
+              onMouseEnter={(ev) =>
+                setHovered({ id: e.id, rect: ev.currentTarget.getBoundingClientRect() })
+              }
               onMouseLeave={() => setHovered(null)}
               className={cn(
                 "absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full transition-transform hover:scale-125",
@@ -262,52 +383,19 @@ function Lane({
               )}
               style={{ left: `${pct * 100}%` }}
               aria-label={`${formatClock(e.atMs)} ${e.title}`}
-            >
-              {isHovered && (
-                <span
-                  className={cn(
-                    "pointer-events-none absolute z-30 w-56 rounded-md border bg-popover px-2 py-1.5 text-left text-[11px] leading-snug text-popover-foreground shadow-md",
-                    // Vertical: top lane opens downward so the tooltip never
-                    // escapes the panel; bottom lane keeps opening upward.
-                    tooltipBelow ? "top-full mt-1.5" : "bottom-full mb-1.5",
-                    // Horizontal: dots near either end pin the tooltip to that
-                    // edge instead of centering it off the window.
-                    pct < 0.2 ? "left-0" : pct > 0.8 ? "right-0" : "left-1/2 -translate-x-1/2"
-                  )}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-                      {tooltipTime} {formatClock(e.atMs)}
-                    </span>
-                    {e.source === "extra" && (
-                      <span className="rounded bg-muted px-1 text-[9px] text-muted-foreground">{extraLabel}</span>
-                    )}
-                  </span>
-                  {/* Why this dot is this colour (severity) + which eval flagged it. */}
-                  <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <span className={cn("size-1.5 rounded-full", dotClass(e))} />
-                      {e.resolved ? t("timeline.resolved") : t(`timeline.sev.${e.severity}` as const)}
-                    </span>
-                    {e.source === "eval" && (e.evalIds?.length ?? 0) > 0 && (
-                      <span>
-                        {t("timeline.evalLabel")}:{" "}
-                        {(e.evalIds ?? []).map((id) => evalNames.get(id) ?? id).join(", ")}
-                      </span>
-                    )}
-                  </span>
-                  <span className="mt-0.5 block font-medium text-popover-foreground">{e.title}</span>
-                  <span className="mt-0.5 block text-muted-foreground">{e.detail}</span>
-                  {e.resolved && e.resolution && (
-                    <span className="mt-0.5 block text-emerald-500">
-                      {t("timeline.resolvedHow")}: {e.resolution}
-                    </span>
-                  )}
-                </span>
-              )}
-            </button>
+            />
           );
         })}
+        {hoveredEvent && hovered && (
+          <FindingHoverCard
+            event={hoveredEvent}
+            anchor={hovered.rect}
+            preferBelow={tooltipBelow}
+            timeLabel={tooltipTime}
+            extraLabel={extraLabel}
+            evalNames={evalNames}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/analysis/FindingRow.tsx
+++ b/src/components/analysis/FindingRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatClock } from "../../lib/store";
@@ -35,6 +36,14 @@ export function FindingRow({
 }>) {
   const { t } = useI18n();
   const evalNames = useEvalNames();
+  // Selection can come from the TIMELINE, where the matching row is usually
+  // scrolled out of view — bring it into view so clicking a dot lands somewhere
+  // visible. "nearest" makes this a no-op when the row is already on screen, so
+  // clicking a row in this list never yanks the list around.
+  const ref = useRef<HTMLLIElement>(null);
+  useEffect(() => {
+    if (selected) ref.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [selected]);
   const evalLabels =
     event.source === "eval"
       ? (event.evalIds ?? [])
@@ -42,7 +51,10 @@ export function FindingRow({
           .filter((label): label is { id: string; name: string } => !!label.name)
       : [];
   return (
-    <li className={cn("rounded-lg border", selected ? "border-primary/50 bg-muted/30" : "border-border")}>
+    <li
+      ref={ref}
+      className={cn("rounded-lg border", selected ? "border-primary/50 bg-muted/30" : "border-border")}
+    >
       <button
         type="button"
         onClick={() => onSelect(event)}

--- a/src/components/analysis/timelineHoverCard.test.ts
+++ b/src/components/analysis/timelineHoverCard.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+
+import { cardPosition } from "./AnalysisTimeline";
+
+/** A 12px dot (size-3) whose centre sits at `centreX`, on a 20px-tall lane. */
+function dot(centreX: number, top = 300) {
+  return { left: centreX - 6, right: centreX + 6, width: 12, top, bottom: top + 12 };
+}
+
+const VIEW = { width: 1000, height: 800 };
+const CARD_W = 256;
+const GAP = 8;
+
+describe("cardPosition", () => {
+  it("centres the card on the dot when there is room either side", () => {
+    const { left } = cardPosition(dot(500), 120, false, VIEW);
+    expect(left).toBe(500 - CARD_W / 2);
+  });
+
+  it("keeps the card inside the left edge instead of overflowing", () => {
+    // The old absolutely-positioned tooltip escaped here and got clipped.
+    const { left } = cardPosition(dot(10), 120, false, VIEW);
+    expect(left).toBe(GAP);
+  });
+
+  it("keeps the card inside the right edge instead of overflowing", () => {
+    const { left } = cardPosition(dot(995), 120, false, VIEW);
+    expect(left).toBe(VIEW.width - CARD_W - GAP);
+  });
+
+  it("opens upward by default, clearing the dot", () => {
+    const { top } = cardPosition(dot(500, 300), 120, false, VIEW);
+    expect(top).toBe(300 - 120 - GAP);
+  });
+
+  it("flips below when there is no room above", () => {
+    const d = dot(500, 20); // near the top of the window
+    const { top } = cardPosition(d, 120, false, VIEW);
+    expect(top).toBe(d.bottom + GAP);
+  });
+
+  it("honors preferBelow when the card fits below", () => {
+    const d = dot(500, 300);
+    const { top } = cardPosition(d, 120, true, VIEW);
+    expect(top).toBe(d.bottom + GAP);
+  });
+
+  it("falls back above when preferBelow would run off the bottom", () => {
+    const d = dot(500, 700); // bottom lane, tall card
+    const { top } = cardPosition(d, 200, true, VIEW);
+    expect(top).toBe(700 - 200 - GAP);
+  });
+
+  it("never positions the card off the top, even when it fits nowhere", () => {
+    const { top } = cardPosition(dot(500, 40), 780, false, VIEW);
+    expect(top).toBeGreaterThanOrEqual(GAP);
+  });
+});


### PR DESCRIPTION
## What this changes

Two reported bugs on the analysis timeline.

**1. The hover card was cut off.** It was an absolutely-positioned element *inside* the timeline, so `StudyScreen`'s `overflow-hidden` column clipped it — worst near the window edges, where its own `left-0` / `right-0` pinning could not help (that pinning only knew about the track, not the window). It is now portaled to `document.body` and positioned `fixed` from the dot's viewport rect.

Collision handling moved into a pure `cardPosition(dot, cardHeight, preferBelow, viewport)`: clamp x into the viewport, flip above/below by available room, never place it off the top. That function is unit-tested (8 cases, including both edges and both flips) — the part most likely to be wrong is the part that's now covered.

The card also got smaller, which was the other half of the complaint: title clamped to 2 lines, detail to 3, resolution to 2, eval list to 1. It's a glance; the full text is one click away in the list beside it.

**2. Clicking a dot didn't move the findings list.** `selectAndSeek` set `selectedFindingId` and seeked the audio, but nothing scrolled the list, so the row it just selected was usually off-screen — the click looked like it only affected the transcript. `FindingRow` now scrolls itself into view when it becomes selected, with `block: "nearest"` so clicking a row that is already visible never jogs the list.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (340 tests; +8 new for `cardPosition`)
- [x] Added or updated tests
- [ ] Ran the app and exercised the change — **not done**: hovering/clicking inside the Tauri window can't be automated from here, so the positioning maths is covered by unit tests instead and the visual pass needs a human. Everything else about the change is type- and test-checked.
- [ ] New user-facing strings — none (existing i18n keys reused)

## Note

This branch was cut while investigating the scenario/`meetingType` design question and carries only these two fixes; the scenario redesign is a separate proposal awaiting a decision.