### PR TITLE
[refactor] ui: lucide icons instead of inline emoji

### DIFF
--- a/src/components/accounts/CompanyPage.tsx
+++ b/src/components/accounts/CompanyPage.tsx
@@ -188,7 +188,7 @@ export function CompanyPage({
 
         {/* Triage: conflicting info + open questions, always on top. */}
         {(pairs.length > 0 || triage.length > 0) && (
-          <Section title={`⚠ ${t("accounts.triage")}`}>
+          <Section title={t("accounts.triage")}>
             {pairs.map((p) => (
               <ConflictPairCard key={`${p.a.id}|${p.b.id}`} a={p.a} b={p.b} />
             ))}

--- a/src/components/live/CoachFeed.tsx
+++ b/src/components/live/CoachFeed.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ArrowUp, ChevronDown, Loader2, Sparkles } from "lucide-react";
+import { ArrowUp, ChevronDown, Loader2, MessageCircle, Sparkles } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -271,7 +271,10 @@ export function CoachFeed({ onSeek }: Readonly<{ onSeek: (ms: number) => void }>
           ))}
           {askCards.map((c) => (
             <div key={c.id} className="rounded-lg border bg-muted/30 px-3 py-2 text-sm">
-              <p className="mb-1 text-xs font-medium text-muted-foreground">💬 {c.question}</p>
+              <p className="mb-1 flex items-start gap-1.5 text-xs font-medium text-muted-foreground">
+                <MessageCircle className="mt-0.5 size-3.5 shrink-0" />
+                <span className="min-w-0">{c.question}</span>
+              </p>
               {c.answer ? (
                 <div className="prose prose-sm dark:prose-invert max-w-none">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{c.answer}</ReactMarkdown>

--- a/src/components/live/IntelligenceBoard.tsx
+++ b/src/components/live/IntelligenceBoard.tsx
@@ -1,5 +1,17 @@
 import { lazy, Suspense, useEffect, useState } from "react";
-import { Loader2, Pause, Play, RefreshCw } from "lucide-react";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  Check,
+  Flag,
+  Lightbulb,
+  Loader2,
+  Pause,
+  Play,
+  RefreshCw,
+  TriangleAlert,
+  type LucideIcon,
+} from "lucide-react";
 import { useStore } from "../../lib/store";
 import { runIntelExtraction } from "../../lib/intel/extract";
 import { useAccounts } from "../../lib/accounts/store";
@@ -182,7 +194,7 @@ export function IntelligenceBoard() {
 }
 
 /** The objection tracker (呼吸版): open items in front, answered ones folded
- *  behind a count — addressed state drives ⚠/✓. */
+ *  behind a count — addressed state drives the alert/check mark. */
 export function ObjectionsLedger({
   objections,
 }: Readonly<{ objections?: IntelObjection[] }>) {
@@ -211,16 +223,18 @@ export function ObjectionsLedger({
           </button>
         )}
       </div>
+      {/* items-start, not items-baseline: an icon has no text baseline, so the
+          mark is nudged down to sit on the first line of a wrapping item. */}
       {open.map((o) => (
-        <div key={o.text} className="flex items-baseline gap-1.5 text-xs">
-          <span className="font-bold text-amber-600 dark:text-amber-400">⚠</span>
+        <div key={o.text} className="flex items-start gap-1.5 text-xs">
+          <TriangleAlert className="mt-0.5 size-3 shrink-0 text-amber-600 dark:text-amber-400" />
           <span>{o.text}</span>
         </div>
       ))}
       {showAddressed &&
         addressed.map((o) => (
-          <div key={o.text} className="flex items-baseline gap-1.5 text-xs">
-            <span className="text-emerald-600 dark:text-emerald-400">✓</span>
+          <div key={o.text} className="flex items-start gap-1.5 text-xs">
+            <Check className="mt-0.5 size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
             <span className="text-muted-foreground">{o.text}</span>
           </div>
         ))}
@@ -268,13 +282,13 @@ export function IntelSections() {
           <Section
             title={`${t("board.sec.concessions")} — ${t("speaker.you")} ${intel.concessionsMe?.length ?? 0}：${intel.concessionsThem?.length ?? 0} ${t("speaker.them")}`}
           >
-            <List items={intel.concessionsMe} prefix="🫱" />
-            <List items={intel.concessionsThem} prefix="🫲" />
+            <List items={intel.concessionsMe} prefix={ArrowUpRight} />
+            <List items={intel.concessionsThem} prefix={ArrowDownLeft} />
           </Section>
         )}
       {intel.agreed && intel.agreed.length > 0 && (
         <Section title={t("board.sec.agreed")}>
-          <List items={intel.agreed} prefix="✓" className="text-emerald-700 dark:text-emerald-400" />
+          <List items={intel.agreed} prefix={Check} className="text-emerald-700 dark:text-emerald-400" />
         </Section>
       )}
       {intel.open && intel.open.length > 0 && (
@@ -312,7 +326,7 @@ export function IntelSections() {
       )}
       {intel.competitors && intel.competitors.length > 0 && (
         <Section title={t("board.sec.competitors")}>
-          <List items={intel.competitors} prefix="🚩" />
+          <List items={intel.competitors} prefix={Flag} />
         </Section>
       )}
 
@@ -329,13 +343,13 @@ export function IntelSections() {
       )}
       {intel.leverage && intel.leverage.length > 0 && (
         <Section title={t("board.sec.leverage")}>
-          <List items={intel.leverage} prefix="💡" className="font-medium" />
+          <List items={intel.leverage} prefix={Lightbulb} className="font-medium" />
         </Section>
       )}
       {(intel.give?.length || intel.get?.length) && (
         <Section title={t("board.sec.giveGet")}>
-          <List items={intel.give} prefix="🫱" />
-          <List items={intel.get} prefix="🫲" />
+          <List items={intel.give} prefix={ArrowUpRight} />
+          <List items={intel.get} prefix={ArrowDownLeft} />
         </Section>
       )}
     </>
@@ -353,18 +367,36 @@ function Section({ title, children }: Readonly<{ title: string; children: React.
   );
 }
 
+/**
+ * `prefix` takes either a lucide icon or a literal marker, because the two
+ * kinds of marker here are not the same thing. Semantic markers (give/get,
+ * competitor, leverage, agreed) became icons; the typographic bullets ○ ◆ ◇
+ * stay text — they are list glyphs, not pictograms, and lucide has nothing
+ * that reads as a bullet at this size. The icon inherits `currentColor`, so
+ * each call site's semantic color still lands on the mark.
+ */
 function List({
   items,
   prefix,
   className,
-}: Readonly<{ items?: string[]; prefix: string; className?: string }>) {
+}: Readonly<{ items?: string[]; prefix: string | LucideIcon; className?: string }>) {
   if (!items?.length) return null;
+  let marker: React.ReactNode;
+  if (typeof prefix === "string") {
+    marker = <span className="shrink-0">{prefix}</span>;
+  } else {
+    const Icon = prefix;
+    marker = <Icon className="mt-0.5 size-3 shrink-0" />;
+  }
   return (
     <>
       {items.map((x, i) => (
-        <div key={i} className={`text-xs ${className ?? "text-muted-foreground"}`}>
-          <span className="mr-1">{prefix}</span>
-          {x}
+        <div
+          key={i}
+          className={`flex items-start gap-1 text-xs ${className ?? "text-muted-foreground"}`}
+        >
+          {marker}
+          <span className="min-w-0">{x}</span>
         </div>
       ))}
     </>

--- a/src/components/preflight/PlanCard.tsx
+++ b/src/components/preflight/PlanCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, Plus } from "lucide-react";
+import { Check, Plus, Zap, type LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 import { useStore } from "../../lib/store";
 import { useI18n } from "../../i18n";
@@ -138,7 +138,7 @@ export function PlanCard({ plan }: Readonly<{ plan: PlanView }>) {
               key={e.trigger}
               text={e.trigger}
               hint={`→ ${e.move}`}
-              lead="⚡"
+              lead={Zap}
               taken={taken.has(`${e.trigger} → ${e.move}`)}
               onTake={() => take(`${e.trigger} → ${e.move}`)}
             />
@@ -183,17 +183,20 @@ function TakeRow({
   text: string;
   hint?: string;
   index?: number;
-  lead?: string;
+  /** Marker for rows that aren't a numbered step — occupies the same slot. */
+  lead?: LucideIcon;
   taken: boolean;
   onTake: () => void;
 }>) {
   const { t } = useI18n();
-  const marker = index ? `${index}` : lead;
+  // A numbered step wins the slot; `lead` fills it for unordered rows so both
+  // kinds of row keep the same left rail.
+  const Lead = index === undefined ? lead : undefined;
   return (
     <div className="group flex items-start gap-2 rounded-md px-1 py-0.5 hover:bg-background/70">
-      {marker && (
-        <span className="mt-px w-3 shrink-0 text-center text-[10px] tabular-nums text-muted-foreground">
-          {marker}
+      {(index !== undefined || Lead) && (
+        <span className="mt-px flex w-3 shrink-0 justify-center text-[10px] tabular-nums leading-4 text-muted-foreground">
+          {Lead ? <Lead className="size-3 shrink-0" /> : index}
         </span>
       )}
       <div className="flex min-w-0 flex-1 flex-col">

--- a/src/components/preflight/PrepCopilot.tsx
+++ b/src/components/preflight/PrepCopilot.tsx
@@ -11,6 +11,7 @@ import {
   Sparkles,
   Square,
   Target,
+  TriangleAlert,
   X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -520,8 +521,9 @@ export function PrepCopilot() {
             </p>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground">
               {head.redlines > 0 && (
-                <span className="text-red-600 dark:text-red-400">
-                  ⚠ {t("preflight.copilot.redlines", { n: head.redlines })}
+                <span className="flex items-center gap-1 text-red-600 dark:text-red-400">
+                  <TriangleAlert className="size-3 shrink-0" />
+                  {t("preflight.copilot.redlines", { n: head.redlines })}
                 </span>
               )}
               {head.openQuestions > 0 && (

--- a/src/components/preflight/ReviewPanel.tsx
+++ b/src/components/preflight/ReviewPanel.tsx
@@ -125,7 +125,7 @@ export function ReviewPanel() {
 
         {redlines.length > 0 && (
           <div className="flex flex-col gap-1.5">
-            <SectionTitle>⚠ {t("preflight.review.redlines")}</SectionTitle>
+            <SectionTitle>{t("preflight.review.redlines")}</SectionTitle>
             {redlines.map((c) => (
               <p
                 key={c.id}

--- a/src/components/shell/AppSidebar.tsx
+++ b/src/components/shell/AppSidebar.tsx
@@ -13,6 +13,7 @@ import {
   Plus,
   Swords,
   Trash2,
+  TriangleAlert,
   UsersRound,
 } from "lucide-react";
 import { useAccounts, threadsOf, triageClaims, personsOf } from "../../lib/accounts/store";
@@ -142,8 +143,9 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
               }}
               badge={
                 nTriage > 0 ? (
-                  <span className="shrink-0 rounded-full bg-orange-500/15 px-1.5 text-[10px] font-semibold text-orange-700 dark:text-orange-300">
-                    ⚠{nTriage}
+                  <span className="flex shrink-0 items-center gap-0.5 rounded-full bg-orange-500/15 px-1.5 text-[10px] font-semibold text-orange-700 dark:text-orange-300">
+                    <TriangleAlert className="size-3 shrink-0" />
+                    {nTriage}
                   </span>
                 ) : null
               }

--- a/src/lib/accounts/redline.ts
+++ b/src/lib/accounts/redline.ts
@@ -21,7 +21,9 @@ export function buildRedlineEvals(claims: Claim[], language: AppLanguage): EvalD
     .filter((c) => c.category === "redline" && c.status === "active")
     .map((c) => ({
       id: `${REDLINE_EVAL_PREFIX}${c.id}`,
-      name: `🚨 ${translate(language, "accounts.redline.evalName")}`,
+      // Plain text on purpose: this name is persisted and rendered as a raw
+      // string everywhere it surfaces, so a marker here can only be literal.
+      name: translate(language, "accounts.redline.evalName"),
       description: c.text,
       prompt:
         `RED LINE — the user (ME) must NOT reveal, confirm, or hint at the following: "${c.text}". ` +


### PR DESCRIPTION
## What this changes

Emoji were doing UI work in eight places. They read as noisy and inconsistent — each platform draws them differently, and next to a stroke-based icon set they look like a different design language. Replaced with lucide (already a dependency, no CDN), following one rule:

**If removing the symbol still leaves the meaning clear, remove it. Only keep a mark where it carries information the words don't.**

**Removed outright** — the neighbouring text already says it:
- `CompanyPage` section title `⚠ 待處理` → plain title
- `ReviewPanel` section title `⚠ 紅線` → plain title
- `redline.ts` — `🚨` lived inside a persisted eval *name*, rendered as a raw string wherever it surfaces, so a marker there could only ever be literal text. Deleted, with a comment recording why nothing replaced it.

**Kept as an icon** — the mark is the only thing distinguishing the row:
- `IntelligenceBoard` list prefixes: 🫱/🫲 concessions → `ArrowUpRight` / `ArrowDownLeft`, 🚩 competitors → `Flag`, 💡 leverage → `Lightbulb`, plus ⚠/✓ status → `TriangleAlert` / `Check`
- `CoachFeed` 💬 → `MessageCircle`
- `AppSidebar` triage badge `⚠2` → icon + count
- `PrepCopilot` ⚠ → `TriangleAlert`. Judged inline status, not a title: it sits in a wrapping row of sibling stats and is the only severe one, so without a mark the sole differentiator is red text — color-only signalling, and the weaker accessibility choice.
- `PlanCard` `lead="⚡"` → `Zap`. It fills the same 12px left-rail slot the numbered ideal-path rows fill with their step index; emptying that column breaks the card's alignment.

## Notes

- `List`'s `prefix` became `string | LucideIcon` rather than gaining a second prop: three call sites pass `○ ◆ ◇`, which are typographic bullets rather than emoji and were out of scope. The icon inherits `currentColor`, so every call site's existing semantic color still lands on the mark. Row layout moved to `flex items-start gap-1`, which also gives wrapped items a hanging indent instead of tucking under the marker.
- All eight emoji were concatenated in JSX, never inside message values, so **no i18n changes** — both locales are untouched.
- Comments that mention emoji (the 🌐 menu docs) are left alone; they aren't UI.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes — 368 tests, exactly the baseline
- [x] All eight lucide names exist in the installed lucide-react 1.18.0; no substitutions
- [ ] Ran the app — visual pass needed; nothing here is logic