### PR TITLE
[feature] android: in-app account deletion, and a web deletion route for both platforms

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,4 +62,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.okhttp.mockwebserver)
 }

--- a/android/app/src/main/kotlin/com/pathors/parley/cloud/CloudClient.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/cloud/CloudClient.kt
@@ -84,6 +84,19 @@ class CloudException(
     val isNotFound: Boolean get() = status == 404
 
     /**
+     * [CloudClient.deleteAccount] was refused because the account still owns at
+     * least one shared organization.
+     *
+     * Its own flag rather than a generic 409, because it is the one deletion
+     * failure the user can actually act on — the backend refuses on purpose
+     * (cloud `src/index.ts`, `DELETE /me`): silently removing a shared workspace
+     * would take its other members' recordings with it. The workspace has to be
+     * transferred or deleted first, which today means the desktop app.
+     */
+    val ownsOrganizations: Boolean
+        get() = status == 409 && code == OWNED_ORGANIZATIONS
+
+    /**
      * Whether retrying the very same request could plausibly succeed: server
      * faults, rate limiting and request timeouts. A 4xx is otherwise the client's
      * fault and would fail identically forever.
@@ -92,6 +105,11 @@ class CloudException(
         get() = status == 0 || status >= 500 || status == 408 || status == 429
 
     override fun toString(): String = "CloudException(status=$status, code=$code, message=$message)"
+
+    companion object {
+        /** The worker's `{ error }` value behind [ownsOrganizations]. */
+        const val OWNED_ORGANIZATIONS = "owned_organizations"
+    }
 }
 
 /**
@@ -136,6 +154,23 @@ class CloudClient(
      */
     suspend fun signOut() {
         execute(Request.Builder().url(url("auth", "sign-out")).post(EMPTY_BODY)) { }
+    }
+
+    /**
+     * `DELETE /me` — permanently erase the account: the user row and everything
+     * that cascades from it (sessions, linked providers, usage, memberships,
+     * personal folders) plus every recording blob under this user's R2 prefixes.
+     * Irreversible; there is no undo and no tombstone to restore from.
+     *
+     * The session token is dead the moment this returns, so the caller must clear
+     * local auth (and anything still queued for upload) rather than sign out.
+     *
+     * Throws [CloudException] with [CloudException.ownsOrganizations] when the
+     * account still owns a shared organization — a refusal to explain, not a
+     * failure to retry. Same contract as iOS `CloudClient.deleteAccount()`.
+     */
+    suspend fun deleteAccount() {
+        execute(Request.Builder().url(url("me")).delete()) { }
     }
 
     // ── recordings (personal) ────────────────────────────────────────────────

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/AccountSheet.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/AccountSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +15,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -21,16 +25,25 @@ import com.pathors.parley.R
 import com.pathors.parley.cloud.HostedQuota
 
 /**
- * Who is signed in, what the plan has left, and the way out.
+ * Who is signed in, what the plan has left, and the two ways out — signing out,
+ * and deleting the account for good.
  *
  * Usage comes from `GET /me/usage`, the same numbers the relay enforces — so a
  * "quota exhausted" banner during a meeting and this sheet always agree.
+ *
+ * Account deletion lives here because this is the account surface, and because
+ * Google Play requires an in-app deletion route for any app that offers account
+ * creation. It mirrors iOS Settings → Account: a destructive button that only
+ * arms a confirmation dialog, and a second, separately-labelled destructive tap
+ * inside that dialog to actually go through with it. One stray tap can never
+ * delete an account.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountSheet(viewModel: HomeViewModel, onDismiss: () -> Unit) {
     val account by viewModel.account.collectAsState()
     val sheetState = rememberModalBottomSheetState()
+    var confirmingDelete by remember { mutableStateOf(false) }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -78,8 +91,85 @@ fun AccountSheet(viewModel: HomeViewModel, onDismiss: () -> Unit) {
                     color = MaterialTheme.colorScheme.error,
                 )
             }
+
+            // Same condition as iOS: shown once `me()` has confirmed who is
+            // signed in. While the account is merely unreachable there is no
+            // point offering a call that cannot reach the server either.
+            if (account.user != null) {
+                TextButton(
+                    onClick = {
+                        viewModel.clearDeleteAccountError()
+                        confirmingDelete = true
+                    },
+                    enabled = !account.deleting,
+                ) {
+                    Text(
+                        text = stringResource(
+                            if (account.deleting) {
+                                R.string.account_delete_in_progress
+                            } else {
+                                R.string.account_delete
+                            }
+                        ),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+
+                account.deleteError?.let { error ->
+                    Text(
+                        text = stringResource(
+                            when (error) {
+                                DeleteAccountError.OWNS_ORGANIZATIONS ->
+                                    R.string.account_delete_error_owns_organizations
+
+                                DeleteAccountError.FAILED -> R.string.account_delete_error_failed
+                            }
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
         }
     }
+
+    if (confirmingDelete) {
+        DeleteAccountDialog(
+            onConfirm = {
+                confirmingDelete = false
+                viewModel.deleteAccount()
+            },
+            onDismiss = { confirmingDelete = false },
+        )
+    }
+}
+
+/**
+ * The second step. Its body spells out exactly what is destroyed — the account,
+ * every synced recording and its audio, permanently — rather than asking "are you
+ * sure?", and the confirm button repeats the action instead of saying "OK", so
+ * the destructive tap is never ambiguous.
+ */
+@Composable
+private fun DeleteAccountDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.account_delete_confirm_title)) },
+        text = { Text(stringResource(R.string.account_delete_confirm_body)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.account_delete_confirm_action),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
 }
 
 @Composable

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/HomeViewModel.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/HomeViewModel.kt
@@ -21,6 +21,14 @@ import kotlinx.coroutines.withContext
 enum class HomeError { NETWORK, SERVER, SIGNED_OUT }
 
 /**
+ * Why account deletion did not happen. The sheet owns the copy for each case.
+ *
+ * [OWNS_ORGANIZATIONS] is deliberately its own case: it is the only one the user
+ * can do something about, and telling them to "try again" would be a lie.
+ */
+enum class DeleteAccountError { OWNS_ORGANIZATIONS, FAILED }
+
+/**
  * The library screen's state: what the cloud has, what is still waiting to get
  * there, and the account details behind the avatar button.
  *
@@ -43,6 +51,9 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
         val user: CloudUser? = null,
         val quota: HostedQuota? = null,
         val failed: Boolean = false,
+        /** True while `DELETE /me` is in flight — the destructive action is disabled. */
+        val deleting: Boolean = false,
+        val deleteError: DeleteAccountError? = null,
     )
 
     private val _state = MutableStateFlow(UiState())
@@ -105,6 +116,55 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
     fun signOut() {
         viewModelScope.launch { container.auth.signOut() }
     }
+
+    /**
+     * Permanently delete this account (`DELETE /me`) — the Play Store's required
+     * in-app deletion route, and the same call iOS Settings makes.
+     *
+     * On success the server has already destroyed the session, so this clears the
+     * token locally rather than signing out (there is nothing left to revoke) and
+     * wipes the pending-upload queue: those recordings have no account to land in
+     * any more, and the confirmation dialog promised the audio would be gone.
+     * Clearing the token is also what returns the app to the sign-in wall —
+     * `ParleyRoot` watches `isSignedIn`.
+     *
+     * The queue is emptied BEFORE the token, so the sign-in screen can never
+     * appear over a still-populated queue that a re-sign-in would then upload
+     * into a brand-new account.
+     */
+    fun deleteAccount() {
+        if (_account.value.deleting) return
+        viewModelScope.launch {
+            _account.value = _account.value.copy(deleting = true, deleteError = null)
+            val result = runCatching { container.cloud.deleteAccount() }
+            result.fold(
+                onSuccess = {
+                    withContext(Dispatchers.IO) { container.uploadQueue.clear() }
+                    container.auth.clearSession()
+                },
+                onFailure = { error ->
+                    _account.value = _account.value.copy(
+                        deleting = false,
+                        deleteError = classifyDeletion(error),
+                    )
+                },
+            )
+        }
+    }
+
+    /** Dismiss the deletion error so re-opening the dialog starts clean. */
+    fun clearDeleteAccountError() {
+        if (_account.value.deleteError != null) {
+            _account.value = _account.value.copy(deleteError = null)
+        }
+    }
+
+    private fun classifyDeletion(error: Throwable): DeleteAccountError =
+        if ((error as? CloudException)?.ownsOrganizations == true) {
+            DeleteAccountError.OWNS_ORGANIZATIONS
+        } else {
+            DeleteAccountError.FAILED
+        }
 
     private fun classify(error: Throwable): HomeError = when {
         (error as? CloudException)?.isAuthExpired == true -> HomeError.SIGNED_OUT

--- a/android/app/src/main/kotlin/com/pathors/parley/upload/PendingUploadQueue.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/upload/PendingUploadQueue.kt
@@ -121,6 +121,19 @@ class PendingUploadQueue(private val directory: File) {
         manifestFile(id).deleteQuietly()
     }
 
+    /**
+     * Drop everything the queue is holding, blobs included.
+     *
+     * Only for account deletion: once `DELETE /me` has succeeded there is no
+     * account left for these to upload to, and leaving finished meeting audio on
+     * disk would contradict what the confirmation dialog promised. Ordinary
+     * sign-out deliberately keeps the queue — the same person usually signs back
+     * in, and the recordings are still theirs.
+     */
+    fun clear() {
+        directory.listFiles()?.forEach { file -> if (file.isFile) file.deleteQuietly() }
+    }
+
     /** Total bytes the queue is holding on disk, for a "waiting to upload" readout. */
     fun bytesOnDisk(): Long =
         directory.listFiles()?.filter { it.isFile }?.sumOf { it.length() } ?: 0L

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -51,6 +51,13 @@
     <string name="account_loading">載入中…</string>
     <string name="account_load_failed">無法載入帳號資訊。</string>
     <string name="account_sign_out">登出</string>
+    <string name="account_delete">刪除帳號</string>
+    <string name="account_delete_in_progress">刪除帳號中…</string>
+    <string name="account_delete_confirm_title">要永久刪除帳號嗎？</string>
+    <string name="account_delete_confirm_body">這會永久刪除你的 Parley 帳號，以及所有已同步的錄音——音訊、逐字稿、摘要、資料夾與使用紀錄。刪除後無法復原，也無法取回任何資料。這台裝置上尚未上傳的錄音同樣會一併清除。若你是共享組織的擁有者，請先移轉或刪除該組織。</string>
+    <string name="account_delete_confirm_action">刪除我的帳號與資料</string>
+    <string name="account_delete_error_owns_organizations">你仍是至少一個組織的擁有者。請先在桌面版移轉或刪除該組織，再刪除帳號。</string>
+    <string name="account_delete_error_failed">帳號未被刪除。請檢查網路連線後再試一次。</string>
 
     <!-- Meeting -->
     <string name="meeting_title">會議</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -52,6 +52,13 @@
     <string name="account_loading">Loading…</string>
     <string name="account_load_failed">Couldn\'t load your account details.</string>
     <string name="account_sign_out">Sign out</string>
+    <string name="account_delete">Delete account</string>
+    <string name="account_delete_in_progress">Deleting account…</string>
+    <string name="account_delete_confirm_title">Delete your account permanently?</string>
+    <string name="account_delete_confirm_body">This permanently deletes your Parley account and every recording synced to it — audio, transcripts, summaries, folders and usage history. It cannot be undone, and nothing can be recovered afterwards. Recordings still waiting to upload on this device are discarded too. If you own a shared organization, transfer or delete it first.</string>
+    <string name="account_delete_confirm_action">Delete my account and data</string>
+    <string name="account_delete_error_owns_organizations">You still own at least one organization. Transfer or delete it in the desktop app first, then delete your account.</string>
+    <string name="account_delete_error_failed">Your account was not deleted. Check your connection and try again.</string>
 
     <!-- Meeting -->
     <string name="meeting_title">Meeting</string>

--- a/android/app/src/test/kotlin/com/pathors/parley/cloud/CloudClientDeleteAccountTest.kt
+++ b/android/app/src/test/kotlin/com/pathors/parley/cloud/CloudClientDeleteAccountTest.kt
@@ -1,0 +1,102 @@
+package com.pathors.parley.cloud
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `DELETE /me` on the wire, and how its failures are classified.
+ *
+ * The 409 case is the one that matters: the account-deletion UI branches on
+ * [CloudException.ownsOrganizations] to tell the user to transfer their
+ * organization first, and a regression that flattened it into a generic error
+ * would leave them staring at "try again" for something retrying can never fix.
+ */
+class CloudClientDeleteAccountTest {
+    private val server = MockWebServer()
+
+    private fun client(unauthorized: AtomicInteger = AtomicInteger()): CloudClient =
+        CloudClient(
+            baseUrl = server.url("/").toString(),
+            tokenProvider = { "session-token" },
+            onUnauthorized = { unauthorized.incrementAndGet() },
+        )
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `sends an authenticated DELETE to me`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ok":true}"""))
+
+        client().deleteAccount()
+
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/me", request.path)
+        assertEquals("Bearer session-token", request.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `409 owned_organizations is its own typed refusal`() = runBlocking {
+        server.enqueue(
+            MockResponse().setResponseCode(409).setBody(
+                """
+                {"error":"owned_organizations",
+                 "organizations":[{"id":"org_1","name":"Pathors"}],
+                 "message":"Delete or transfer owned organizations before deleting this account."}
+                """.trimIndent()
+            )
+        )
+
+        val error = runCatching { client().deleteAccount() }.exceptionOrNull()
+
+        val cloudError = error as CloudException
+        assertEquals(409, cloudError.status)
+        assertEquals(CloudException.OWNED_ORGANIZATIONS, cloudError.code)
+        assertTrue(cloudError.ownsOrganizations)
+        // Retrying can never clear this — the organization has to go first.
+        assertFalse(cloudError.isRetryable)
+    }
+
+    @Test
+    fun `an unrelated 409 is not the organization refusal`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(409).setBody("""{"error":"conflict"}"""))
+
+        val error = runCatching { client().deleteAccount() }.exceptionOrNull() as CloudException
+
+        assertEquals(409, error.status)
+        assertFalse(error.ownsOrganizations)
+    }
+
+    @Test
+    fun `a 401 clears the session and is not the organization refusal`() = runBlocking {
+        val unauthorized = AtomicInteger()
+        server.enqueue(MockResponse().setResponseCode(401).setBody("""{"code":"unauthorized"}"""))
+
+        val error = runCatching { client(unauthorized).deleteAccount() }
+            .exceptionOrNull() as CloudException
+
+        assertTrue(error.isAuthExpired)
+        assertFalse(error.ownsOrganizations)
+        assertEquals(1, unauthorized.get())
+    }
+
+    @Test
+    fun `a server fault stays retryable`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(503))
+
+        val error = runCatching { client().deleteAccount() }.exceptionOrNull() as CloudException
+
+        assertTrue(error.isRetryable)
+        assertFalse(error.ownsOrganizations)
+    }
+}

--- a/android/docs/api-cloud.md
+++ b/android/docs/api-cloud.md
@@ -79,14 +79,39 @@ All methods are `suspend` and throw `CloudException` on a non-2xx response.
 | `pushRecording(id, summary, meta): Double?` | `POST /recordings/{id}` `{summary, meta}` → server `updatedAt` |
 | `deleteRecording(id)` | `DELETE /recordings/{id}` |
 | `signOut()` | `POST /auth/sign-out` (prefer `AuthManager.signOut()`) |
+| `deleteAccount()` | `DELETE /me` — permanent account deletion. See below. |
 
 **Ordering rule:** audio is uploaded **before** the summary/meta push, always. A
 row claiming `hasAudio` before its blob exists 404s the download on every other
 device. `MeetingUploader` already does this; hand-rolled push paths must too.
 
 Not implemented (exists on the backend and on iOS, unused by this app so far):
-folders, organizations, `POST /recordings/{id}/share`, `DELETE /me`. They are
-additive — no caller changes when they land.
+folders, organizations, `POST /recordings/{id}/share`. They are additive — no
+caller changes when they land.
+
+### Deleting the account
+
+`deleteAccount()` erases the user row and everything cascading from it (sessions,
+linked providers, usage, memberships, personal folders) plus every recording blob
+under the account's R2 prefixes. Irreversible — no tombstone, nothing to restore.
+Google Play requires this route in-app for any app that offers account creation;
+`AccountSheet` is where it is surfaced, behind a two-step confirmation.
+
+The session is dead when it returns, so the caller **clears** local auth rather
+than signing out — there is nothing left to revoke — and empties the pending
+queue, which now has no account to upload into:
+
+```kotlin
+cloud.deleteAccount()
+uploadQueue.clear()
+auth.clearSession()          // flips `isSignedIn` → the sign-in wall returns
+```
+
+The one refusal worth handling separately is `ownsOrganizations`: the backend
+returns 409 `owned_organizations` while the account still owns a shared
+workspace, because deleting it silently would take other members' recordings
+with it. It has to be transferred or deleted first (today, from the desktop app).
+Retrying will never clear it, so say that instead of "try again".
 
 ### Errors
 
@@ -99,6 +124,7 @@ additive — no caller changes when they land.
 | 402 | `isQuotaExhausted` | Hosted quota gone. Not retryable until `HostedQuota.periodResetTs`. |
 | 403 | `isForbidden` | Resource-level. **Never** sign the user out — the session is fine. |
 | 404 | `isNotFound` | |
+| 409 `owned_organizations` | `ownsOrganizations` | `DELETE /me` only. The account still owns a shared organization; transfer or delete it first. Never retryable. |
 | 0 / 5xx / 408 / 429 | `isRetryable` | Worth another attempt. |
 
 `status == 0` means the failure never reached HTTP (unparseable body). Plain

--- a/website/account-deletion/index.html
+++ b/website/account-deletion/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>刪除 Parley 帳號</title>
+    <meta name="description" content="如何永久刪除 Parley 帳號與所有錄音，包含 iOS、Android 的操作路徑與無法開啟 app 時的聯絡方式。" />
+    <link rel="canonical" href="https://parley.tw/account-deletion/" />
+    <link rel="icon" type="image/svg+xml" href="../assets/logo.svg" />
+    <link rel="stylesheet" href="../legal.css" />
+  </head>
+  <body>
+    <header class="topline">
+      <a class="brand" href="../" aria-label="Parley 首頁"><img src="../assets/logo.svg" alt="" />Parley</a>
+      <a class="back" href="../">回到首頁</a>
+    </header>
+    <main>
+      <p class="eyebrow">Account deletion / 刪除帳號</p>
+      <h1>刪除帳號，就是真的刪掉。</h1>
+      <p class="lead">本頁說明如何永久刪除你的 Parley 帳號與所有已同步的錄音。你可以在 app 內自行完成，也可以在無法開啟 app 時寄信給我們處理。</p>
+
+      <div class="callout"><p><strong>刪除的範圍：</strong>帳號本身，以及所有已同步到這個帳號的錄音——音訊檔、逐字稿、摘要、資料夾與使用紀錄。刪除是永久且無法復原的，我們沒有可供還原的備份。</p></div>
+
+      <h2>在 app 內刪除</h2>
+      <ul class="support-list">
+        <li><strong>iOS</strong><span>開啟 Parley →「設定」→「帳號」→「Delete account／刪除帳號」，在確認視窗按下「刪除我的帳號與資料」。</span></li>
+        <li><strong>Android</strong><span>開啟 Parley → 右上角「帳號」開啟帳號面板 →「刪除帳號」，在確認視窗按下「刪除我的帳號與資料」。</span></li>
+      </ul>
+      <p>兩個平台都會先跳出確認視窗說明刪除範圍，需要再按一次才會真的執行。完成後 app 會回到登入畫面，這台裝置上尚未上傳的錄音也會一併清除。</p>
+
+      <h2>共享組織的例外</h2>
+      <p>若你仍是某個共享組織的擁有者，刪除會被擋下。這是刻意的：直接刪掉共享工作區，會連同其他成員的共同錄音一起消失。請先在桌面版把該組織移轉給其他成員或刪除該組織，再回來刪除帳號。</p>
+
+      <h2>沒有安裝 app 也可以刪除</h2>
+      <p>不需要安裝或重新安裝 app。請用<strong>註冊時使用的電子郵件地址</strong>寄信到 <a href="mailto:contact@pathors.com?subject=Parley%20account%20deletion">contact@pathors.com</a>，主旨寫「Parley account deletion」，信中註明要刪除的帳號 email。我們會以該信箱與你確認身分後執行刪除，範圍與 app 內刪除完全相同。</p>
+
+      <h2>相關頁面</h2>
+      <ul class="support-list">
+        <li><a href="../privacy/"><strong>隱私權政策</strong><span>我們收集哪些資料、存放在哪裡、保留多久。</span></a></li>
+        <li><a href="../support/"><strong>支援</strong><span>登入、錄音、同步與錄音庫問題。</span></a></li>
+      </ul>
+
+      <h2>English</h2>
+      <p><strong>What deletion removes.</strong> Deleting your Parley account permanently removes the account itself and every recording synced to it — audio files, transcripts, summaries, folders, and usage history. Deletion is permanent and irreversible; there is no backup to restore from.</p>
+
+      <h3>Deleting from the app</h3>
+      <ul class="support-list">
+        <li><strong>iOS</strong><span>Open Parley → Settings → Account → Delete account, then confirm with "Delete my account and personal data".</span></li>
+        <li><strong>Android</strong><span>Open Parley → tap Account (top right) to open the account sheet → Delete account, then confirm with "Delete my account and data".</span></li>
+      </ul>
+      <p>Both platforms show a confirmation dialog spelling out what is destroyed and require a second, explicit tap. Afterwards the app returns to the sign-in screen, and any recordings still queued for upload on that device are discarded too.</p>
+
+      <h3>If you own a shared organization</h3>
+      <p>Deletion is refused while your account still owns a shared organization, because removing it would take its other members' shared recordings with it. Transfer the organization to another member, or delete it, from the desktop app first — then delete your account.</p>
+
+      <h3>Deleting without installing the app</h3>
+      <p>You do not need to install or reinstall Parley. Email <a href="mailto:contact@pathors.com?subject=Parley%20account%20deletion">contact@pathors.com</a> <strong>from the address your account is registered to</strong>, with the subject "Parley account deletion" and the account email in the message. We confirm your identity through that address and then delete the account, with exactly the same scope as in-app deletion.</p>
+    </main>
+    <footer>© 2026 Pathors AI · <a href="../privacy/">Privacy</a> · <a href="../support/">Support</a></footer>
+  </body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -549,6 +549,7 @@ claude mcp add --transport http parley \
           <a href="https://github.com/pathorsAI/parley/blob/main/LICENSE" target="_blank" rel="noopener">License</a>
           <a href="privacy/">Privacy</a>
           <a href="support/">Support</a>
+          <a href="account-deletion/">Delete account</a>
           <a href="https://pathors.com" target="_blank" rel="noopener">Pathors AI</a>
         </nav>
       </div>

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -20,7 +20,7 @@
       <p class="lead">本政策說明官方雲端版 Parley 如何處理帳號、錄音、逐字稿與 AI 使用資料。開源桌面版在未啟用雲端服務時，可僅依你選擇的本機與第三方供應商設定運作。</p>
       <span class="updated">最後更新：2026 年 7 月 27 日</span>
 
-      <div class="callout"><p><strong>簡短版：</strong>Parley 只在你按下錄音後收取麥克風音訊；音訊與逐字稿會同步到你的 Parley 帳號，以便你在裝置間查看。你可在 app 設定中永久刪除個人帳號與資料。</p></div>
+      <div class="callout"><p><strong>簡短版：</strong>Parley 只在你按下錄音後收取麥克風音訊；音訊與逐字稿會同步到你的 Parley 帳號，以便你在裝置間查看。你可在 app 內永久刪除個人帳號與資料，也可以<a href="../account-deletion/">不安裝 app 直接提出刪除</a>。</p></div>
 
       <h2>我們收集的資料</h2>
       <div class="data-grid">
@@ -42,7 +42,7 @@
       <p>官方雲端版使用 Cloudflare 的 D1 與 R2 儲存帳號資料、錄音中繼資料和加密傳輸的音訊物件。即時轉錄使用 Soniox；官方 AI 功能使用 Groq。若你選擇以 Google 或 Apple 登入，該登入提供者會依其自身政策處理登入資料。這些供應商只為提供 Parley 服務而處理資料。</p>
 
       <h2>保留與刪除</h2>
-      <p>你的帳號資料與個人錄音會保留至你刪除它們。可在 iOS app 的「設定 → 帳號 → 刪除帳號」永久刪除帳號、個人錄音、逐字稿、資料夾與使用資料。若你是共享組織的擁有者，必須先移轉或刪除該組織，避免意外刪除其他成員的共同資料。</p>
+      <p>你的帳號資料與個人錄音會保留至你刪除它們。刪除帳號會永久移除帳號、個人錄音的音訊與逐字稿、資料夾與使用資料，且無法復原。iOS 從「設定 → 帳號 → 刪除帳號」；Android 從右上角「帳號」面板的「刪除帳號」。無法開啟 app 時，也可以依<a href="../account-deletion/">刪除帳號說明頁</a>以註冊信箱來信提出。若你是共享組織的擁有者，必須先移轉或刪除該組織，避免意外刪除其他成員的共同資料。</p>
       <p>同步失敗的完成錄音會暫存在你的裝置 App Support 空間，直到上傳成功；成功後會自動移除。你可刪除 app 來清除該裝置上的暫存資料。</p>
 
       <h2>你的責任與選擇</h2>
@@ -52,8 +52,8 @@
       <p>隱私問題、資料請求或政策意見，請寄至 <a href="mailto:contact@pathors.com">contact@pathors.com</a>。</p>
 
       <h2>English summary</h2>
-      <p>Parley processes account information, user-initiated recordings, transcripts, and usage data to provide transcription and synced meeting history. We do not sell personal data or use meeting content for advertising. You can delete your account and personal data from Settings in the iOS app. Contact <a href="mailto:contact@pathors.com">contact@pathors.com</a> for privacy requests.</p>
+      <p>Parley processes account information, user-initiated recordings, transcripts, and usage data to provide transcription and synced meeting history. We do not sell personal data or use meeting content for advertising. You can permanently delete your account and all of its recordings from inside the app — iOS: Settings → Account → Delete account; Android: the Account sheet → Delete account — or, without installing the app, by following the <a href="../account-deletion/">account deletion page</a>. Contact <a href="mailto:contact@pathors.com">contact@pathors.com</a> for privacy requests.</p>
     </main>
-    <footer>© 2026 Pathors AI · <a href="../support/">Support</a></footer>
+    <footer>© 2026 Pathors AI · <a href="../support/">Support</a> · <a href="../account-deletion/">刪除帳號 / Account deletion</a></footer>
   </body>
 </html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -15,4 +15,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://parley.tw/account-deletion/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -23,7 +23,8 @@
       <ul class="support-list">
         <li><a href="mailto:contact@pathors.com?subject=Parley%20support"><strong>寄信給 Parley 支援</strong><span>登入、帳號、同步、資料與一般產品問題。</span></a></li>
         <li><a href="https://github.com/pathorsAI/parley/issues" target="_blank" rel="noopener"><strong>回報開源版本問題</strong><span>附上重現步驟、版本與非敏感性日誌。GitHub 會在新分頁開啟。</span></a></li>
-        <li><a href="../privacy/"><strong>隱私與帳號刪除</strong><span>查看資料處理方式；iOS app 可從「設定 → 帳號」提出永久刪除。</span></a></li>
+        <li><a href="../privacy/"><strong>隱私權政策</strong><span>查看我們收集哪些資料、存放在哪裡、保留多久。</span></a></li>
+        <li><a href="../account-deletion/"><strong>刪除帳號</strong><span>iOS 與 Android 的 app 內刪除路徑，以及無法開啟 app 時的來信方式。</span></a></li>
       </ul>
 
       <h2>iOS 常見問題</h2>


### PR DESCRIPTION
## Why

**This unblocks Google Play submission.** Play requires that any app offering account creation provide *both*:

1. an in-app way to delete the account, and
2. a publicly reachable web URL where a user can request deletion **without installing the app**.

Parley Android had neither. `DELETE /me` has existed on the backend and shipped on iOS since launch, but the Android `CloudClient` never implemented it (`android/docs/api-cloud.md` listed it under "not implemented"), and `website/privacy/index.html` told users to delete "from Settings in the iOS app" — a dead end for an Android-only user. Either gap alone gets the listing rejected.

## What changed

### `CloudClient.deleteAccount()`

`DELETE /me` with the bearer token, same contract as iOS `ParleyKit/CloudClient.swift`.

The backend refuses (409 `owned_organizations`) while the account still owns a shared workspace — deleting it silently would take its other members' recordings with it. That refusal gets its **own typed flag**, `CloudException.ownsOrganizations`, alongside the file's existing `isAuthExpired` / `isForbidden` / `isQuotaExhausted` conventions, rather than collapsing into a generic failure. It is the one deletion error the user can actually act on, and it is deliberately **not** `isRetryable` — telling them to "try again" would be a lie.

### In-app deletion UX

Mirrors iOS Settings → Account exactly, in Material3:

- A destructive **"Delete account"** `TextButton` in the account sheet, shown once `me()` has confirmed who is signed in (same condition as iOS — no point offering a call that cannot reach the server either).
- It only **arms** an `AlertDialog`. The dialog body names what is destroyed — the account, every synced recording and its audio, transcripts, summaries, folders, usage history, permanently and irreversibly, plus the not-yet-uploaded queue on the device — instead of asking "are you sure?".
- The confirm button repeats the action (**"Delete my account and data"**, error-coloured) rather than saying OK, so the destructive tap is never ambiguous. Two deliberate taps on two separately-labelled destructive controls; one stray tap can never delete an account. iOS uses the same two-step (a `confirmationDialog`, not a typed confirmation), so this matches rather than inventing a stricter gesture.
- On success: the pending-upload queue is wiped (those recordings have no account to land in, and the dialog promised the audio would be gone) and the token is **cleared**, not signed out — the server already destroyed the session, so there is nothing to revoke. Clearing the token is what returns the app to the sign-in wall; `ParleyRoot` already watches `isSignedIn`.
- On the org-owner refusal: a specific, actionable line — *"You still own at least one organization. Transfer or delete it in the desktop app first, then delete your account."* — rather than a retry prompt. Every other failure gets the generic connection message.

Queue-then-token ordering is deliberate: the sign-in screen must never appear over a still-populated queue that a re-sign-in would upload into a brand-new account.

### Strings

All eight new strings in **both** `values/strings.xml` and `values-zh-rTW/strings.xml`. Verified programmatically: 96 names, zero asymmetry.

### Website

New page at **`/account-deletion/`** (`website/account-deletion/index.html`) — zero-build static like the rest of the site, `legal.css`, zh-Hant with an English section, same structure as `privacy/` and `support/`. It states what deletion removes, the in-app route for each platform (iOS Settings → Account; Android account sheet), the shared-organization exception, and the contact route at contact@pathors.com for someone who cannot open the app. Added to `sitemap.xml` and linked from the landing footer, privacy and support.

`website/privacy/index.html` corrected: the deletion paragraph, the summary callout and the English summary all claimed iOS-only deletion. `website/support/index.html` had the same claim in its contact list.

**No invented policy.** No retention window, no response-time SLA, no "within N days" — nothing that is not already stated somewhere in the repo. The identity check for emailed requests ("email from the address the account is registered to") is procedure, not a commitment.

### Docs

`android/docs/api-cloud.md`: `DELETE /me` moved out of "not implemented" into the method table, with a section covering the clear-don't-sign-out ordering and the `ownsOrganizations` refusal, plus a row in the error table.

## Verification

`JAVA_HOME=$(/usr/libexec/java_home -v 24) ./gradlew assembleDebug :parleykit:test :app:testDebugUnitTest` → **BUILD SUCCESSFUL**, 45 tasks.

New `CloudClientDeleteAccountTest` (5 tests, MockWebServer — added `testImplementation(libs.okhttp.mockwebserver)` to `:app`, which `:parleykit` already used) covers the error mapping: the authenticated `DELETE /me` on the wire, 409 `owned_organizations` → `ownsOrganizations` + not retryable, an unrelated 409 → not the org refusal, 401 → `isAuthExpired` + `onUnauthorized` fired once, 503 → still retryable.

The website is zero-build; HTML well-formedness and every relative link were checked instead.

## Not in this PR

`android/AppStore/` is untouched — #232 (`docs/android-store-listing`) owns that, and documents this same gap in `data-safety.md`. That PR's data-safety declaration and this PR's implementation should land together for the submission.