### PR TITLE
[refactor] settings: one expand shows the whole scenario editor

### DIFF
--- a/src/settings/StageBundleSettings.tsx
+++ b/src/settings/StageBundleSettings.tsx
@@ -17,6 +17,8 @@ import { log } from "../lib/log";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { initialStageId, scenarioEditorShape, stageAfterRemoval } from "./scenarioEditorShape";
 
 /**
  * Scenario editor (scenario system): the in-app way to maintain meeting
@@ -25,6 +27,11 @@ import { Textarea } from "@/components/ui/textarea";
  * slots (label+hint), exit criteria; slot queries and coach rules keep their
  * effective values and stay editable via the MCP server / JSON. Builtin edits
  * become whole-stage overrides (S9); untouched builtins keep shipped copy.
+ *
+ * Expanding a scenario is the only click there is: the stage form comes up with
+ * it. Sales is the lone scenario with a real pipeline, so it gets chips that
+ * swap the form's contents; everything else has one stage (or none) and must
+ * never make the user meet the word "stage" to edit its board.
  */
 
 interface SlotRow {
@@ -76,7 +83,9 @@ function dropSlotRow(d: Draft, i: number): Draft {
 }
 
 /** The per-stage edit form — top-level so the editor's scenario→stage maps
- *  stay shallow. Simple fields only; queries/coach rules stay MCP/JSON-side. */
+ *  stay shallow. Simple fields only; queries/coach rules stay MCP/JSON-side.
+ *  It now sits directly in the expanded scenario, so it draws no box of its
+ *  own: `divided` is the single hairline separating it from whatever precedes. */
 function StageDraftForm({
   draft,
   setDraft,
@@ -84,6 +93,8 @@ function StageDraftForm({
   canReset,
   canDelete,
   confirmingDelete,
+  divided,
+  modified,
   onSave,
   onReset,
   onDelete,
@@ -94,13 +105,15 @@ function StageDraftForm({
   canReset: boolean;
   canDelete: boolean;
   confirmingDelete: boolean;
+  divided: boolean;
+  modified: boolean;
   onSave: () => void;
   onReset: () => void;
   onDelete: () => void;
 }>) {
   const { t } = useI18n();
   return (
-    <div className="flex flex-col gap-3 border-t px-3 py-3">
+    <div className={cn("flex flex-col gap-3", divided && "border-t pt-3")}>
       <label className="flex flex-col gap-1 text-xs">
         <span className="text-muted-foreground">{t("settings.stages.name")}</span>
         <Input
@@ -186,6 +199,11 @@ function StageDraftForm({
             {confirmingDelete ? t("settings.stages.deleteConfirm") : t("settings.stages.delete")}
           </Button>
         )}
+        {modified && (
+          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">
+            {t("settings.stages.modified")}
+          </span>
+        )}
       </div>
     </div>
   );
@@ -227,24 +245,30 @@ export function ScenarioSettings() {
     }
   }
 
-  function toggleScenario(id: string) {
+  /** Point the editor at a stage. Selection only — there is no collapsed state
+   *  to fall back to, so a second click on the same stage is a no-op. */
+  function selectStage(scenario: Scenario, stageId: string | null) {
     setConfirmDelete(null);
-    setOpenStage(null);
-    setDraft(null);
-    setOpenScenario(openScenario === id ? null : id);
-  }
-
-  function toggleStage(scenario: Scenario, stageId: string) {
-    setConfirmDelete(null);
-    if (openStage === stageId) {
+    const bundle = stageId ? scenario.bundles[stageId] : undefined;
+    if (!stageId || !bundle) {
       setOpenStage(null);
       setDraft(null);
       return;
     }
-    const bundle = scenario.bundles[stageId];
-    if (!bundle) return;
     setOpenStage(stageId);
     setDraft(draftFrom(bundle, scenario.names[stageId] ?? stageId));
+  }
+
+  function toggleScenario(scenario: Scenario) {
+    setConfirmDelete(null);
+    if (openScenario === scenario.id) {
+      setOpenScenario(null);
+      selectStage(scenario, null);
+      return;
+    }
+    setOpenScenario(scenario.id);
+    // Expanding is the only click: the form for the first stage comes up with it.
+    selectStage(scenario, initialStageId(scenario.order));
   }
 
   /** Where a stage's edits land: sales customs → customStages; custom-scenario
@@ -310,16 +334,20 @@ export function ScenarioSettings() {
     await persist(next);
   }
 
-  async function resetBuiltinStage() {
+  async function resetBuiltinStage(scenario: Scenario) {
     if (!openStage) return;
+    const stageId = openStage;
     const overrides = { ...file.overrides };
-    delete overrides[openStage];
-    await persist({ ...file, overrides });
-    setOpenStage(null);
-    setDraft(null);
+    delete overrides[stageId];
+    const next = { ...file, overrides };
+    await persist(next);
+    // The form stays open on this stage, so refill it from the shipped copy
+    // rather than leaving the edits we just discarded on screen.
+    const fresh = buildScenarioSet(tr, next).byId[scenario.id]?.bundles[stageId];
+    setDraft(fresh ? draftFrom(fresh, scenario.names[stageId] ?? stageId) : null);
   }
 
-  async function removeStage() {
+  async function removeStage(scenario: Scenario) {
     if (!openStage) return;
     if (confirmDelete !== openStage) {
       setConfirmDelete(openStage);
@@ -346,8 +374,7 @@ export function ScenarioSettings() {
             customStages: file.customStages.filter((c) => c.id !== openStage),
           }
     );
-    setOpenStage(null);
-    setDraft(null);
+    selectStage(scenario, stageAfterRemoval(scenario.order, openStage));
   }
 
   async function addSalesStage() {
@@ -385,16 +412,16 @@ export function ScenarioSettings() {
     if (!name) return;
     const id = newId("sc");
     // A scenario is born with one stage carrying its name — single-stage
-    // scenarios never show a stage row, so this is invisible until they split.
+    // scenarios never show a stage chip, so this is invisible until they split.
+    const stage = emptyStage(newId("st"), name);
     await persist({
       ...file,
-      customScenarios: [
-        ...file.customScenarios,
-        { id, name, icon: "🎯", stages: [emptyStage(newId("st"), name)] },
-      ],
+      customScenarios: [...file.customScenarios, { id, name, icon: "🎯", stages: [stage] }],
     });
     setNewScenarioName("");
     setOpenScenario(id);
+    setOpenStage(stage.id);
+    setDraft(draftFrom(stage.bundle, name));
   }
 
   async function removeScenario(id: string) {
@@ -444,12 +471,17 @@ export function ScenarioSettings() {
           const scDelKey = `sc:${sc.id}`;
           const custom = !sc.builtin;
           const fileDef = file.customScenarios.find((x) => x.id === sc.id);
+          const shape = scenarioEditorShape(sc.order);
+          const isModified = (stageId: string) =>
+            !!file.overrides[stageId] ||
+            isCustomSalesStage(stageId) ||
+            !!customScenarioOf(stageId);
           return (
             <div key={sc.id} className="rounded-lg border">
               <button
                 type="button"
-                onClick={() => toggleScenario(sc.id)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm"
+                onClick={() => toggleScenario(sc)}
+                className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm"
               >
                 {scOpened ? (
                   <ChevronDown className="size-3.5 text-muted-foreground" />
@@ -553,57 +585,55 @@ export function ScenarioSettings() {
                     </label>
                   )}
 
-                  {/* Stage list (single-stage scenarios simply show one row). */}
-                  <div className="flex flex-col gap-1.5">
-                    {sc.order.map((stageId) => {
-                      const opened = openStage === stageId;
-                      const modified =
-                        !!file.overrides[stageId] ||
-                        isCustomSalesStage(stageId) ||
-                        !!customScenarioOf(stageId);
-                      return (
-                        <div key={stageId} className="rounded-md border">
-                          <button
-                            type="button"
-                            onClick={() => toggleStage(sc, stageId)}
-                            className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs"
-                          >
-                            {opened ? (
-                              <ChevronDown className="size-3 text-muted-foreground" />
-                            ) : (
-                              <ChevronRight className="size-3 text-muted-foreground" />
-                            )}
-                            <span className="flex-1 font-medium">
-                              {sc.names[stageId] ?? stageId}
-                            </span>
-                            {sc.builtin && modified && (
-                              <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">
-                                {t("settings.stages.modified")}
-                              </span>
-                            )}
-                          </button>
-
-                          {opened && draft && (
-                            <StageDraftForm
-                              draft={draft}
-                              setDraft={setDraft}
-                              nameLocked={sc.builtin && isBuiltinSalesStage(stageId)}
-                              canReset={
-                                sc.builtin &&
-                                !isCustomSalesStage(stageId) &&
-                                !!file.overrides[stageId]
-                              }
-                              canDelete={isCustomSalesStage(stageId) || !!customScenarioOf(stageId)}
-                              confirmingDelete={confirmDelete === stageId}
-                              onSave={() => void saveStage(sc)}
-                              onReset={() => void resetBuiltinStage()}
-                              onDelete={() => void removeStage()}
+                  {/* Only a pipeline (sales) gives you something to choose
+                      between; the chips pick which form is below, they don't
+                      hide it. One stage needs no picker at all. */}
+                  {shape === "multi" && (
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {sc.order.map((stageId) => (
+                        <button
+                          key={stageId}
+                          type="button"
+                          onClick={() => selectStage(sc, stageId)}
+                          className={cn(
+                            "flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors",
+                            stageId === openStage
+                              ? "bg-primary font-medium text-primary-foreground"
+                              : "bg-muted text-muted-foreground hover:text-foreground"
+                          )}
+                        >
+                          {sc.names[stageId] ?? stageId}
+                          {sc.builtin && isModified(stageId) && (
+                            <span
+                              title={t("settings.stages.modified")}
+                              className="size-1.5 rounded-full bg-amber-500"
                             />
                           )}
-                        </div>
-                      );
-                    })}
-                  </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+
+                  {shape !== "kind" && openStage && draft && sc.bundles[openStage] && (
+                    <StageDraftForm
+                      draft={draft}
+                      setDraft={setDraft}
+                      nameLocked={sc.builtin && isBuiltinSalesStage(openStage)}
+                      canReset={
+                        sc.builtin &&
+                        !isCustomSalesStage(openStage) &&
+                        !!file.overrides[openStage]
+                      }
+                      canDelete={isCustomSalesStage(openStage) || !!customScenarioOf(openStage)}
+                      confirmingDelete={confirmDelete === openStage}
+                      divided={(custom && !!fileDef) || shape === "multi"}
+                      // Multi-stage scenarios carry this on the chip instead.
+                      modified={shape === "single" && sc.builtin && isModified(openStage)}
+                      onSave={() => void saveStage(sc)}
+                      onReset={() => void resetBuiltinStage(sc)}
+                      onDelete={() => void removeStage(sc)}
+                    />
+                  )}
 
                   {/* Add stage: sales keeps its insert-after splice; custom
                       scenarios append. Typed builtins stay single-stage. */}

--- a/src/settings/scenarioEditorShape.test.ts
+++ b/src/settings/scenarioEditorShape.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { initialStageId, scenarioEditorShape, stageAfterRemoval } from "./scenarioEditorShape";
+
+describe("scenarioEditorShape", () => {
+  it("calls a stageless scenario a kind", () => {
+    expect(scenarioEditorShape([])).toBe("kind");
+  });
+
+  it("calls one stage single — no chips, no second click", () => {
+    expect(scenarioEditorShape(["negotiation"])).toBe("single");
+  });
+
+  it("calls two or more stages multi", () => {
+    expect(scenarioEditorShape(["discovery", "demo"])).toBe("multi");
+    expect(scenarioEditorShape(["a", "b", "c", "d", "e"])).toBe("multi");
+  });
+});
+
+describe("initialStageId", () => {
+  it("picks the first stage", () => {
+    expect(initialStageId(["discovery", "demo"])).toBe("discovery");
+  });
+
+  it("has nothing to pick for a kind", () => {
+    expect(initialStageId([])).toBeNull();
+  });
+});
+
+describe("stageAfterRemoval", () => {
+  it("falls back to the first survivor", () => {
+    expect(stageAfterRemoval(["a", "b", "c"], "b")).toBe("a");
+    expect(stageAfterRemoval(["a", "b", "c"], "a")).toBe("b");
+  });
+
+  it("returns null when the last stage goes", () => {
+    expect(stageAfterRemoval(["a"], "a")).toBeNull();
+  });
+
+  it("leaves the selection alone when the removed id is not in the list", () => {
+    expect(stageAfterRemoval(["a", "b"], "ghost")).toBe("a");
+  });
+});

--- a/src/settings/scenarioEditorShape.ts
+++ b/src/settings/scenarioEditorShape.ts
@@ -1,0 +1,29 @@
+/**
+ * What the scenario editor shows once a scenario row is expanded.
+ *
+ * Lives outside the component because the rule it encodes — one expand puts the
+ * whole editor on screen — is the thing that kept regressing into a second
+ * layer of accordions. Only a multi-stage scenario (in practice: sales) has
+ * anything to choose between; a single-stage scenario must never make the user
+ * learn that "stage" is a concept.
+ */
+export type ScenarioEditorShape = "kind" | "single" | "multi";
+
+export function scenarioEditorShape(order: readonly string[]): ScenarioEditorShape {
+  if (order.length === 0) return "kind";
+  return order.length === 1 ? "single" : "multi";
+}
+
+/** The stage a freshly expanded scenario edits. Null only for a boardless kind. */
+export function initialStageId(order: readonly string[]): string | null {
+  return order[0] ?? null;
+}
+
+/** Where the selection lands after the current stage is deleted: the first
+ *  survivor, so the form stays populated instead of blanking the panel. */
+export function stageAfterRemoval(
+  order: readonly string[],
+  removed: string
+): string | null {
+  return initialStageId(order.filter((id) => id !== removed));
+}


### PR DESCRIPTION
## What this changes

The scenario editor was two nested accordions: expanding a scenario revealed a **list of stages**, and you had to click a stage to reach the form you actually came for. Most scenarios have exactly one stage (negotiation, partnership, every custom scenario in practice) and kinds have none — so that second level was a pure extra click onto a one-row "list" that didn't explain itself.

Now **one expand shows everything editable**, in three shapes:

- **Kind (0 stages)** — the note explaining what a kind is, plus (for custom ones) name / emoji / eval template / delete and the analysis-lens textarea. No stage vocabulary at all.
- **Single stage** — the form is right there under the meta. No chips, no second expand. The user never has to learn that "stages" exist.
- **Multiple stages (only `sales`)** — a row of stage chips with the selected stage's form **always visible** below, defaulting to the first. Switching stages swaps the form; it is a selector, not an accordion. A modified stage carries a small amber dot on its chip.

The save path is untouched: `saveStage`, `patchScenarioMeta`, `removeScenario`, `persist`, the draft lifecycle, and the three-way routing of edits (customStages / customScenarios / overrides) all keep their existing semantics. What changed is which state drives what renders — `openStage` now means "which stage is selected" instead of "which stage is expanded".

Shape decisions are a pure function (`scenarioEditorShape.ts`: `scenarioEditorShape`, `initialStageId`, `stageAfterRemoval`) with its own tests, so "what does expanding this show" is decided in one place.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes — **368 tests** (360 baseline + 8 for the new shape helpers)
- [x] Added or updated tests
- [x] No new user-facing strings — the modified marker reuses the existing `settings.stages.modified` key, so both locales are already covered
- [ ] Ran the app and exercised the change — the interaction needs a human pass; logic is type- and test-checked

## Two things left deliberately undone

1. **`onBlur` autosave** on four fields (scenario name, icon, eval template, guidance) — the house rule is an explicit Save button. Changing it means reworking when `patchScenarioMeta` fires, which is a save-semantics change and out of scope for a render-structure refactor. Worth its own pass.
2. A single-stage scenario still shows both "scenario name" and "stage name", which reads redundant — but the stage name feeds `boardTitle` (the heading shown on the live board) and nothing else can edit it, so removing it would drop a capability rather than tidy one.