### PR TITLE
[feature] hosted Parley can batch-transcribe uploaded recordings

### DIFF
--- a/src-tauri/src/replay.rs
+++ b/src-tauri/src/replay.rs
@@ -1375,6 +1375,13 @@ fn parley_batch_error(status: reqwest::StatusCode, body: &str) -> String {
             "Your monthly hosted transcription quota is used up — upgrade your plan or wait for it to reset."
                 .to_string()
         }
+        // The cloud caps how many transcriptions one account can have in flight,
+        // counting live meetings too — so this usually means "you're recording
+        // right now", which is a wait, not a failure.
+        429 => {
+            "Too many transcriptions running at once — wait for a meeting or an earlier upload to finish, then try again."
+                .to_string()
+        }
         413 => {
             "This recording is too large for hosted transcription — split it into shorter files and upload them separately."
                 .to_string()

--- a/src-tauri/src/replay.rs
+++ b/src-tauri/src/replay.rs
@@ -4,10 +4,13 @@
 //! pre-recorded/batch API and returns ready-to-render, diarized-where-supported
 //! segments. `transcribe_file` dispatches by provider: Soniox (upload → job →
 //! poll → diarized tokens) is the reference; Deepgram / AssemblyAI / OpenAI /
-//! Gemini adapters live alongside it but are GATED OFF in the STT registry
-//! (`supportsFileUpload: false`) until each is smoke-tested against its live API.
-//! The wrapper (compression, acoustic speech-rate, per-provider caching) is
-//! provider-independent.
+//! Gemini adapters live alongside it, and Gemini is still GATED OFF in the STT
+//! registry (`supportsFileUpload: false`) until it's smoke-tested against its
+//! live API. Hosted "parley" is the odd one out: it posts to Parley Cloud, which
+//! proxies Soniox with the master key server-side, so no vendor name, model or
+//! key ever crosses this boundary — it authenticates with the cloud session
+//! token exactly like the realtime relay does. The wrapper (compression,
+//! acoustic speech-rate, per-provider caching) is provider-independent.
 
 use std::time::Duration;
 
@@ -128,12 +131,16 @@ struct TranscriptResponse {
     tokens: Vec<Token>,
 }
 
-/// Transcribe an audio file via Soniox's async API and return diarized segments.
+/// Transcribe an audio file via the selected provider's batch API and return
+/// diarized segments.
 ///
-/// `language_hints` may be empty (Soniox auto-detects). `diarization` toggles
-/// speaker separation. The `api_key` is supplied by the frontend from settings
-/// and never leaves the Rust side beyond the Soniox request.
+/// `language_hints` may be empty (providers auto-detect). `diarization` toggles
+/// speaker separation. The `api_key` is supplied by the frontend and never leaves
+/// the Rust side beyond the provider request — for hosted "parley" it is the
+/// cloud session token, and `batch_url` is the cloud endpoint that stands in for
+/// a vendor (see the match below).
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn transcribe_file(
     app: AppHandle,
     path: String,
@@ -142,6 +149,10 @@ pub async fn transcribe_file(
     model: Option<String>,
     language_hints: Vec<String>,
     diarization: bool,
+    // Hosted "parley" mode: the cloud batch endpoint's `https://` base URL. When
+    // set, `api_key` is the cloud Bearer token (not a vendor key). Absent for
+    // BYOK providers, which address their vendor from the adapter itself.
+    batch_url: Option<String>,
 ) -> Result<TranscriptionResult, String> {
     ensure_crypto_provider();
 
@@ -155,7 +166,12 @@ pub async fn transcribe_file(
 
     if api_key.trim().is_empty() {
         log::warn!("replay: missing api key provider={}", provider);
-        return Err("Missing transcription API key".to_string());
+        // Hosted mode's credential is the signed-in cloud session, not a pasted
+        // key, so this one message has to point at both doors.
+        return Err(
+            "Missing transcription credential — add the provider's API key in Settings, or sign in to Parley Cloud."
+                .to_string(),
+        );
     }
 
     // Cache: an identical re-upload (same file name + byte size, same provider)
@@ -223,7 +239,10 @@ pub async fn transcribe_file(
     // Run the rest of the flow, ensuring the temp file is cleaned up afterward.
     // Dispatch on the provider — each `*_batch` returns the same
     // `TranscriptionResult` shape (segments + duration); the acoustic speech-rate
-    // is grafted on afterward since it's provider-independent.
+    // is grafted on afterward since it's provider-independent. The BYOK arms talk
+    // to their vendor with the user's own key; the hosted "parley" arm talks only
+    // to Parley Cloud, which holds the vendor key — hence no model is forwarded
+    // there and the endpoint has to be handed in from the frontend.
     let result = match provider.as_str() {
         "soniox" => run_upload_and_transcribe(
             &client,
@@ -246,8 +265,29 @@ pub async fn transcribe_file(
         "gemini" => {
             gemini_batch(&client, &api_key, &upload_path, model.as_deref(), &language_hints).await
         }
+        "parley" => match batch_url.as_deref().map(str::trim).filter(|u| !u.is_empty()) {
+            Some(base) => {
+                parley_batch(
+                    &client,
+                    &api_key,
+                    base,
+                    &upload_path,
+                    &language_hints,
+                    diarization,
+                )
+                .await
+            }
+            // Hosted mode's api_key is the cloud session token, which only the
+            // cloud accepts — sending it to a vendor would die with an opaque
+            // auth error. Refuse loudly instead (a call site that forgot
+            // batchUrl is a frontend bug), mirroring start_meeting's relay_url
+            // guard for the streaming path.
+            None => Err("hosted transcription requires the cloud batch URL".to_string()),
+        },
+        // Only an unknown/misspelled provider id reaches here now — naming a
+        // specific replacement would go stale the way "switch to Soniox" did.
         other => Err(format!(
-            "File transcription for '{other}' is not supported yet — switch to Soniox in Settings."
+            "File transcription for '{other}' is not supported yet — switch to another transcription provider in Settings."
         )),
     }
     .map(|mut r| {
@@ -1174,6 +1214,178 @@ async fn gemini_batch(
         cached: false,
         speech_rate_hz: 0.0,
     })
+}
+
+// --- Parley Cloud (hosted batch) ----------------------------------------------
+
+/// Job status from the cloud. camelCase on the wire (the cloud is TypeScript);
+/// `durationMs` is null until the job completes, `errorMessage` only ever set on
+/// the "error" status.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CloudJobStatus {
+    status: String,
+    #[serde(default)]
+    error_message: Option<String>,
+    #[serde(default)]
+    duration_ms: Option<u64>,
+}
+
+/// Hosted batch transcription through Parley Cloud.
+///
+/// Shorter than the Soniox adapter on purpose: the cloud owns the vendor account,
+/// so uploading the file and creating the job collapse into a single POST, and
+/// no model name is ever sent (picking it is the cloud's business, not ours).
+/// `token` is the cloud session bearer; `base` is `${CLOUD_URL}/stt/batch`.
+/// The transcript comes back in the same token shape the Soniox arm parses —
+/// deliberately, so `Token` / `TranscriptResponse` / `group_tokens` are reused
+/// verbatim and diarized output can't drift between hosted and BYOK modes.
+async fn parley_batch(
+    client: &reqwest::Client,
+    token: &str,
+    base: &str,
+    upload_path: &str,
+    language_hints: &[String],
+    diarization: bool,
+) -> Result<TranscriptionResult, String> {
+    let bytes = tokio::fs::read(upload_path)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))?;
+
+    // 1. Upload the raw (already compressed) bytes; the response is the job id.
+    // The hints param is omitted entirely when empty so the cloud auto-detects,
+    // rather than being handed an empty list to interpret.
+    let mut url = format!("{base}?diarization={}", if diarization { "1" } else { "0" });
+    if !language_hints.is_empty() {
+        url.push_str(&format!("&language_hints={}", language_hints.join(",")));
+    }
+    log::info!(
+        "replay: uploading to parley cloud bytes={} diarization={}",
+        bytes.len(),
+        diarization
+    );
+    let create_resp = client
+        .post(url)
+        .bearer_auth(token)
+        .header("Content-Type", "application/octet-stream")
+        .body(bytes)
+        .send()
+        .await
+        .map_err(|e| format!("Upload to Parley Cloud failed: {e}"))?;
+    let status = create_resp.status();
+    if !status.is_success() {
+        let body = create_resp.text().await.unwrap_or_default();
+        log::error!("replay: parley batch create failed status={}", status);
+        return Err(parley_batch_error(status, &body));
+    }
+    let created: IdResponse = read_json(create_resp, "parley batch create").await?;
+    let job_id = created.id;
+    log::info!("replay: parley cloud job created jobId={}", job_id);
+
+    // 2. Poll until the job settles. Same cadence and cap as the BYOK adapters —
+    // the cloud normalizes upstream states into the four below, so a status we
+    // don't recognize is treated as "still working" rather than a hard failure.
+    let mut reported_duration_ms: Option<u64> = None;
+    for poll in 1..=MAX_POLLS {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        let status_resp = client
+            .get(format!("{base}/{job_id}"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| format!("Poll request failed: {e}"))?;
+        let job: CloudJobStatus = read_json(status_resp, "parley batch status").await?;
+        match job.status.as_str() {
+            "completed" => {
+                let duration_ms = job.duration_ms.unwrap_or(0);
+                log::info!(
+                    "replay: parley cloud job completed durationMs={} polls={}",
+                    duration_ms,
+                    poll
+                );
+                reported_duration_ms = Some(duration_ms);
+                break;
+            }
+            "error" => {
+                let msg = job.error_message.unwrap_or_else(|| "unknown error".into());
+                log::error!("replay: parley cloud job error errorMessage={}", msg);
+                return Err(format!("Transcription failed: {msg}"));
+            }
+            // "queued" | "processing" | anything else → keep polling.
+            _ => continue,
+        }
+    }
+    let Some(audio_duration_ms) = reported_duration_ms else {
+        log::error!("replay: parley cloud job timed out maxPolls={}", MAX_POLLS);
+        return Err("Transcription timed out".to_string());
+    };
+
+    // 3. Fetch the diarized tokens.
+    let transcript_resp = client
+        .get(format!("{base}/{job_id}/transcript"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| format!("Fetch transcript failed: {e}"))?;
+    let transcript: TranscriptResponse =
+        read_json(transcript_resp, "parley batch transcript").await?;
+
+    // 4. Best-effort cleanup so the cloud isn't left holding the audio. Fire and
+    // forget, like the Soniox arm's deletes — we already have the transcript, so
+    // a failure here must not fail the transcription.
+    let _ = client
+        .delete(format!("{base}/{job_id}"))
+        .bearer_auth(token)
+        .send()
+        .await;
+
+    let segments = group_tokens(&transcript.tokens);
+    let duration_ms = segments
+        .iter()
+        .map(|s| s.end_ms)
+        .max()
+        .unwrap_or(audio_duration_ms)
+        .max(audio_duration_ms);
+
+    Ok(TranscriptionResult {
+        segments,
+        duration_ms,
+        cached: false,
+        speech_rate_hz: 0.0,
+    })
+}
+
+/// Turn a failed batch-create response into something the user can act on. These
+/// strings land in a toast, so each one names the next step: the status is what
+/// distinguishes "your session died" from "you're out of quota" from "this file
+/// is simply too big", and those need different actions. Unrecognized statuses
+/// keep the cloud's own `{"error": …}` code so a bug report still carries detail.
+fn parley_batch_error(status: reqwest::StatusCode, body: &str) -> String {
+    let code = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            v.get("error")
+                .and_then(|e| e.as_str())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_default();
+    match status.as_u16() {
+        401 => "Sign in to Parley Cloud to transcribe recordings.".to_string(),
+        402 => {
+            "Your monthly hosted transcription quota is used up — upgrade your plan or wait for it to reset."
+                .to_string()
+        }
+        413 => {
+            "This recording is too large for hosted transcription — split it into shorter files and upload them separately."
+                .to_string()
+        }
+        502 => {
+            "Parley Cloud couldn't reach the transcription service — try again in a few minutes."
+                .to_string()
+        }
+        _ if code.is_empty() => format!("Hosted transcription failed (HTTP {status})"),
+        _ => format!("Hosted transcription failed (HTTP {status}): {code}"),
+    }
 }
 
 /// Turn a reqwest Response into a deserialized body, surfacing the HTTP status +

--- a/src/lib/replay/ingest.test.ts
+++ b/src/lib/replay/ingest.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { arbitrateImportPaths } from "./ingest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The ingest gate logs its refusals, and `log`'s Tauri-less path touches
+// `window`. Logging is a side channel here, not the thing under test.
+vi.mock("../log", () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  attachConsoleOnce: vi.fn(),
+}));
+
+import { useStore } from "../store";
+import type { Settings } from "../types";
+import { arbitrateImportPaths, assertUploadTranscribable } from "./ingest";
+import { sttBatchUrl } from "../transcription/providers";
 
 // The single audio-vs-transcript arbitration rule (R7) shared by the picker and
 // the window drag-drop. If this rule changes, every import door changes with it.
@@ -34,5 +45,65 @@ describe("arbitrateImportPaths", () => {
       kind: "audio",
       path: "/a/CALL.M4A",
     });
+  });
+});
+
+// The credential a provider is missing is NOT the same thing for everyone:
+// hosted Parley has no key field, so telling the user to paste one sends them
+// looking for a box that doesn't exist. These pin the branch.
+describe("assertUploadTranscribable", () => {
+  const base = useStore.getState().settings;
+  const settingsFor = (over: Partial<Settings>): Settings => ({ ...base, ...over });
+
+  beforeEach(() => {
+    useStore.setState({ cloudAuth: null });
+  });
+
+  it("refuses a provider without batch support without naming a replacement", () => {
+    expect(() =>
+      assertUploadTranscribable(settingsFor({ transcriptionProvider: "gemini" })),
+    ).toThrow(/switch to another transcription provider in Settings/);
+  });
+
+  it("tells a BYOK provider's user to add an API key", () => {
+    expect(() =>
+      assertUploadTranscribable(
+        settingsFor({ transcriptionProvider: "soniox", sonioxApiKey: "" }),
+      ),
+    ).toThrow(/Add your Soniox API key/);
+  });
+
+  it("tells a signed-out hosted user to sign in, not to paste a key", () => {
+    let message = "";
+    try {
+      assertUploadTranscribable(settingsFor({ transcriptionProvider: "parley" }));
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/Sign in to Parley Cloud/);
+    expect(message).not.toMatch(/API key/);
+  });
+
+  it("passes hosted upload once a cloud session exists", () => {
+    useStore.setState({
+      cloudAuth: {
+        token: "sess_123",
+        user: { id: "u1", name: "Test", email: "t@example.com" },
+        activeOrganizationId: null,
+      },
+    });
+    expect(() =>
+      assertUploadTranscribable(settingsFor({ transcriptionProvider: "parley" })),
+    ).not.toThrow();
+  });
+});
+
+// Provider-hiding: the hosted arm gets a cloud endpoint and BYOK providers get
+// nothing (their adapter addresses the vendor itself).
+describe("sttBatchUrl", () => {
+  it("returns the cloud batch endpoint for hosted Parley only", () => {
+    expect(sttBatchUrl("parley")).toMatch(/\/stt\/batch$/);
+    expect(sttBatchUrl("soniox")).toBeUndefined();
+    expect(sttBatchUrl("deepgram")).toBeUndefined();
   });
 });

--- a/src/lib/replay/ingest.ts
+++ b/src/lib/replay/ingest.ts
@@ -5,7 +5,9 @@
 // word/segment timestamps), and returns a `ReplaySession` the replay UI can play
 // and scrub. Which providers are eligible is gated by `supportsFileUpload` in the
 // STT registry — the backend dispatch (`replay.rs::transcribe_file`) must
-// implement each one before its flag flips on. Today that's Soniox only.
+// implement each one before its flag flips on. Today every provider but Gemini
+// qualifies, including hosted Parley Cloud, which batch-transcribes through its
+// own endpoint (`sttBatchUrl`) on the signed-in session rather than an API key.
 
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -13,7 +15,8 @@ import { open } from "@tauri-apps/plugin-dialog";
 import type { Settings, TranscriptSegment } from "../types";
 import { useStore } from "../store";
 import type { ReplaySession } from "./types";
-import { STT_BY_ID, sttApiKey } from "../transcription/providers";
+import type { SttProviderInfo } from "../transcription/providers";
+import { STT_BY_ID, sttApiKey, sttBatchUrl } from "../transcription/providers";
 import { toTraditional } from "../zhConvert";
 import { log } from "../log";
 import { recordUsage } from "../usage/log";
@@ -78,21 +81,37 @@ interface RustTranscriptionResult {
   speechRateHz: number;
 }
 
+/**
+ * How to obtain the credential this provider is missing. Hosted Parley has no
+ * key field at all — it rides the signed-in cloud session — so the BYOK wording
+ * would send the user hunting in Settings for a box that doesn't exist. Shared
+ * by the upload gate and {@link transcribeRecording}, which check the same thing
+ * at two different moments (before the picker, and again at invoke time).
+ */
+function missingCredentialMessage(info: SttProviderInfo): string {
+  return info.id === "parley"
+    ? "Sign in to Parley Cloud in Settings to transcribe recordings."
+    : `Add your ${info.label} API key in Settings to transcribe recordings.`;
+}
+
 /** Throw (with the actionable message) unless the configured STT provider can
  *  batch-transcribe an uploaded file. Only audio needs this — text transcripts
- *  import without any provider. */
-function assertUploadTranscribable(settings: Settings): void {
+ *  import without any provider. Exported for the unit test that pins both
+ *  refusal messages. */
+export function assertUploadTranscribable(settings: Settings): void {
   const provider = settings.transcriptionProvider;
   const info = STT_BY_ID[provider];
   if (!info.supportsFileUpload) {
     log.warn("ingest: rejected, provider has no file-upload support", { provider });
+    // Naming a specific replacement would go stale the moment the registry
+    // changes (it already did once); every other provider handles uploads today.
     throw new Error(
-      `Uploading a recording isn't supported for ${info.label} yet — switch the transcription provider to Soniox in Settings.`,
+      `Uploading a recording isn't supported for ${info.label} yet — switch to another transcription provider in Settings.`,
     );
   }
   if (!sttApiKey(settings, provider).trim()) {
-    log.warn("ingest: missing stt key", { provider });
-    throw new Error(`Add your ${info.label} API key in Settings to transcribe recordings.`);
+    log.warn("ingest: missing stt credential", { provider });
+    throw new Error(missingCredentialMessage(info));
   }
 }
 
@@ -185,8 +204,9 @@ export async function pickImportFiles(settings: Settings): Promise<ImportPick | 
 }
 
 /**
- * Transcribe an already-picked recording into a `ReplaySession` (diarized batch
- * transcription via Soniox). Reports decoding/uploading/transcribing stages.
+ * Transcribe an already-picked recording into a `ReplaySession` (batch
+ * transcription via the configured provider, diarized where it supports it).
+ * Reports decoding/uploading/transcribing stages.
  */
 export async function transcribeRecording(
   settings: Settings,
@@ -197,7 +217,7 @@ export async function transcribeRecording(
   const info = STT_BY_ID[provider];
   const apiKey = sttApiKey(settings, provider).trim();
   if (!apiKey) {
-    throw new Error(`Add your ${info.label} API key in Settings to transcribe recordings.`);
+    throw new Error(missingCredentialMessage(info));
   }
 
   const name = fileNameOf(audioPath);
@@ -212,6 +232,8 @@ export async function transcribeRecording(
 
   // The Rust command uploads the file, creates the async job, polls to
   // completion, then fetches the diarized tokens. It owns the network + secrets.
+  // `batchUrl` is set only for hosted Parley, where `apiKey` is the cloud session
+  // token and the cloud — not this client — knows the vendor.
   reportStage(opts, { stage: "transcribing" });
   log.info("ingest: transcribe invoke", { provider, languageHints, diarization: info.diarization });
   const result = await invoke<RustTranscriptionResult>("transcribe_file", {
@@ -221,6 +243,7 @@ export async function transcribeRecording(
     model: null,
     languageHints,
     diarization: info.diarization,
+    batchUrl: sttBatchUrl(provider) ?? null,
   });
   log.info("ingest: transcription ok", {
     segments: result.segments.length,

--- a/src/lib/transcription/providers.ts
+++ b/src/lib/transcription/providers.ts
@@ -19,9 +19,10 @@ export interface SttProviderInfo {
    * wizard, and must stay in sync with which providers the `transcribe_file`
    * dispatch actually implements. `true` = an implemented batch adapter whose
    * request/response shape is verified against the vendor's API docs (Soniox,
-   * Deepgram, AssemblyAI, OpenAI). Gemini stays `false` — its inline Ogg-Opus
+   * Deepgram, AssemblyAI, OpenAI) or, for hosted Parley, against the cloud's own
+   * `/stt/batch` contract. Gemini is the only `false` left — its inline Ogg-Opus
    * support + model naming are unconfirmed and it returns no timestamps or
-   * diarization; hosted Parley stays `false` until a cloud batch endpoint exists.
+   * diarization.
    */
   supportsFileUpload: boolean;
   /** Settings field holding this provider's API key. */
@@ -47,17 +48,17 @@ export const STT_PROVIDERS: SttProviderInfo[] = [
   { id: "assemblyai", label: "AssemblyAI", diarization: false, supportsFileUpload: true, apiKeyField: "assemblyaiApiKey", keyPlaceholder: "…", icon: "/providers/assemblyai.png" },
   { ...fromLlm("openai"), diarization: false, supportsFileUpload: true },
   { ...fromLlm("gemini"), diarization: false, supportsFileUpload: false },
-  // Hosted account mode: audio is relayed through Parley Cloud to Soniox (which
+  // Hosted account mode: audio goes through Parley Cloud to Soniox (which
   // diarizes), so no vendor is exposed and no key field is used — auth is the
   // signed-in cloud session (see sttApiKey). Borrows the Parley brand from the
   // LLM registry. The picker only offers it in the cloud build when signed in.
-  // File upload needs a cloud batch endpoint (relaying to Soniox async) that
-  // isn't wired yet — off until that exists and is verified.
+  // Both tenses are hosted: live audio over the `/stt/stream` relay, uploaded
+  // recordings over the `/stt/batch` endpoint (see sttRelayUrl / sttBatchUrl).
   {
     id: "parley",
     label: PROVIDER_BY_ID["parley"].label,
     diarization: true,
-    supportsFileUpload: false,
+    supportsFileUpload: true,
     apiKeyField: "parleyApiKey",
     keyPlaceholder: "",
     icon: PROVIDER_BY_ID["parley"].icon,
@@ -102,4 +103,16 @@ export function sttRelayUrl(
   return id === "parley"
     ? `${CLOUD_URL.replace(/^http/, "ws")}/stt/stream?feature=${feature}`
     : undefined;
+}
+
+/**
+ * The BATCH (uploaded recording) endpoint for a provider — the replay path's
+ * counterpart to {@link sttRelayUrl}. Hosted "parley" POSTs the audio to Parley
+ * Cloud, which drives Soniox's async API with the master key server-side, so the
+ * vendor key never lives on the client. BYOK providers address their vendor from
+ * the Rust adapter itself and have no batch URL. `transcribe_file` must be passed
+ * this alongside the credential from `sttApiKey`, or the hosted arm refuses.
+ */
+export function sttBatchUrl(id: SttProviderId): string | undefined {
+  return id === "parley" ? `${CLOUD_URL}/stt/batch` : undefined;
 }


### PR DESCRIPTION
## Why

Uploading a recording was refused whenever the transcription provider was the hosted **Parley** account: `supportsFileUpload` was `false` for `parley`, and `replay.rs::transcribe_file` had no arm for it. The reason was structural — batch transcription only ever spoke to a vendor with the user's *own* key, and in hosted mode the vendor key lives on the cloud. So the one provider that is supposed to need no setup was the one that told you to go configure another provider before you could import a file.

## What

The desktop posts the recording to Parley Cloud's own batch endpoint and polls it, authenticating with the signed-in session token — the same trust model the realtime relay already uses. The cloud drives the vendor's async API with the master key server-side, so no vendor name, model, or key crosses the boundary.

- `replay.rs`: new `parley_batch` adapter (upload + job creation collapse into one POST, since the cloud owns the account), plus a `batch_url` parameter on `transcribe_file` and a `"parley"` dispatch arm that refuses loudly if the URL is missing — mirroring `start_meeting`'s `relay_url` guard.
- `providers.ts`: `parley.supportsFileUpload` → `true`, and a new `sttBatchUrl()` alongside `sttRelayUrl()`.
- `ingest.ts`: passes `batchUrl`; a signed-out hosted user is now told to **sign in** instead of to paste an API key into a field that doesn't exist; the refusal message no longer names Soniox as *the* upload provider (Gemini is the only one left without batch support).

The transcript comes back in the same token shape the Soniox arm already parses, so `group_tokens` and the whole provider-independent wrapper (compression, acoustic speech-rate, per-provider cache) are reused verbatim rather than forked. Hosted uploads get their own cache key for free.

## Ordering

**Do not merge before the cloud `/stt/batch` endpoint is deployed** — this flips the feature on in the UI, and without the endpoint a hosted upload would fail at the first POST.

## Checks

- `bunx tsc --noEmit` — pass
- `bunx vitest run` — pass (23 files, 221 tests, incl. 5 new)
- `cargo check` — pass, no warnings

Not yet exercised against a live cloud endpoint; that is the smoke test once the cloud side is up.
