### PR TITLE
[docs] the release notes stop guessing at why CI could not sign

### DIFF
--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -71,14 +71,11 @@ overwritten on the next generate — and commit the regenerated plist with it.
 Both targets carry the number and both must move together. To re-upload without
 a commit, run the workflow manually with the `build_number` input.
 
-**When CI cannot sign.** The permissions error above is not hypothetical: the
-`ios-v1.3` run failed exactly this way, archiving fine and then dying in export
-with `Cloud signing permission error` / `No profiles for 'com.pathors.parley.ios'
-were found`. The API key can build but cannot mint a distribution profile.
-
-A Mac with the team's Apple ID signed into Xcode **can** — the account does the
-cloud signing the key is not allowed to — so the release does not have to wait
-for a new key. Build it by hand, then fix the key.
+**Building by hand is still a first-class path**, and it is how 1.0 through 1.3
+actually shipped. A Mac with the team's Apple ID signed into Xcode already holds
+the distribution identity in its keychain, so none of the certificate machinery
+above applies: archive, export, upload. Reach for this whenever CI is in the way
+rather than waiting on it.
 
 <details>
 <summary>Building and uploading by hand</summary>


### PR DESCRIPTION
Two claims in `ios/RELEASING.md` were wrong, and both were written from the shape of an error message rather than from evidence. I wrote one of them.

**"That key's role is too narrow."** Probing the App Store Connect API with the existing key returns `200` on `/v1/users`, which a Developer-role key cannot read. And `POST /v1/certificates` for an Apple Distribution certificate now succeeds on every run. The role was never the problem: the team held no distribution certificate for cloud signing to find, and Xcode reported that absence as a permission error.

**"The API key can build but cannot mint a distribution profile."** It mints the certificate *and* the profiles — that is what `asc_signing.py` does each run, verified end to end: mint, archive and export all pass now.

What survives is the part that is true and useful: building by hand from a Mac signed into the team needs none of this, and that is how 1.0 through 1.3 actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)