### PR TITLE
[docs] ios: the hand-build path, and that export does not upload

### DIFF
--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -42,22 +42,51 @@ overwritten on the next generate — and commit the regenerated plist with it.
 Both targets carry the number and both must move together. To re-upload without
 a commit, run the workflow manually with the `build_number` input.
 
+**When CI cannot sign.** The permissions error above is not hypothetical: the
+`ios-v1.3` run failed exactly this way, archiving fine and then dying in export
+with `Cloud signing permission error` / `No profiles for 'com.pathors.parley.ios'
+were found`. The API key can build but cannot mint a distribution profile.
+
+A Mac with the team's Apple ID signed into Xcode **can** — the account does the
+cloud signing the key is not allowed to — so the release does not have to wait
+for a new key. Build it by hand, then fix the key.
+
 <details>
 <summary>Building and uploading by hand</summary>
+
+Archive and export an `.ipa`, signing through the Xcode account rather than an
+API key:
 
 ```bash
 cd ios/App
 xcodegen generate
-xcodebuild -project Parley.xcodeproj -scheme Parley \
+xcodebuild -project Parley.xcodeproj -scheme Parley -configuration Release \
   -destination 'generic/platform=iOS' \
-  -archivePath build/Parley.xcarchive archive
+  -archivePath build/Parley.xcarchive -allowProvisioningUpdates archive
 xcodebuild -exportArchive -archivePath build/Parley.xcarchive \
   -exportOptionsPlist ExportOptions.plist -exportPath build/export \
   -allowProvisioningUpdates
 ```
 
-With an Xcode account signed in, the export uploads directly to App Store
-Connect.
+`ExportOptions.plist` declares no `destination`, so that second command only
+writes `build/export/Parley.ipa` — it does **not** upload, whatever the export
+log's talk of App Store Connect suggests. Uploading needs a copy of the plist
+with `destination` set to `upload`:
+
+```bash
+sed 's|<key>uploadSymbols</key>|<key>destination</key><string>upload</string><key>uploadSymbols</key>|' \
+  ExportOptions.plist > /tmp/UploadOptions.plist
+xcodebuild -exportArchive -archivePath build/Parley.xcarchive \
+  -exportOptionsPlist /tmp/UploadOptions.plist -exportPath build/upload \
+  -allowProvisioningUpdates
+```
+
+That re-signs and uploads in one step, ending in `Upload succeeded`. The build
+then processes in App Store Connect for a few minutes to a few hours before it
+can be attached to a version.
+
+Keep `build/Parley.xcarchive` until the release is out. It holds the dSYMs, and
+a hand-built upload has no CI run holding them for you.
 </details>
 
 ## Store metadata


### PR DESCRIPTION
Two corrections to `ios/RELEASING.md`, both found while shipping 1.3 build 9.

**The hand-build block was wrong.** It said that with an Xcode account signed
in, "the export uploads directly to App Store Connect". It does not:
`ExportOptions.plist` declares no `destination`, so `-exportArchive` writes
`build/export/Parley.ipa` and stops. The export log mentions App Store Connect
regardless, which is probably how the claim survived a read. Uploading needs a
second export against a copy of the plist with `destination` set to `upload`.

**The CI failure mode now has a documented way out.** The doc already warned
that a too-narrow API key role causes a permissions error. `ios-v1.3` hit it:
the run archived cleanly and died in export with

```
error: exportArchive Cloud signing permission error
error: exportArchive No profiles for 'com.pathors.parley.ios' were found
```

The key can build but cannot mint a distribution profile. A Mac with the team's
Apple ID in Xcode can — the account does the cloud signing the key is not
allowed to — so a release does not have to wait for a new key. 1.3 (9) was
archived, exported and uploaded that way and is in App Store Connect now.

Also says to keep the `.xcarchive`: a hand-built upload has no CI run holding
its dSYMs, and a TestFlight crash report without them is unreadable.

**Not fixed here:** the API key itself. `APPLE_API_KEY` still needs replacing
with an App Manager key, which needs App Store Connect access.

Failed run: https://github.com/pathorsAI/parley/actions/runs/31971821763