### PR TITLE
[feature] MCP: folder management and recording deletion tools

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -349,9 +349,9 @@ fn now_ms() -> u64 {
 
 /// Coarse read/write classification for the activity feed, by tool-name verb.
 fn tool_kind(name: &str) -> &'static str {
-    const WRITE_VERBS: [&str; 11] = [
+    const WRITE_VERBS: [&str; 13] = [
         "upsert_", "delete_", "add_", "remove_", "check_", "set_", "update_", "rename_", "move_",
-        "share_", "copy_",
+        "share_", "copy_", "create_", "import_",
     ];
     if WRITE_VERBS.iter().any(|v| name.starts_with(v)) {
         "write"
@@ -758,6 +758,42 @@ fn tools() -> Vec<Value> {
             json!({ "type": "object", "properties": {} }),
         ),
         tool(
+            "create_folder",
+            "Create a personal folder",
+            "Create a personal history folder and return { id, name, existed }. \
+             Idempotent by name: when a folder with that name already exists it is \
+             returned (existed: true) instead of duplicated. When cloud sync is on \
+             the folder is mirrored to the cloud registry.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Folder display name." }
+                },
+                "required": ["name"]
+            }),
+        ),
+        tool(
+            "rename_folder",
+            "Rename a personal folder",
+            "Rename a personal history folder by id. Get ids from list_folders.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string", "description": "New display name." }
+                },
+                "required": ["id", "name"]
+            }),
+        ),
+        tool(
+            "delete_folder",
+            "Delete a personal folder",
+            "Delete a personal history folder by id. The recordings it held are NOT \
+             deleted — they fall back to the personal root (the orphan→root rule). \
+             Get ids from list_folders.",
+            json!({ "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] }),
+        ),
+        tool(
             "import_transcript",
             "Import .txt transcripts as recordings",
             "Import plain-text transcript files as audio-less personal recordings \
@@ -799,6 +835,22 @@ fn tools() -> Vec<Value> {
             }),
         ),
         tool(
+            "delete_recording",
+            "Delete a saved recording (DESTRUCTIVE)",
+            "Permanently delete a personal recording: its local files AND its personal \
+             cloud copy. The cloud id is tombstoned — it can never be re-uploaded, so \
+             this CANNOT be undone. Copies previously shared into an org are NOT \
+             affected. Prefer move_recording_to_folder for archiving; only delete when \
+             the user explicitly wants the recording gone.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "Personal recording id (from list_recordings)." }
+                },
+                "required": ["id"]
+            }),
+        ),
+        tool(
             "list_orgs",
             "List organizations",
             "List the organizations the signed-in user belongs to, as { id, name, role }. \
@@ -817,6 +869,68 @@ fn tools() -> Vec<Value> {
             "List an org's folders",
             "List an organization's folders as { id, name }. Get org ids from list_orgs.",
             json!({ "type": "object", "properties": { "orgId": { "type": "string" } }, "required": ["orgId"] }),
+        ),
+        tool(
+            "create_org_folder",
+            "Create an org folder",
+            "Create a shared folder in an organization and return { id, name, existed }. \
+             Idempotent by name: an existing same-name folder is returned (existed: true) \
+             instead of duplicated. Any org member can create; requires the user to be \
+             signed in to Parley cloud. Get org ids from list_orgs.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "orgId": { "type": "string" },
+                    "name": { "type": "string", "description": "Folder display name." }
+                },
+                "required": ["orgId", "name"]
+            }),
+        ),
+        tool(
+            "rename_org_folder",
+            "Rename an org folder",
+            "Rename an organization's shared folder by id (creator or org admin/owner \
+             only). Get folder ids from list_org_folders.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "orgId": { "type": "string" },
+                    "id": { "type": "string" },
+                    "name": { "type": "string", "description": "New display name." }
+                },
+                "required": ["orgId", "id", "name"]
+            }),
+        ),
+        tool(
+            "delete_org_folder",
+            "Delete an org folder",
+            "Delete an organization's shared folder by id (creator or org admin/owner \
+             only). The recordings it held are NOT deleted — they fall back to the org \
+             root. Get folder ids from list_org_folders.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "orgId": { "type": "string" },
+                    "id": { "type": "string" }
+                },
+                "required": ["orgId", "id"]
+            }),
+        ),
+        tool(
+            "move_org_recording_to_folder",
+            "Move an org recording between org folders",
+            "Move an org-shared recording into one of that org's folders, or back to \
+             the org root by omitting folderId. Get recording ids from \
+             list_org_recordings and folder ids from list_org_folders.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "orgId": { "type": "string" },
+                    "id": { "type": "string", "description": "Org recording id (from list_org_recordings)." },
+                    "folderId": { "type": "string", "description": "Target org folder id; omit for the org root." }
+                },
+                "required": ["orgId", "id"]
+            }),
         ),
         tool(
             "share_recording_to_org",
@@ -1027,6 +1141,41 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
             call_frontend(state, "set_recording_analysis", args).await?
         }
         "list_folders" => call_frontend(state, "list_folders", json!({})).await?,
+        "create_folder" => {
+            call_frontend(
+                state,
+                "create_folder",
+                json!({ "name": required_str(&args, "name")? }),
+            )
+            .await?
+        }
+        "rename_folder" => {
+            call_frontend(
+                state,
+                "rename_folder",
+                json!({
+                    "id": required_str(&args, "id")?,
+                    "name": required_str(&args, "name")?
+                }),
+            )
+            .await?
+        }
+        "delete_folder" => {
+            call_frontend(
+                state,
+                "delete_folder",
+                json!({ "id": required_str(&args, "id")? }),
+            )
+            .await?
+        }
+        "delete_recording" => {
+            call_frontend(
+                state,
+                "delete_recording",
+                json!({ "id": required_str(&args, "id")? }),
+            )
+            .await?
+        }
         "import_transcript" => {
             let paths = args
                 .get("paths")
@@ -1068,6 +1217,52 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
                 state,
                 "list_org_folders",
                 json!({ "orgId": required_str(&args, "orgId")? }),
+            )
+            .await?
+        }
+        "create_org_folder" => {
+            call_frontend(
+                state,
+                "create_org_folder",
+                json!({
+                    "orgId": required_str(&args, "orgId")?,
+                    "name": required_str(&args, "name")?
+                }),
+            )
+            .await?
+        }
+        "rename_org_folder" => {
+            call_frontend(
+                state,
+                "rename_org_folder",
+                json!({
+                    "orgId": required_str(&args, "orgId")?,
+                    "id": required_str(&args, "id")?,
+                    "name": required_str(&args, "name")?
+                }),
+            )
+            .await?
+        }
+        "delete_org_folder" => {
+            call_frontend(
+                state,
+                "delete_org_folder",
+                json!({
+                    "orgId": required_str(&args, "orgId")?,
+                    "id": required_str(&args, "id")?
+                }),
+            )
+            .await?
+        }
+        "move_org_recording_to_folder" => {
+            call_frontend(
+                state,
+                "move_org_recording_to_folder",
+                json!({
+                    "orgId": required_str(&args, "orgId")?,
+                    "id": required_str(&args, "id")?,
+                    "folderId": args.get("folderId").cloned().unwrap_or(Value::Null)
+                }),
             )
             .await?
         }

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -2,6 +2,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useStore } from "./store";
 import { isTauri } from "./tauriEvents";
+import { CLOUD_ENABLED } from "./flags";
+import { syncEnabled } from "./cloud/client";
+import { log } from "./log";
 import type { ActionItem, EvalDef, TimelineEvent } from "./types";
 
 /**
@@ -181,6 +184,34 @@ function applyCommand(cmd: SessionCommand): void {
 }
 
 /**
+ * Mirror a personal-folder mutation to the cloud registry. Non-fatal by design
+ * (same as the History-window UI): the local registry is the source of truth
+ * and `pushUnsyncedFolders` re-mirrors creates on the next sync sweep, so a
+ * transient cloud failure must not fail the MCP call that already succeeded
+ * locally.
+ */
+async function mirrorFolderToCloud(
+  op: "create" | "rename" | "delete",
+  id: string,
+  name: string,
+  createdAt?: number,
+): Promise<void> {
+  if (!CLOUD_ENABLED || !syncEnabled()) return;
+  try {
+    const cloud = await import("./cloud/folders");
+    if (op === "create") {
+      await cloud.createCloudFolder({ id, name, createdAt: createdAt ?? Date.now() });
+    } else if (op === "rename") {
+      await cloud.renameCloudFolder(id, name);
+    } else {
+      await cloud.deleteCloudFolder(id);
+    }
+  } catch (e) {
+    log.warn("session: folder cloud mirror failed", { op, id, error: String(e) });
+  }
+}
+
+/**
  * Execute an RPC command (one that carries an id) and return its result data.
  * These reach the pieces the Rust MCP server can't touch directly: cloud/org
  * HTTP calls (the bearer token lives in this process) and the localStorage
@@ -264,6 +295,52 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       const { listFoldersFresh } = await import("./history/folders");
       return (await listFoldersFresh()).map((f) => ({ id: f.id, name: f.name }));
     }
+    case "create_folder": {
+      const name = argStr(a.name).trim();
+      if (!name) throw new Error("name is required");
+      const { listFoldersFresh, createLocalFolder, emitFoldersUpdated } = await import(
+        "./history/folders"
+      );
+      // Adopt a same-name folder when one exists (the import_transcript rule),
+      // so repeated calls stay idempotent. Fresh read first: another instance
+      // may have created it since this window loaded.
+      const existing = (await listFoldersFresh()).find((f) => f.name === name);
+      if (existing) return { id: existing.id, name: existing.name, existed: true };
+      const folder = createLocalFolder(name);
+      await mirrorFolderToCloud("create", folder.id, folder.name, folder.createdAt);
+      await emitFoldersUpdated().catch(() => {});
+      return { id: folder.id, name: folder.name, existed: false };
+    }
+    case "rename_folder": {
+      const id = argStr(a.id);
+      const name = argStr(a.name).trim();
+      if (!id || !name) throw new Error("id and name are required");
+      const { listFoldersFresh, renameLocalFolder, emitFoldersUpdated } = await import(
+        "./history/folders"
+      );
+      if (!(await listFoldersFresh()).some((f) => f.id === id)) {
+        throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
+      }
+      renameLocalFolder(id, name);
+      await mirrorFolderToCloud("rename", id, name);
+      await emitFoldersUpdated().catch(() => {});
+      return { id, name };
+    }
+    case "delete_folder": {
+      const id = argStr(a.id);
+      if (!id) throw new Error("id is required");
+      const { listFoldersFresh, deleteLocalFolder, emitFoldersUpdated } = await import(
+        "./history/folders"
+      );
+      const existing = (await listFoldersFresh()).find((f) => f.id === id);
+      if (!existing) {
+        throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
+      }
+      deleteLocalFolder(id);
+      await mirrorFolderToCloud("delete", id, existing.name);
+      await emitFoldersUpdated().catch(() => {});
+      return { id, name: existing.name };
+    }
     case "list_orgs": {
       const { listMyOrgs } = await import("./cloud/orgs");
       return await listMyOrgs();
@@ -276,6 +353,44 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       const { listOrgFolders } = await import("./cloud/folders");
       const folders = await listOrgFolders(argStr(a.orgId));
       return folders.map((f) => ({ id: f.id, name: f.name }));
+    }
+    case "create_org_folder": {
+      const orgId = argStr(a.orgId);
+      const name = argStr(a.name).trim();
+      if (!orgId || !name) throw new Error("orgId and name are required");
+      const { listOrgFolders, createOrgFolder } = await import("./cloud/folders");
+      // Same idempotence rule as create_folder: adopt an existing same-name
+      // folder rather than minting a server-side twin.
+      const existing = (await listOrgFolders(orgId)).find((f) => f.name === name);
+      if (existing) return { id: existing.id, name: existing.name, existed: true };
+      const folder = await createOrgFolder(orgId, name);
+      return { id: folder.id, name: folder.name, existed: false };
+    }
+    case "rename_org_folder": {
+      const orgId = argStr(a.orgId);
+      const id = argStr(a.id);
+      const name = argStr(a.name).trim();
+      if (!orgId || !id || !name) throw new Error("orgId, id and name are required");
+      const { renameOrgFolder } = await import("./cloud/folders");
+      await renameOrgFolder(orgId, id, name);
+      return { orgId, id, name };
+    }
+    case "delete_org_folder": {
+      const orgId = argStr(a.orgId);
+      const id = argStr(a.id);
+      if (!orgId || !id) throw new Error("orgId and id are required");
+      const { deleteOrgFolder } = await import("./cloud/folders");
+      await deleteOrgFolder(orgId, id);
+      return { orgId, id };
+    }
+    case "move_org_recording_to_folder": {
+      const orgId = argStr(a.orgId);
+      const id = argStr(a.id);
+      if (!orgId || !id) throw new Error("orgId and id are required");
+      const folderId = a.folderId ? argStr(a.folderId) : null;
+      const { setOrgRecordingFolder } = await import("./cloud/folders");
+      await setOrgRecordingFolder(orgId, id, folderId);
+      return { orgId, id, folderId };
     }
     case "share_recording_to_org": {
       const { shareRecordingToOrg } = await import("./cloud/sync");
@@ -345,6 +460,25 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       const { emitHistoryUpdated } = await import("./history/history");
       await emitHistoryUpdated(id);
       return { id };
+    }
+    case "delete_recording": {
+      const id = argStr(a.id);
+      if (!id) throw new Error("id is required");
+      const { listHistory, deleteHistoryEntry, emitHistoryUpdated } = await import(
+        "./history/history"
+      );
+      if (!(await listHistory()).some((e) => e.id === id)) {
+        throw new Error(`no local recording with id ${id} — get ids from list_recordings`);
+      }
+      // Same order as the library UI delete: cloud first (tombstone, so the
+      // sweep can't resurrect the copy), then the local files.
+      if (CLOUD_ENABLED && syncEnabled()) {
+        const { deleteCloudRecording } = await import("./cloud/sync");
+        await deleteCloudRecording(id);
+      }
+      await deleteHistoryEntry(id);
+      await emitHistoryUpdated(id);
+      return { id, deleted: true };
     }
     default:
       throw new Error(`unknown command: ${action}`);


### PR DESCRIPTION
## Why

The built-in MCP server could `list_folders` and `move_recording_to_folder`, but the folder registries themselves were UI-only, and recordings could not be deleted over MCP. During an external library-cleanup session the agent had to write `folders.json` directly and clone entry directories, and org-shared recordings could not be organized at all — they all pile up at the org root.

The frontend already implements everything (`src/lib/history/folders.ts`, `src/lib/cloud/folders.ts`, `src/lib/cloud/sync.ts`); this PR only wires it through the MCP surface via the existing `call_frontend` RPC pattern.

## New tools

| Tool | Notes |
|---|---|
| `create_folder` | personal; idempotent by name (adopts an existing same-name folder, the `import_transcript` rule); mirrored to the cloud registry when sync is on |
| `rename_folder` / `delete_folder` | personal; delete lets recordings fall to the personal root (orphan→root rule) |
| `create_org_folder` | idempotent by name; any org member |
| `rename_org_folder` / `delete_org_folder` | creator or org admin/owner (server-enforced) |
| `move_org_recording_to_folder` | wraps `setOrgRecordingFolder` (PATCH `/orgs/:orgId/recordings/:id/folder`) |
| `delete_recording` | DESTRUCTIVE, called out in the description; cloud copy first (tombstone) then local files, same order as the library UI delete |

Cloud mirroring of personal-folder mutations is non-fatal (matches the History-window UI): the local registry is the source of truth and `pushUnsyncedFolders` re-mirrors on the next sweep.

Also: `create_` / `import_` now classify as writes in the MCP activity feed — `import_transcript` was previously logged as a read.

## Checks

- `bunx tsc --noEmit` ✓
- `bunx vitest run` ✓ (216 tests)
- `cargo check` ✓