### PR TITLE
[feature] MCP: delete_org_recording tool

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -970,7 +970,24 @@ fn tools() -> Vec<Value> {
             "Copy an org recording to personal",
             "Save a copy of an org-shared recording into the personal library (local \
              disk), so it appears in list_recordings and can be opened in replay. The \
-             org copy stays put (removing it needs uploader/admin rights in the app).",
+             org copy stays put (remove it with delete_org_recording).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "orgId": { "type": "string" },
+                    "id": { "type": "string", "description": "Org recording id (from list_org_recordings)." }
+                },
+                "required": ["orgId", "id"]
+            }),
+        ),
+        tool(
+            "delete_org_recording",
+            "Remove a recording from an org (DESTRUCTIVE)",
+            "Remove a shared recording from an organization (uploader or org \
+             admin/owner only, server-enforced). Only the org copy is deleted — a \
+             personal original, if one still exists, is untouched. This cannot be \
+             undone; re-share from the personal copy to restore it. Get ids from \
+             list_org_recordings.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1278,10 +1295,10 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
             )
             .await?
         }
-        "copy_org_recording_to_personal" => {
+        "copy_org_recording_to_personal" | "delete_org_recording" => {
             call_frontend(
                 state,
-                "copy_org_recording_to_personal",
+                name,
                 json!({
                     "orgId": required_str(&args, "orgId")?,
                     "id": required_str(&args, "id")?

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -461,6 +461,14 @@ async function applyRpcCommand(action: string, a: Record<string, unknown>): Prom
       await emitHistoryUpdated(id);
       return { id };
     }
+    case "delete_org_recording": {
+      const orgId = argStr(a.orgId);
+      const id = argStr(a.id);
+      if (!orgId || !id) throw new Error("orgId and id are required");
+      const { deleteOrgRecording } = await import("./cloud/sync");
+      await deleteOrgRecording(orgId, id);
+      return { orgId, id, deleted: true };
+    }
     case "delete_recording": {
       const id = argStr(a.id);
       if (!id) throw new Error("id is required");


### PR DESCRIPTION
Rounds out the org surface added in #249: an agent could share a recording into an org and reorganize org folders, but removing one from the org still required the app UI — hit immediately when a recording turned out not to belong in the org at all.

- `delete_org_recording` wraps the existing `deleteOrgRecording` in `src/lib/cloud/sync.ts` (uploader or org admin/owner, server-enforced). Only the org copy is deleted; a personal original is untouched. Description says DESTRUCTIVE and how to restore (re-share from personal).
- `copy_org_recording_to_personal`'s description no longer claims removal is app-only.

Checks: `bunx tsc --noEmit` ✓, `cargo check` ✓, `bunx vitest run` ✓ (216).