### PR TITLE
[feature] android: screenshot demo mode with fictional fixtures

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -38,6 +38,9 @@ android {
 
     buildFeatures {
         compose = true
+        // BuildConfig.DEBUG gates the store-screenshot demo mode, so a release
+        // build cannot be talked into serving fixtures by a deep link.
+        buildConfig = true
     }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="parley" android:host="auth-callback" />
+                <!-- Store-screenshot demo mode (debug builds only, see DemoMode):
+                     adb shell am start -a android.intent.action.VIEW \
+                       -d "'parley://demo/library'" -->
+                <data android:scheme="parley" android:host="demo" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/kotlin/com/pathors/parley/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
 import com.pathors.parley.auth.AuthCallback
+import com.pathors.parley.screenshot.DemoMode
 import com.pathors.parley.ui.ParleyRoot
 import com.pathors.parley.ui.theme.ParleyTheme
 import kotlinx.coroutines.launch
@@ -17,6 +18,9 @@ import kotlinx.coroutines.launch
  * page's `parley://auth-callback?token=…` redirect arrives here — as the launch
  * intent on a cold start, or through [onNewIntent] when the app is already up —
  * rather than starting a second copy of the app.
+ *
+ * The same door takes `parley://demo/…` in debug builds, which is how the store
+ * screenshots are driven (see [DemoMode]).
  */
 class MainActivity : ComponentActivity() {
 
@@ -38,6 +42,9 @@ class MainActivity : ComponentActivity() {
 
     private fun handleDeepLink(intent: Intent?) {
         val uri = intent?.data ?: return
+        // Screenshot demo first: it claims only `parley://demo/…` in debug builds
+        // and hands everything else straight on to the sign-in handler.
+        if (DemoMode.handle(uri)) return
         val container = parleyContainer
         lifecycleScope.launch {
             when (val result = container.auth.handleAuthCallback(uri)) {

--- a/android/app/src/main/kotlin/com/pathors/parley/ParleyApplication.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ParleyApplication.kt
@@ -7,6 +7,7 @@ import com.pathors.parley.auth.AuthManager
 import com.pathors.parley.cloud.CloudClient
 import com.pathors.parley.meeting.ImportSession
 import com.pathors.parley.meeting.MeetingSession
+import com.pathors.parley.screenshot.DemoMode
 import com.pathors.parley.upload.MeetingUploader
 import com.pathors.parley.upload.PendingUploadQueue
 import kotlinx.coroutines.CoroutineScope
@@ -89,6 +90,9 @@ class AppContainer(private val app: Application) {
     /** Best-effort upload of everything the queue is holding. Never throws. */
     fun drainPendingUploads() {
         appScope.launch {
+            // Demo mode must not reach the network at all, and must not touch a
+            // real user's queue if one happens to exist on this device.
+            if (DemoMode.isActive) return@launch
             if (auth.currentToken() == null) return@launch
             runCatching { uploader.drain() }
         }

--- a/android/app/src/main/kotlin/com/pathors/parley/meeting/MeetingSession.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/meeting/MeetingSession.kt
@@ -81,6 +81,24 @@ enum class TranscriptionIssue {
 }
 
 /**
+ * Everything the live meeting screen reads off a recording in progress.
+ *
+ * [MeetingSession] is the only implementation that touches a microphone; the
+ * screenshot demo (`screenshot/DemoMeetingSession`) supplies the same five flows
+ * from scripted fixtures, which is what lets the live screen be captured on an
+ * emulator with no audio input and no network.
+ */
+interface LiveMeeting {
+    val state: StateFlow<MeetingState>
+    val segments: StateFlow<List<TranscriptSegment>>
+    val issue: StateFlow<TranscriptionIssue?>
+
+    /** Input level, 0..1 — drives the level meter. */
+    val level: StateFlow<Float>
+    val elapsedMs: StateFlow<Long>
+}
+
+/**
  * One live meeting: microphone → Ogg/Opus file **and** microphone → STT relay,
  * from the same chunk stream, plus the upload that follows.
  *
@@ -103,23 +121,23 @@ class MeetingSession(
     /** Display title for the finished recording; built by the UI layer. */
     private val title: String,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-) {
+) : LiveMeeting {
     private val mic = MicCapture(context)
 
     private val _state = MutableStateFlow<MeetingState>(MeetingState.Idle)
-    val state: StateFlow<MeetingState> = _state.asStateFlow()
+    override val state: StateFlow<MeetingState> = _state.asStateFlow()
 
     private val _segments = MutableStateFlow<List<TranscriptSegment>>(emptyList())
-    val segments: StateFlow<List<TranscriptSegment>> = _segments.asStateFlow()
+    override val segments: StateFlow<List<TranscriptSegment>> = _segments.asStateFlow()
 
     private val _issue = MutableStateFlow<TranscriptionIssue?>(null)
-    val issue: StateFlow<TranscriptionIssue?> = _issue.asStateFlow()
+    override val issue: StateFlow<TranscriptionIssue?> = _issue.asStateFlow()
 
     private val _elapsedMs = MutableStateFlow(0L)
-    val elapsedMs: StateFlow<Long> = _elapsedMs.asStateFlow()
+    override val elapsedMs: StateFlow<Long> = _elapsedMs.asStateFlow()
 
     /** RMS of the last microphone chunk, 0..1 — drives the level meter. */
-    val level: StateFlow<Float> get() = mic.level
+    override val level: StateFlow<Float> get() = mic.level
 
     /** Wall-clock start, carried into the recording's `createdAt`. */
     val startedAtMs: Long = System.currentTimeMillis()

--- a/android/app/src/main/kotlin/com/pathors/parley/screenshot/DemoMeetingSession.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/screenshot/DemoMeetingSession.kt
@@ -1,0 +1,129 @@
+package com.pathors.parley.screenshot
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import com.pathors.parley.kit.TranscriptSegment
+import com.pathors.parley.meeting.LiveMeeting
+import com.pathors.parley.meeting.MeetingState
+import com.pathors.parley.meeting.TranscriptionIssue
+import kotlin.random.Random
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * A live meeting that never touches the microphone, the relay, the encoder or
+ * the upload queue: the scripted fixture segments from [DemoMode] played back on
+ * a timer, plus a plausible level meter.
+ *
+ * The live screen is the frame the store listing most needs — a phone listening
+ * to a room with the transcript already there — and it is also the one that
+ * cannot be captured on an emulator, which has no audio input and would render
+ * a flat meter over an empty transcript. So the screen swaps this in for a real
+ * [com.pathors.parley.meeting.MeetingSession] while demo mode is on, and the
+ * `microphone` foreground service is never started at all.
+ *
+ * Starts mid-conversation on purpose: two settled runs and an unfinished tail is
+ * the state worth showing, not an empty transcript waiting for someone to speak.
+ */
+class DemoMeetingSession(
+    private val script: List<TranscriptSegment> = DemoMode.liveScript(),
+    private val tail: TranscriptSegment = DemoMode.liveTail(),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
+) : LiveMeeting {
+
+    private val _state = MutableStateFlow<MeetingState>(MeetingState.Recording)
+    override val state: StateFlow<MeetingState> = _state.asStateFlow()
+
+    private val _segments = MutableStateFlow<List<TranscriptSegment>>(emptyList())
+    override val segments: StateFlow<List<TranscriptSegment>> = _segments.asStateFlow()
+
+    /** A demo meeting never has a transcription problem to report. */
+    override val issue: StateFlow<TranscriptionIssue?> = MutableStateFlow(null).asStateFlow()
+
+    private val _level = MutableStateFlow(0f)
+    override val level: StateFlow<Float> = _level.asStateFlow()
+
+    private val _elapsedMs = MutableStateFlow(START_AT_MS)
+    override val elapsedMs: StateFlow<Long> = _elapsedMs.asStateFlow()
+
+    private var transcriptJob: Job? = null
+    private var meterJob: Job? = null
+
+    /** Seed the opening frame and start both timers. Safe to call twice. */
+    fun start() {
+        if (transcriptJob != null) return
+        _segments.value = script.take(SEEDED_LINES) + tail
+        transcriptJob = scope.launch { runTranscript() }
+        meterJob = scope.launch { runMeter() }
+    }
+
+    /**
+     * Settle the tail into the next scripted run every few seconds, then hang a
+     * fresh tail off the end — the same upsert-by-id rhythm the relay produces.
+     * When the script runs out the last tail simply stays put, which leaves the
+     * screen in a capturable mid-flight state rather than an "ended" one.
+     */
+    private suspend fun runTranscript() {
+        var settled = SEEDED_LINES
+        while (settled < script.size) {
+            delay(SETTLE_INTERVAL_MS)
+            settled += 1
+            _segments.value = script.take(settled) + tail
+        }
+    }
+
+    /**
+     * A believable meter: speech-shaped jitter around a talking level rather
+     * than a flat bar, seeded so successive captures look alike.
+     */
+    private suspend fun runMeter() {
+        val random = Random(SEED)
+        val startedAt = _elapsedMs.value
+        var ticks = 0L
+        while (true) {
+            _level.value = (BASE_LEVEL + random.nextFloat() * LEVEL_SPREAD).coerceIn(0f, 1f)
+            delay(METER_INTERVAL_MS)
+            ticks += 1
+            _elapsedMs.value = startedAt + ticks * METER_INTERVAL_MS
+        }
+    }
+
+    /** Stop both timers. Nothing is saved, because nothing was ever captured. */
+    fun dispose() {
+        transcriptJob = null
+        meterJob = null
+        scope.coroutineContext[Job]?.cancel()
+    }
+
+    private companion object {
+        /** Runs already on screen before the first tick — the opening frame. */
+        const val SEEDED_LINES = 2
+
+        /** A clock that reads like a meeting under way, not one just started. */
+        const val START_AT_MS = 108_000L
+
+        const val SETTLE_INTERVAL_MS = 4_000L
+        const val METER_INTERVAL_MS = 140L
+        const val BASE_LEVEL = 0.12f
+        const val LEVEL_SPREAD = 0.55f
+        const val SEED = 7
+    }
+}
+
+/** A demo meeting bound to the composition that shows it. */
+@Composable
+fun rememberDemoMeeting(): DemoMeetingSession {
+    val session = remember { DemoMeetingSession().also { it.start() } }
+    DisposableEffect(session) {
+        onDispose { session.dispose() }
+    }
+    return session
+}

--- a/android/app/src/main/kotlin/com/pathors/parley/screenshot/DemoMode.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/screenshot/DemoMode.kt
@@ -1,0 +1,544 @@
+package com.pathors.parley.screenshot
+
+import android.net.Uri
+import com.pathors.parley.BuildConfig
+import com.pathors.parley.cloud.CloudUser
+import com.pathors.parley.cloud.HostedQuota
+import com.pathors.parley.cloud.RecordingMeta
+import com.pathors.parley.cloud.RecordingSource
+import com.pathors.parley.cloud.RecordingSummary
+import com.pathors.parley.kit.TranscriptSegment
+import java.util.Locale
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Deterministic demo state for Play Store screenshots — debug builds only.
+ *
+ * Why this exists: every screen the store listing needs is behind the sign-in
+ * wall, and the wall is behind a real account. Capturing by hand means signing a
+ * device into a live account, which is (a) slow, (b) impossible to reproduce
+ * exactly next release, and (c) puts real customer data one mis-tap away from a
+ * public store listing. This is the Android half of iOS
+ * `ios/App/Parley/ScreenshotDemo.swift`, and it makes the same three promises:
+ *
+ *  1. **Signed in without a token.** [enabled] short-circuits the sign-in wall in
+ *     `ParleyRoot`; nothing is ever written to the auth DataStore.
+ *  2. **No network, ever.** Every cloud call the UI would make is answered from
+ *     the fixtures below, so a reviewer's (or CI's) offline machine captures the
+ *     same frames as a connected one, and production is never touched.
+ *  3. **No residue.** The flag and the navigation cue live in memory only. There
+ *     is no disk write, no pending-upload queue entry, no notification, no
+ *     microphone. `parley://demo/off` (or a process restart) leaves the app
+ *     exactly as it was.
+ *
+ * Driven entirely by deep links, the way iOS is driven by `simctl openurl` —
+ * input automation on an emulator is unreliable, `am start` is not:
+ *
+ * ```
+ * adb shell am start -a android.intent.action.VIEW -d "'parley://demo/library'"
+ * ```
+ *
+ * Routes: `library`, `transcript`, `record` (alias `meeting`), `account`
+ * (alias `settings`), and `off`.
+ *
+ * Everything below is invented. No real company, person, account, or meeting is
+ * represented, the only address is in the RFC-reserved `example.com`, and the
+ * copy is written separately in English and Traditional Chinese — a screenshot
+ * set that reads like a translation sells the product short in whichever store
+ * it lands in.
+ */
+object DemoMode {
+
+    /** The screens the listing needs, each addressable by its own URL. */
+    enum class Screen { LIBRARY, TRANSCRIPT, MEETING, ACCOUNT }
+
+    /**
+     * A navigation request. [serial] makes each one distinct so firing the same
+     * URL twice re-navigates instead of being swallowed as "no change".
+     */
+    data class Navigation(val screen: Screen, val serial: Long)
+
+    private val _enabled = MutableStateFlow(false)
+
+    /** Whether the app is serving fixtures instead of the cloud. */
+    val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    private val _navigation = MutableStateFlow<Navigation?>(null)
+
+    /** The screen the last `parley://demo/…` asked for. */
+    val navigation: StateFlow<Navigation?> = _navigation.asStateFlow()
+
+    private var serial = 0L
+
+    /** Cheap synchronous read for the non-Compose injection points. */
+    val isActive: Boolean get() = _enabled.value
+
+    /**
+     * Handle a `parley://demo/…` deep link. Returns false for anything else — a
+     * sign-in callback, or any route in a release build — so `MainActivity`'s
+     * real handler still sees it.
+     */
+    fun handle(uri: Uri): Boolean {
+        if (!BuildConfig.DEBUG) return false
+        if (uri.scheme != SCHEME || uri.host != HOST) return false
+        val route = uri.pathSegments.lastOrNull().orEmpty()
+        if (route == ROUTE_OFF) {
+            disable()
+            return true
+        }
+        val screen = when (route) {
+            "library", "recordings" -> Screen.LIBRARY
+            "transcript", "recording" -> Screen.TRANSCRIPT
+            "record", "meeting" -> Screen.MEETING
+            "account", "settings" -> Screen.ACCOUNT
+            else -> return false
+        }
+        _enabled.value = true
+        serial += 1
+        _navigation.value = Navigation(screen, serial)
+        return true
+    }
+
+    /** Leave demo mode. In-memory only, so this is the whole clean-up. */
+    fun disable() {
+        _enabled.value = false
+        _navigation.value = null
+    }
+
+    // ── language ─────────────────────────────────────────────────────────────
+
+    /**
+     * The demo copy follows the device locale, because the screenshot sets are
+     * captured per-locale: a zh-TW capture has to be a Chinese screenshot all the
+     * way down, transcript included.
+     */
+    private fun isChinese(locale: Locale): Boolean = locale.language == "zh"
+
+    private fun t(locale: Locale, en: String, zh: String): String =
+        if (isChinese(locale)) zh else en
+
+    // ── account fixtures ─────────────────────────────────────────────────────
+
+    fun user(locale: Locale = Locale.getDefault()): CloudUser = CloudUser(
+        id = "demo-user",
+        name = t(locale, "Alex Rivera", "李書瑋"),
+        email = "alex@example.com",
+    )
+
+    fun quota(): HostedQuota = HostedQuota(
+        plan = "free",
+        sttSecondsUsed = 8_640.0,
+        sttSecondsLimit = 36_000.0,
+        llmCreditsUsed = 180.0,
+        llmCreditsLimit = 500.0,
+        periodResetTs = EPOCH_MS + 18 * DAY_MS,
+    )
+
+    // ── library fixtures ─────────────────────────────────────────────────────
+
+    /** The recording the `transcript` route opens: the fully analyzed one. */
+    const val FEATURED_ID = "demo-renewal"
+
+    private const val DISCOVERY_ID = "demo-discovery"
+    private const val REVIEW_ID = "demo-review"
+
+    fun recordings(locale: Locale = Locale.getDefault()): List<RecordingSummary> = listOf(
+        RecordingSummary(
+            id = FEATURED_ID,
+            title = t(locale, "Renewal terms — Northwind", "續約條件討論 — 北風工業"),
+            source = RecordingSource.LIVE,
+            createdAt = EPOCH_MS,
+            durationMs = 1_122_000.0,
+            speakerCount = 2,
+            findingsCount = 3,
+            actionItemsCount = 2,
+            hasAudio = true,
+            snippet = t(
+                locale,
+                "Forty seats against an eighty-seat quote; price held through the next renewal.",
+                "四十席對上八十席的報價；價格鎖到下一次續約。",
+            ),
+        ),
+        RecordingSummary(
+            id = DISCOVERY_ID,
+            title = t(locale, "Discovery call — Halcyon Labs", "新客戶需求訪談 — 晴光實驗室"),
+            source = RecordingSource.LIVE,
+            createdAt = EPOCH_MS - DAY_MS,
+            durationMs = 1_925_000.0,
+            speakerCount = 3,
+            findingsCount = 2,
+            actionItemsCount = 1,
+            hasAudio = true,
+            snippet = t(
+                locale,
+                "Security questionnaire due Friday; invoicing split across two cost centres.",
+                "資安問卷週五前回覆；請款要拆成兩個成本中心。",
+            ),
+        ),
+        RecordingSummary(
+            id = REVIEW_ID,
+            title = t(locale, "Quarterly review — Meridian", "季度檢討 — 子午線"),
+            source = RecordingSource.UPLOAD,
+            createdAt = EPOCH_MS - 5 * DAY_MS,
+            durationMs = 2_831_000.0,
+            speakerCount = 2,
+            findingsCount = 0,
+            actionItemsCount = 0,
+            hasAudio = true,
+            snippet = t(
+                locale,
+                "Usage up 22% quarter on quarter; two action items carried over.",
+                "使用量季增 22%；兩項待辦順延到下一季。",
+            ),
+        ),
+    )
+
+    /** The meta the detail screen renders, or null for an id we don't have. */
+    fun meta(id: String, locale: Locale = Locale.getDefault()): RecordingMeta? {
+        val summary = recordings(locale).firstOrNull { it.id == id } ?: return null
+        return RecordingMeta(
+            buildJsonObject {
+                put("id", summary.id)
+                put("title", summary.title)
+                put("source", summary.source)
+                put("createdAt", summary.createdAt.toLong())
+                put("durationMs", summary.durationMs.toLong())
+                put("audio", "audio.ogg")
+                put("analyzed", summary.findingsCount != 0)
+                putJsonObject("speakerNames") {
+                    speakerNames(id, locale).forEach { (key, name) -> put(key, name) }
+                }
+                putJsonArray("segments") {
+                    lines(id, locale).forEach { line ->
+                        addJsonObject {
+                            put("id", "mix-${line.index}")
+                            put("source", "mix")
+                            put("speaker", line.speaker)
+                            put("text", line.text)
+                            put("isFinal", true)
+                            put("startMs", line.atMs)
+                            put("endMs", line.atMs + LINE_LENGTH_MS)
+                        }
+                    }
+                }
+                putJsonArray("findings") {
+                    findings(id, locale).forEach { finding ->
+                        addJsonObject {
+                            put("title", finding.title)
+                            put("detail", finding.detail)
+                            put("atMs", finding.atMs)
+                            put("severity", finding.severity)
+                        }
+                    }
+                }
+                putJsonArray("actionItems") {
+                    actionItems(id, locale).forEach { item ->
+                        addJsonObject {
+                            put("text", item.text)
+                            put("rationale", item.rationale)
+                            put("done", false)
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    private fun speakerNames(id: String, locale: Locale): Map<String, String> = when (id) {
+        DISCOVERY_ID -> mapOf(
+            "mix-1" to t(locale, "Head of platform", "平台負責人"),
+            "mix-2" to t(locale, "You", "我"),
+            "mix-3" to t(locale, "Security lead", "資安主管"),
+        )
+
+        else -> mapOf(
+            "mix-1" to t(locale, "Client lead", "客戶窗口"),
+            "mix-2" to t(locale, "You", "我"),
+        )
+    }
+
+    // ── transcript fixtures ──────────────────────────────────────────────────
+
+    private data class Line(val index: Int, val speaker: Int, val atMs: Long, val text: String)
+
+    /**
+     * The conversations, written the way B2B calls actually sound — a seat count
+     * against a quote, a price hold, an onboarding estimate with a condition
+     * attached. A screenshot reading "test test test" tells a reviewer nothing
+     * about what the product does.
+     */
+    private fun lines(id: String, locale: Locale): List<Line> = when (id) {
+        DISCOVERY_ID -> listOf(
+            Line(
+                1, 1, 9_000,
+                t(
+                    locale,
+                    "We run about thirty calls a week across two teams, and nobody writes them up. That's the problem we're trying to solve.",
+                    "我們兩個團隊一週大概三十通會議，但沒有人做紀錄，這就是我們想解決的問題。",
+                ),
+            ),
+            Line(
+                2, 2, 31_000,
+                t(
+                    locale,
+                    "Then the place to start is the transcript, not the summary — people trust a summary once they can check it against what was said.",
+                    "那就從逐字稿開始，而不是摘要——大家要能對照原話，才會信任摘要。",
+                ),
+            ),
+            Line(
+                3, 3, 52_000,
+                t(
+                    locale,
+                    "Before any of that, I need the security questionnaire back. Friday, or this slips to next quarter.",
+                    "在那之前，我需要先拿回資安問卷。週五前，不然就要拖到下一季。",
+                ),
+            ),
+            Line(
+                4, 2, 74_000,
+                t(
+                    locale,
+                    "Friday works. One thing to flag: your invoicing has to be split across two cost centres, so I'll set that up before the trial starts.",
+                    "週五沒問題。有一件事要先講：你們的請款要拆成兩個成本中心，我會在試用開始前先設定好。",
+                ),
+            ),
+        )
+
+        REVIEW_ID -> listOf(
+            Line(
+                1, 1, 14_000,
+                t(
+                    locale,
+                    "Usage is up twenty-two percent quarter on quarter, and almost all of it came from the two teams that onboarded in March.",
+                    "使用量季增二十二個百分點，而且幾乎都來自三月導入的那兩個團隊。",
+                ),
+            ),
+            Line(
+                2, 2, 38_000,
+                t(
+                    locale,
+                    "That matches what we saw. The two action items from last quarter are still open — both are waiting on your IT team.",
+                    "跟我們看到的一致。上一季的兩項待辦還沒關掉，兩件都卡在你們的 IT。",
+                ),
+            ),
+            Line(
+                3, 1, 61_000,
+                t(
+                    locale,
+                    "Carry them over. I'd rather close them properly next quarter than mark them done today.",
+                    "順延吧。我寧可下一季好好收掉，也不要今天硬把它們標成完成。",
+                ),
+            ),
+        )
+
+        else -> listOf(
+            Line(
+                1, 1, 12_000,
+                t(
+                    locale,
+                    "We're happy with the platform overall. The blocker is the seat count — we budgeted for forty and the quote came back at eighty.",
+                    "平台整體我們用得很滿意，卡住的是席次——我們編了四十席，但報價回來是八十席。",
+                ),
+            ),
+            Line(
+                2, 2, 27_000,
+                t(
+                    locale,
+                    "Forty is the floor on the enterprise tier, so I can't go under it. What I can do is hold this year's price through the next renewal.",
+                    "四十席是企業版的最低門檻，我沒辦法再往下。我能做的是把今年的價格鎖到下一次續約。",
+                ),
+            ),
+            Line(
+                3, 1, 44_000,
+                t(
+                    locale,
+                    "A price hold helps. What about the onboarding time you mentioned last week — you said two weeks?",
+                    "鎖價有幫助。那你上週提到的導入時間呢，你說兩週？",
+                ),
+            ),
+            Line(
+                4, 2, 58_000,
+                t(
+                    locale,
+                    "Two weeks assumes your SSO is already on Okta. If it isn't, add a week for the identity mapping.",
+                    "兩週的前提是你們的 SSO 已經在 Okta 上。如果不是，身分對應要再加一週。",
+                ),
+            ),
+            Line(
+                5, 1, 76_000,
+                t(
+                    locale,
+                    "It is. Send the revised quote with the price hold in writing and I'll take it to finance on Thursday.",
+                    "是在 Okta 上。你把含鎖價條款的修訂報價寄來，我週四拿去給財務。",
+                ),
+            ),
+            Line(
+                6, 2, 92_000,
+                t(
+                    locale,
+                    "I'll have it to you tomorrow morning, and I'll include the security questionnaire your team asked for.",
+                    "明天早上寄給你，並附上你們團隊要的資安問卷。",
+                ),
+            ),
+        )
+    }
+
+    // ── analysis fixtures ────────────────────────────────────────────────────
+
+    private data class Finding(
+        val title: String,
+        val detail: String,
+        val atMs: Long,
+        val severity: String,
+    )
+
+    private data class ActionItem(val text: String, val rationale: String)
+
+    private fun findings(id: String, locale: Locale): List<Finding> = when (id) {
+        FEATURED_ID -> listOf(
+            Finding(
+                t(locale, "Seat count is the only blocker", "唯一的卡點是席次"),
+                t(
+                    locale,
+                    "Forty seats budgeted against an eighty-seat quote. Everything else about the renewal was already agreed.",
+                    "編列四十席，報價卻是八十席。續約的其他條件其實都談定了。",
+                ),
+                12_000, "high",
+            ),
+            Finding(
+                t(locale, "A price hold replaced a discount", "用鎖價取代了折扣"),
+                t(
+                    locale,
+                    "Holding this year's rate through the next renewal kept the conversation moving without cutting below the enterprise seat floor.",
+                    "把今年的價格鎖到下一次續約，讓談判繼續往前，又不必跌破企業版的席次門檻。",
+                ),
+                27_000, "medium",
+            ),
+            Finding(
+                t(locale, "The onboarding estimate has a condition", "導入時程附帶條件"),
+                t(
+                    locale,
+                    "Two weeks assumes SSO is already on Okta; add a week for identity mapping if it isn't. The customer confirmed it is.",
+                    "兩週的前提是 SSO 已在 Okta 上；若不是，身分對應要再加一週。客戶已確認是。",
+                ),
+                58_000, "low",
+            ),
+        )
+
+        DISCOVERY_ID -> listOf(
+            Finding(
+                t(locale, "The security questionnaire gates the timeline", "資安問卷決定了時程"),
+                t(
+                    locale,
+                    "Friday is a hard date — missing it pushes the whole evaluation into next quarter.",
+                    "週五是硬期限，錯過就整個評估拖到下一季。",
+                ),
+                52_000, "high",
+            ),
+            Finding(
+                t(locale, "Billing needs two cost centres", "請款需要拆成兩個成本中心"),
+                t(
+                    locale,
+                    "Raised as an aside, but it has to be set up before the trial starts or the first invoice bounces internally.",
+                    "只是順口提到，但要在試用開始前設定好，否則第一張帳單在他們內部就會被退。",
+                ),
+                74_000, "medium",
+            ),
+        )
+
+        else -> emptyList()
+    }
+
+    private fun actionItems(id: String, locale: Locale): List<ActionItem> = when (id) {
+        FEATURED_ID -> listOf(
+            ActionItem(
+                t(
+                    locale,
+                    "Send the revised quote with the price hold in writing",
+                    "寄出含鎖價條款的修訂報價",
+                ),
+                t(
+                    locale,
+                    "Finance reviews it on Thursday, so it has to land Wednesday at the latest.",
+                    "財務週四要審，最晚週三要送到。",
+                ),
+            ),
+            ActionItem(
+                t(
+                    locale,
+                    "Attach the security questionnaire to the same email",
+                    "同一封信附上資安問卷",
+                ),
+                t(
+                    locale,
+                    "Their team asked for it directly, and it gates their internal sign-off.",
+                    "對方團隊直接要的，而且他們的內部核准卡在這份文件。",
+                ),
+            ),
+        )
+
+        DISCOVERY_ID -> listOf(
+            ActionItem(
+                t(locale, "Return the security questionnaire by Friday", "週五前回覆資安問卷"),
+                t(
+                    locale,
+                    "Named as the gate on the whole evaluation timeline.",
+                    "對方明講這是整個評估時程的關卡。",
+                ),
+            ),
+        )
+
+        else -> emptyList()
+    }
+
+    // ── live meeting fixture ─────────────────────────────────────────────────
+
+    /**
+     * The renewal conversation again, this time as live segments for
+     * [DemoMeetingSession] to play back on a timer — the live screen has to be
+     * capturable on an emulator with no microphone and no audio input.
+     */
+    fun liveScript(locale: Locale = Locale.getDefault()): List<TranscriptSegment> =
+        lines(FEATURED_ID, locale).map { line ->
+            TranscriptSegment(
+                id = "mix-${line.index}",
+                source = "mix",
+                speaker = line.speaker,
+                text = line.text,
+                isFinal = true,
+                startMs = line.atMs,
+                endMs = line.atMs + LINE_LENGTH_MS,
+            )
+        }
+
+    /** The unfinished tail: what the relay has heard but not settled yet. */
+    fun liveTail(locale: Locale = Locale.getDefault()): TranscriptSegment = TranscriptSegment(
+        id = "mix-tail",
+        source = "mix",
+        speaker = 1,
+        text = t(
+            locale,
+            "So if we sign this week, when could your team actually",
+            "所以如果我們這週簽，你們團隊實際上什麼時候能",
+        ),
+        isFinal = false,
+        startMs = 108_000,
+        endMs = 112_000,
+    )
+
+    private const val SCHEME = "parley"
+    private const val HOST = "demo"
+    private const val ROUTE_OFF = "off"
+
+    /** A fixed clock, so a re-capture months later produces identical frames. */
+    private const val EPOCH_MS = 1_786_498_800_000.0
+
+    private const val DAY_MS = 86_400_000.0
+    private const val LINE_LENGTH_MS = 12_000L
+}

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/HomeScreen.kt
@@ -50,6 +50,7 @@ import com.pathors.parley.cloud.RecordingSource
 import com.pathors.parley.cloud.RecordingSummary
 import com.pathors.parley.meeting.MeetingService
 import com.pathors.parley.meeting.MeetingState
+import com.pathors.parley.screenshot.DemoMode
 import com.pathors.parley.upload.PendingUpload
 
 /**
@@ -80,6 +81,15 @@ fun HomeScreen(
     // Reload on every visit: a meeting or an import that finished while this
     // screen was off-stage has a new row waiting in the cloud.
     LaunchedEffect(Unit) { viewModel.refresh() }
+
+    // `parley://demo/account` lands on the library and opens the account sheet —
+    // the one screen the store listing needs that has no route of its own.
+    val demoNavigation by DemoMode.navigation.collectAsState()
+    LaunchedEffect(demoNavigation) {
+        val target = demoNavigation ?: return@LaunchedEffect
+        showAccount = target.screen == DemoMode.Screen.ACCOUNT
+        if (showAccount) viewModel.loadAccount()
+    }
 
     Scaffold(
         topBar = {

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/HomeViewModel.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.pathors.parley.cloud.CloudException
 import com.pathors.parley.cloud.CloudUser
 import com.pathors.parley.cloud.HostedQuota
 import com.pathors.parley.cloud.RecordingSummary
+import com.pathors.parley.screenshot.DemoMode
 import com.pathors.parley.upload.PendingUpload
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,6 +53,12 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
     val account: StateFlow<AccountState> = _account.asStateFlow()
 
     fun refresh() {
+        if (DemoMode.isActive) {
+            // Fixtures, not the cloud — and deliberately not the pending queue
+            // either: demo mode never reads or writes a real user's disk state.
+            _state.value = UiState(loading = false, recordings = DemoMode.recordings())
+            return
+        }
         viewModelScope.launch {
             _state.value = _state.value.copy(loading = true)
             val pending = withContext(Dispatchers.IO) { container.uploadQueue.list() }
@@ -88,6 +95,10 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
     }
 
     fun loadAccount() {
+        if (DemoMode.isActive) {
+            _account.value = AccountState(user = DemoMode.user(), quota = DemoMode.quota())
+            return
+        }
         if (_account.value.loading) return
         viewModelScope.launch {
             _account.value = AccountState(loading = true)
@@ -103,6 +114,12 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
     }
 
     fun signOut() {
+        // In demo mode "sign out" is how you leave demo mode: there is no session
+        // to revoke, and the real sign-out must never run against a live account.
+        if (DemoMode.isActive) {
+            DemoMode.disable()
+            return
+        }
         viewModelScope.launch { container.auth.signOut() }
     }
 

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/MeetingScreen.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/MeetingScreen.kt
@@ -48,11 +48,14 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.pathors.parley.R
 import com.pathors.parley.kit.TranscriptSegment
+import com.pathors.parley.meeting.LiveMeeting
 import com.pathors.parley.meeting.MeetingFailure
 import com.pathors.parley.meeting.MeetingService
 import com.pathors.parley.meeting.MeetingSession
 import com.pathors.parley.meeting.MeetingState
 import com.pathors.parley.meeting.TranscriptionIssue
+import com.pathors.parley.screenshot.DemoMode
+import com.pathors.parley.screenshot.rememberDemoMeeting
 import kotlinx.coroutines.delay
 
 /**
@@ -67,6 +70,14 @@ import kotlinx.coroutines.delay
 fun MeetingScreen(onDone: () -> Unit) {
     val context = LocalContext.current
     val session by MeetingService.activeSession.collectAsState()
+
+    // Store screenshots: scripted segments on a timer, no permission prompt, no
+    // foreground service, no microphone — an emulator has no audio input, and a
+    // capture must never depend on one.
+    if (DemoMode.isActive) {
+        MeetingContent(session = rememberDemoMeeting(), onStop = onDone, onDone = onDone)
+        return
+    }
 
     var granted by remember {
         mutableStateOf(
@@ -123,7 +134,7 @@ private fun requiredPermissions(): Array<String> =
     }
 
 @Composable
-private fun MeetingContent(session: MeetingSession, onStop: () -> Unit, onDone: () -> Unit) {
+private fun MeetingContent(session: LiveMeeting, onStop: () -> Unit, onDone: () -> Unit) {
     val state by session.state.collectAsState()
     val segments by session.segments.collectAsState()
     val issue by session.issue.collectAsState()

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/ParleyRoot.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/ParleyRoot.kt
@@ -12,16 +12,19 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.pathors.parley.AppContainer
 import com.pathors.parley.R
+import com.pathors.parley.screenshot.DemoMode
 
 /** The four places the app can be. */
 private object Route {
@@ -40,16 +43,23 @@ private object Route {
  * answered — being offline must never look like being signed out (see
  * `AuthManager.isSignedIn`). A dead session comes back as a 401, which clears the
  * token from one place and swaps this back to the sign-in screen on its own.
+ *
+ * The one exception is [DemoMode], which stands the wall down without a token so
+ * the store screenshots can be captured. It is debug-only and writes nothing.
  */
 @Composable
 fun ParleyRoot() {
     val container = rememberContainer()
     val signedIn by container.auth.isSignedIn.collectAsState(initial = null)
+    val demo by DemoMode.enabled.collectAsState()
 
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-        when (signedIn) {
-            null -> Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator() }
-            false -> SignInScreen(container)
+        when {
+            demo -> ParleyNavHost(container)
+            signedIn == null ->
+                Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator() }
+
+            signedIn == false -> SignInScreen(container)
             else -> ParleyNavHost(container)
         }
     }
@@ -59,6 +69,8 @@ fun ParleyRoot() {
 private fun ParleyNavHost(container: AppContainer) {
     val navController = rememberNavController()
     val context = LocalContext.current
+
+    DemoNavigation(navController)
 
     // The Storage Access Framework: no storage permission, any provider (Files,
     // Drive, a recorder app), and the grant lives as long as we need the Uri.
@@ -96,6 +108,28 @@ private fun ParleyNavHost(container: AppContainer) {
                 recordingId = entry.arguments?.getString("id").orEmpty(),
                 onBack = { navController.popBackStack() },
             )
+        }
+    }
+}
+
+/**
+ * Drives the navigation graph from `parley://demo/…`, so a screenshot run is a
+ * list of URLs rather than a list of taps (input automation on an emulator is
+ * unreliable; `am start` is not).
+ *
+ * The account route only has to reach the library — [HomeScreen] watches the same
+ * cue and opens its account sheet.
+ */
+@Composable
+private fun DemoNavigation(navController: NavHostController) {
+    val navigation by DemoMode.navigation.collectAsState()
+    LaunchedEffect(navigation) {
+        val target = navigation ?: return@LaunchedEffect
+        navController.popBackStack(Route.HOME, inclusive = false)
+        when (target.screen) {
+            DemoMode.Screen.LIBRARY, DemoMode.Screen.ACCOUNT -> Unit
+            DemoMode.Screen.TRANSCRIPT -> navController.navigate(Route.recording(DemoMode.FEATURED_ID))
+            DemoMode.Screen.MEETING -> navController.navigate(Route.MEETING)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/RecordingDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/RecordingDetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.pathors.parley.AppContainer
 import com.pathors.parley.cloud.RecordingMeta
+import com.pathors.parley.screenshot.DemoMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -57,24 +58,30 @@ class RecordingDetailViewModel(
     }
 
     fun load() {
+        if (DemoMode.isActive) {
+            _state.value = fromMeta(DemoMode.meta(recordingId))
+            return
+        }
         viewModelScope.launch {
             _state.value = UiState(loading = true)
             val result = runCatching { container.cloud.recordingMeta(recordingId) }
-            _state.value = result.fold(
-                onSuccess = { meta ->
-                    UiState(
-                        loading = false,
-                        meta = meta,
-                        findings = readFindings(meta),
-                        actionItems = readActionItems(meta),
-                    )
-                },
-                onFailure = { UiState(loading = false, failed = true) },
-            )
+            _state.value = fromMeta(result.getOrNull())
         }
     }
 
     companion object {
+
+        /** The loaded state for a meta, or the failed state when there is none. */
+        internal fun fromMeta(meta: RecordingMeta?): UiState = when (meta) {
+            null -> UiState(loading = false, failed = true)
+            else -> UiState(
+                loading = false,
+                meta = meta,
+                findings = readFindings(meta),
+                actionItems = readActionItems(meta),
+            )
+        }
+
         fun factory(container: AppContainer, recordingId: String) = viewModelFactory {
             initializer { RecordingDetailViewModel(container, recordingId) }
         }

--- a/android/app/src/test/kotlin/com/pathors/parley/screenshot/DemoModeTest.kt
+++ b/android/app/src/test/kotlin/com/pathors/parley/screenshot/DemoModeTest.kt
@@ -1,0 +1,133 @@
+package com.pathors.parley.screenshot
+
+import com.pathors.parley.ui.RecordingDetailViewModel
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The fixtures are the product in a screenshot, so they are worth testing: both
+ * languages have to be complete (a half-translated set ships a half-translated
+ * store listing), and the content has to be the shape the detail screen reads.
+ *
+ * The deep-link routing itself needs `android.net.Uri` and `BuildConfig`, so it
+ * is covered on-device rather than here.
+ */
+class DemoModeTest {
+
+    private val en = Locale.ENGLISH
+    private val zh = Locale.TRADITIONAL_CHINESE
+
+    @Test
+    fun `library is populated in both languages`() {
+        listOf(en, zh).forEach { locale ->
+            val recordings = DemoMode.recordings(locale)
+            assertEquals(3, recordings.size)
+            recordings.forEach { recording ->
+                assertTrue(recording.title.isNotBlank())
+                assertTrue(recording.snippet.orEmpty().isNotBlank())
+                assertTrue(recording.durationMs > 0)
+                assertTrue(recording.createdAt > 0)
+            }
+        }
+    }
+
+    @Test
+    fun `every language differs, so nothing is left untranslated`() {
+        val english = DemoMode.recordings(en)
+        val chinese = DemoMode.recordings(zh)
+        english.zip(chinese).forEach { (a, b) ->
+            assertEquals(a.id, b.id)
+            assertNotEquals(a.title, b.title)
+            assertNotEquals(a.snippet, b.snippet)
+        }
+        assertNotEquals(DemoMode.user(en).name, DemoMode.user(zh).name)
+    }
+
+    @Test
+    fun `the featured recording carries transcript, findings and action items`() {
+        listOf(en, zh).forEach { locale ->
+            val meta = DemoMode.meta(DemoMode.FEATURED_ID, locale)
+            assertNotNull(meta)
+            requireNotNull(meta)
+            assertEquals(6, meta.segments.size)
+            assertTrue(meta.analyzed)
+            assertTrue(meta.segments.all { it.text.isNotBlank() && it.isFinal })
+            // Two speakers, both named — the point of the transcript screenshot.
+            assertEquals(2, meta.segments.map { meta.speakerKey(it) }.toSet().size)
+            assertTrue(meta.segments.all { meta.speakerName(it) != null })
+
+            val findings = RecordingDetailViewModel.readFindings(meta)
+            val actions = RecordingDetailViewModel.readActionItems(meta)
+            assertEquals(3, findings.size)
+            assertEquals(2, actions.size)
+            assertTrue(findings.all { it.title.isNotBlank() && it.detail.isNotBlank() })
+            assertTrue(findings.all { it.atMs != null })
+            assertTrue(actions.all { it.text.isNotBlank() && !it.done })
+        }
+    }
+
+    @Test
+    fun `every listed recording opens`() {
+        DemoMode.recordings(en).forEach { summary ->
+            val meta = DemoMode.meta(summary.id, en)
+            assertNotNull(meta)
+            requireNotNull(meta)
+            assertEquals(summary.id, meta.id)
+            assertEquals(summary.title, meta.title)
+            assertEquals(summary.durationMs, meta.durationMs, 0.0)
+            // The summary's counts have to be the truth about the meta, or a
+            // future card that renders them would be lying in a screenshot.
+            assertEquals(
+                summary.findingsCount ?: 0,
+                RecordingDetailViewModel.readFindings(meta).size,
+            )
+            assertEquals(
+                summary.actionItemsCount ?: 0,
+                RecordingDetailViewModel.readActionItems(meta).size,
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown id has no fixture`() {
+        assertNull(DemoMode.meta("not-a-demo-recording", en))
+    }
+
+    @Test
+    fun `the live script starts mid-conversation and ends unfinished`() {
+        listOf(en, zh).forEach { locale ->
+            val script = DemoMode.liveScript(locale)
+            assertEquals(6, script.size)
+            assertTrue(script.all { it.isFinal && it.source == "mix" })
+            // Ids are what the UI upserts on; duplicates would collapse rows.
+            assertEquals(script.size, script.map { it.id }.toSet().size)
+
+            val tail = DemoMode.liveTail(locale)
+            assertFalse(tail.isFinal)
+            assertTrue(tail.id.endsWith("-tail"))
+            assertTrue(tail.startMs > script.last().startMs)
+        }
+    }
+
+    @Test
+    fun `nothing points at a real person, company or address`() {
+        val text = listOf(en, zh).flatMap { locale ->
+            DemoMode.recordings(locale).flatMap { listOf(it.title, it.snippet.orEmpty()) } +
+                DemoMode.recordings(locale).mapNotNull { DemoMode.meta(it.id, locale) }
+                    .flatMap { meta -> meta.segments.map { it.text } } +
+                listOf(DemoMode.user(locale).email)
+        }.joinToString(" ")
+        assertTrue(DemoMode.user(en).email.endsWith("@example.com"))
+        assertFalse(text.contains("pathors", ignoreCase = true))
+        assertFalse(text.contains("parley.tw", ignoreCase = true))
+    }
+
+    private fun assertNotEquals(a: Any?, b: Any?) {
+        assertFalse("expected $a and $b to differ", a == b)
+    }
+}

--- a/android/docs/app-structure.md
+++ b/android/docs/app-structure.md
@@ -93,7 +93,8 @@ Single activity, `androidx.navigation-compose`, four routes: `home`, `meeting`,
 `import`, `recording/{id}`. The sign-in wall sits *in front of* the graph and is
 driven by whether a token is stored (`AuthManager.isSignedIn`) — being offline
 must never look like being signed out; a dead session arrives as a 401, which
-clears the token from one place and swaps the wall back in.
+clears the token from one place and swaps the wall back in. The one thing that
+bypasses the wall is the debug-only screenshot demo mode, below.
 
 ViewModels (`lifecycle-viewmodel-compose`, built through
 `viewModelFactory { initializer { … } }`) are used where a screen has state worth
@@ -108,6 +109,44 @@ Every user-visible string is in `res/values/strings.xml` **and**
 enums (`MeetingFailure`, `ImportFailure`, `HomeError`, `TranscriptionIssue`)
 exist precisely so the session layer never holds display copy — the screen maps
 the enum to a resource.
+
+## Screenshot demo mode
+
+`screenshot/DemoMode.kt` is the Android half of iOS `ScreenshotDemo.swift`: a
+debug-only, in-memory flag that stands the sign-in wall down without a token and
+answers every cloud call from fixed fictional fixtures. It exists because the
+store listing needs populated screens, and the alternative — signing a device
+into a live account — puts real customer data one mis-tap away from a public
+listing and cannot be reproduced exactly next release.
+
+It is driven entirely by deep links, because input automation on an emulator is
+unreliable and `am start` is not:
+
+```bash
+adb shell am start -a android.intent.action.VIEW -d "'parley://demo/library'"
+#                                                    ^ the inner quotes matter
+```
+
+| URL | Screen |
+| --- | --- |
+| `parley://demo/library` | The recordings list, populated |
+| `parley://demo/transcript` | The featured recording: transcript, findings, action items |
+| `parley://demo/record` | The live meeting, mid-transcript (alias: `meeting`) |
+| `parley://demo/account` | The library with the account sheet open (alias: `settings`) |
+| `parley://demo/off` | Leave demo mode |
+
+Three invariants, all worth keeping: **no network** (every call site is guarded,
+so an offline machine captures the same frames), **no writes** (nothing reaches
+the auth DataStore or the pending-upload queue, and the live screen runs a
+scripted `DemoMeetingSession` rather than the microphone and the foreground
+service), and **no residue** (the flag is in memory, so `off` or a restart is
+the whole clean-up). `BuildConfig.DEBUG` gates activation, so a release build
+cannot be talked into serving fixtures.
+
+Fixture copy is written separately in English and Traditional Chinese and picked
+by the device locale, because the screenshot sets are captured per-locale —
+switch with `adb shell cmd locale set-app-locales com.pathors.parley --locales
+zh-TW`.
 
 ## Known gaps
 


### PR DESCRIPTION
## Why

The Play listing needs the app populated, and every screen it needs is behind the sign-in wall. Capturing them today means signing a device into a real account — slow, impossible to reproduce exactly next release, and it puts live customer data one mis-tap away from a public store listing. iOS solved this in `ios/App/Parley/ScreenshotDemo.swift`; Android had no equivalent, which currently blocks the listing.

## What

`android/app/src/main/kotlin/com/pathors/parley/screenshot/DemoMode.kt` — a debug-only, in-memory flag that stands the sign-in wall down **without a token** and answers every cloud call from fixed fictional fixtures. Driven entirely by deep links, because input automation on an emulator is unreliable and `am start` is not:

```bash
adb shell am start -a android.intent.action.VIEW -d "'parley://demo/library'"
#                                                    ^ the inner quotes matter
```

| URL | Screen |
| --- | --- |
| `parley://demo/library` | The recordings list, populated |
| `parley://demo/transcript` | The featured recording: transcript, findings, action items |
| `parley://demo/record` | The live meeting, mid-transcript (alias `meeting`) |
| `parley://demo/account` | The library with the account sheet open (alias `settings`) |
| `parley://demo/off` | Leave demo mode |

`MainActivity` still handles `parley://auth-callback` exactly as before — the demo handler claims only `parley://demo/…`, and only in a debug build, then hands everything else straight on.

## The three invariants

- **No network.** Every cloud call site is guarded (`HomeViewModel.refresh` / `loadAccount`, `RecordingDetailViewModel.load`, `AppContainer.drainPendingUploads`), so an offline reviewer's or CI machine captures the same frames and production is never touched.
- **No writes.** Nothing reaches the auth DataStore or the pending-upload queue. The live screen runs a scripted `DemoMeetingSession` rather than the microphone, the relay, the encoder and the `microphone` foreground service — which is also what makes it capturable on an emulator with no audio input.
- **No residue.** The flag lives in memory, so `parley://demo/off` (or a process restart) is the whole clean-up. `BuildConfig.DEBUG` gates activation, so a release build cannot be talked into serving fixtures.

## Verified on device

AVD `parley-test` (Pixel 7 / API 35), debug APK, all four screens captured in **both** locales:

- **In airplane mode** (`Active default network: none`) every screen was fully populated — a real cloud call would have surfaced the error banner instead.
- **With the network restored**, the whole flow was run again and the app's uid never appears in `dumpsys netstats detail`'s per-uid byte map: zero rx, zero tx. No OkHttp or DNS lines in logcat either.
- A **real pending upload from an earlier session** was sitting in `files/PendingUploads/` throughout. Demo mode neither displayed it, uploaded it, nor touched its mtime; `parley_auth.preferences_pb` stayed 0 bytes.
- `parley://demo/off` returns the app to the sign-in screen, and `parley://auth-callback?error=…` still reaches the auth handler and renders its error — the demo route does not swallow it.

`./gradlew assembleDebug :parleykit:test :app:testDebugUnitTest` passes: 55 tests, 0 failures, including 7 new ones asserting both languages are complete and differ, that the summary counts are the truth about the meta, and that the fixtures name no real person, company or address.

## Content

Entirely invented — a renewal negotiation, a discovery call and a quarterly review, written the way B2B calls actually sound (a seat count against a quote, a price hold, an onboarding estimate with an SSO condition). No real company, person, customer or meeting; the only address is `alex@example.com`, in the RFC-reserved domain. The copy is written separately in English and Traditional Chinese rather than translated one way, and follows the device locale, because the screenshot sets are captured per-locale.

## Scope notes

- `android/AppStore/**` untouched (owned by another PR).
- `ui/AccountSheet.kt` and `cloud/CloudClient.kt` untouched — the account sheet is served through `HomeViewModel`'s existing state, so the sibling `feat/android-account-deletion` PR has no conflict here.
- No new dependencies. One build flag (`buildConfig = true`) so `BuildConfig.DEBUG` exists.