### PR TITLE
[refactor] the voice pane becomes a control panel, not a keyboard

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -143,24 +143,36 @@ Every measurement lives in `KBMetrics` (`KeyboardTheme.swift`) so the view and
 the height constraint can't disagree — a disagreement is a seam. The key
 geometry is the system portrait keyboard's: 42pt caps, 11pt between rows, 6pt
 between keys, 3pt at the screen edge. That puts the QWERTY pane's key area at
-213pt (≈ the system's 216pt) and the voice pane's at 180pt; each mode names its
-own height and the change is animated when the user crosses between them.
+213pt (≈ the system's 216pt).
+
+**The voice pane is measured to come out at 213pt too**, so both panes are
+251pt tall including the strip. That equality is load-bearing rather than tidy:
+the panes are one swipe apart, and a keyboard that changes height mid-swipe
+shoves the host app's content up and down every time the user crosses between
+them. Change one pane's numbers and the other has to follow.
 
 ### Mode strip
 
-Across the top, in the shape Typeless uses: the **Parley wordmark** on the left,
-and a two-segment control on the right — a waveform (voice) and `EN`. The
-selected segment gets a filled pill. **A left/right swipe across the pane body
-switches modes too**, on a `DragGesture` with a 24pt minimum distance and a 56pt
-threshold so a mistyped key is never read as a swipe.
+Across the top: the **Parley wordmark** on the left, and on the right the
+current pane named beside two dots — a long one for where you are, a short one
+for the pane you haven't got to. The dots stay tappable, so nothing is lost.
 
-The strip defaults to `EN` when there is no Full Access, because that is the
-pane that still works in that state.
+This replaced a two-segment control, which read as the *only* way across and
+hid the fact that the pane swipes at all. **The panes sit side by side on a
+track that follows the finger**: a `DragGesture` with a 24pt minimum distance
+drives the track's offset live and commits past a 56pt threshold, so a mistyped
+key is never read as a swipe but a real drag shows the other pane arriving. The
+previous gesture only committed on release — nothing moved while the finger did,
+which is why nobody found it.
+
+The strip defaults to the keyboard pane when there is no Full Access, because
+that is the pane that still works in that state.
 
 ### EN mode
 
 A real QWERTY plane — `qwertyuiop` / `asdfghjkl` (inset half a key, as iOS does)
-/ shift + `zxcvbnm` + delete / `123` + globe + `@` + space + return — plus the
+/ shift + `zxcvbnm` + delete / `123` + globe (only where the system asks for
+one) + `@` + space + return — plus the
 two symbol planes everyone expects: `1234567890` / `-/:;()$&@"` and
 `[]{}#%^*+=` / `_\|~<>$£¥•`, sharing a punctuation row and a bottom row.
 
@@ -187,18 +199,51 @@ The behaviours that make it feel like a keyboard rather than a grid of buttons:
 
 ### Voice mode
 
-The status caption, then the mic pill with `⌫` and `@` flanking it, then the
-globe and a wide return key. Those three quick keys are there because the edits
-a dictating user actually reaches for — take that back, type an address, break
-the line — should not cost a trip through the EN pane.
+**A control panel, not a keyboard.** Nothing on this pane types a letter, so it
+borrows none of UIKit's key-cap treatment — no raised caps, no hard shadows, no
+inverted press. It is a fixed-height text slot over a ⌀80 record button with
+three ⌀44 translucent discs arranged around it:
 
-The mic pill is one of exactly two places the keyboard is allowed to look like
-Parley rather than iOS: idle it carries Pathors' brand gradient (`#1469D4` →
-`#2DB6F3`, top-leading to bottom-trailing); listening it goes flat recording red,
-so "armed" is never something you have to read out of a gradient. The other is
-the wordmark (`#1469D4` light, `#2DB6F3` dark). Everything else — caps, press
-feedback, corner radius — stays system-coloured, because a keyboard that doesn't
-look like a keyboard reads as broken.
+```
+        live transcript (74pt, three lines, bottom-aligned)
+
+                                              ⌫
+   @                    ◉  record
+                                              ⏎
+```
+
+`⌫` and `⏎` stack on the right, where a right thumb falls, because they are the
+edits a dictating user actually reaches for. `@` takes the bottom-left corner —
+low-frequency, and the corner the system's own globe occupies on the devices
+that ask us to draw one (in which case `@` moves up and the globe takes that
+corner). **The top-left is deliberately empty**: it is where the pane breathes.
+
+The pane used to be caps — a mic pill flanked by two 56pt caps over a
+full-width `return` — and that was the mistake. A cap's raised look says "there
+are twenty-six of these, start typing"; on four control buttons it is noise, and
+the widest key on the keyboard was the least-pressed one. The two panes now read
+as different kinds of thing, which is itself a signal for which one you're on.
+
+The record button is one of exactly two places the keyboard is allowed to look
+like Parley rather than iOS: idle it carries Pathors' brand gradient (`#1469D4`
+→ `#2DB6F3`); listening it goes flat recording red inside two rings breathing
+outward, so "armed" is never something you have to read out of a gradient — and
+never needs a second element saying "Listening…" beside it. The other is the
+wordmark (`#1469D4` light, `#2DB6F3` dark). Nothing else on the pane carries a
+colour, including `⏎` when the host has asked for an action.
+
+**Return is a glyph, not a word.** The host decides what the key is *called* —
+Go, Send, Search — and a 44pt disc has no room for "Search"; `returnKeyGlyph`
+maps the type to a symbol instead. What the key *does* is unchanged: it types a
+line break, because a keyboard extension cannot fire the host's return action.
+
+**The live transcript.** The settled tail is echoed above the button in a softer
+ink, followed by the words not yet settled. Settled text has already been
+inserted into the document — but the document is usually behind the keyboard, so
+without the echo dictation reads as words that appear and then vanish. The
+window is capped at 140 characters and cleared with the session: a few hundred
+bytes, not the transcript history a keyboard extension must not hold. The slot's
+height is fixed so beginning to speak never resizes the keyboard.
 
 ### No Bopomofo engine — 注音 is the system's job
 
@@ -208,9 +253,25 @@ cannot reach the system's Chinese input engine, and bundling a Bopomofo engine
 not a round of polish on a dictation keyboard. Chinese input in Parley is
 dictation; Chinese *typing* belongs to the system 注音 keyboard.
 
-That makes the globe load-bearing, so it is present **on every device**, not
-only where `needsInputModeSwitchKey` is true — a 注音 user must always be one
-obvious tap from leaving. It is a real `UIButton` behind a SwiftUI cap, wired
+That made the globe look load-bearing, and it used to be drawn **on every
+device** rather than only where `needsInputModeSwitchKey` is true. That was
+wrong, and it is the one decision in this document that has been reversed.
+
+From iPhone X onwards **iOS draws the Emoji/Globe and Dictation keys itself**,
+in the strip beneath a raised keyboard, over custom keyboards included. That is
+why `needsInputModeSwitchKey` returns false there — the system is telling us it
+has the exit covered — and the HIG asks explicitly not to repeat it: "Don't
+duplicate system-provided keyboard features … avoid causing confusion by
+repeating them in your keyboard." Drawing our own was a duplicate key that cost
+a slot in both panes and made the voice pane read as crowded.
+
+**Both panes now follow the flag.** Where it is true (older, Home-button
+devices) the globe appears — bottom-left in the voice pane, in its usual place
+in the QWERTY bottom row. Where it is false the system's own key is the exit and
+we draw nothing. Either way a 注音 user is always one obvious tap from leaving,
+which is what App Review actually asks for.
+
+It is a real `UIButton` behind a SwiftUI cap or disc, wired
 whole-touch-sequence to `handleInputModeList(from:with:)`: that selector demands
 the live `UIEvent` from a control action, which a SwiftUI gesture has no way to
 supply, and it is UIKit's own globe behaviour — a tap advances to the next
@@ -220,9 +281,12 @@ more tap.
 ## App Review notes
 
 - **4.4.1** (keyboards must work without Full Access): with Full Access off the
-  keyboard opens in `EN` mode and the whole QWERTY plane, the quick keys and the
+  keyboard opens on the QWERTY pane, and the whole plane, the quick keys and the
   globe work normally — none of them need the network or the App Group. Only
   dictation is unavailable, and the voice pane says so with a jump to Settings.
+- **Never trapping the user**: the exit is the system's own globe on the devices
+  that draw one, and ours on the devices that don't — `needsInputModeSwitchKey`
+  decides, in both panes. See the 注音 section above.
 - **2.5.1** (private APIs): the auto-return path is private and version-gated to
   where it works; the rest of the flow (openURL, App Group, insertText, App
   Intents) is entirely public.

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -968,18 +968,18 @@
         }
       }
     },
-    "Map it to Parley Voice Typing to start dictation without switching keyboards.": {
+    "Map it to Parley Voice Typing and dictation starts without leaving the app you are in — no round trip at all.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Map it to Parley Voice Typing to start dictation without switching keyboards."
+            "value": "Map it to Parley Voice Typing and dictation starts without leaving the app you are in — no round trip at all."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "把它設成 Parley Voice Typing，不用切鍵盤就能開始語音輸入。"
+            "value": "把它設成 Parley Voice Typing，語音輸入會直接在你當下的 app 裡開始，完全不用跳出去。"
           }
         }
       }

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -437,7 +437,7 @@ struct SettingsView: View {
                     detail: "Lets your voice reach your Parley account to be transcribed.")
                 dictationStep(
                     number: 3, title: "Action Button (optional)",
-                    detail: "Map it to Parley Voice Typing to start dictation without switching keyboards.")
+                    detail: "Map it to Parley Voice Typing and dictation starts without leaving the app you are in — no round trip at all.")
             } label: {
                 Text("Set-up steps").font(.parley.subheadlineEmphasized)
             }

--- a/ios/Keyboard/KeyboardKeys.swift
+++ b/ios/Keyboard/KeyboardKeys.swift
@@ -39,6 +39,21 @@ struct KeyCap: View {
     }
 }
 
+/// The voice pane's counterpart to `KeyCap`: a flat translucent disc.
+///
+/// The voice pane is a control panel, not a keyboard, so its buttons carry none
+/// of the cap treatment — no raised fill, no hard shadow, no inverted press.
+/// Compose it with `PressableButton` or `RepeatingKey` the same way a cap is.
+struct ControlDisc: View {
+    let dark: Bool
+    let pressed: Bool
+
+    var body: some View {
+        Circle()
+            .fill(pressed ? KBTheme.controlPressed(dark) : KBTheme.control(dark))
+    }
+}
+
 /// A button that reports its own pressed state, so keys and the mic control can
 /// darken under the finger the way system keys do. `.buttonStyle(.plain)` alone
 /// gives no feedback at all, which is what made the keys feel dead.
@@ -126,12 +141,18 @@ struct RepeatingKey<Content: View>: View {
     }
 }
 
-/// The globe.
+/// The globe, shown only where the system asks for one.
 ///
 /// Parley ships no Bopomofo engine — a keyboard extension can't reach the
 /// system Chinese input engine and we are not bundling our own — so a user who
-/// wants 注音 has to be able to leave, on *every* device rather than only where
-/// `needsInputModeSwitchKey` is true. That makes this key load-bearing.
+/// wants 注音 has to be able to leave. This key used to be drawn on *every*
+/// device to guarantee that exit, which was a mistake: from iPhone X onwards
+/// iOS draws the Emoji/Globe and Dictation keys itself, in the strip beneath a
+/// raised keyboard, **including over custom keyboards**, and the HIG asks
+/// explicitly not to repeat them ("Don't duplicate system-provided keyboard
+/// features … avoid causing confusion by repeating them in your keyboard").
+/// `needsInputModeSwitchKey` is how the system says which case it is in, so
+/// both panes now follow it rather than overriding it.
 ///
 /// It is a real `UIButton` because `handleInputModeList(from:with:)` demands the
 /// live `UIEvent` from a control action; a SwiftUI gesture has no event to hand
@@ -141,15 +162,21 @@ struct RepeatingKey<Content: View>: View {
 struct GlobeKey: View {
     weak var controller: UIInputViewController?
     let dark: Bool
+    /// The voice pane draws its controls as discs, the letter pane as caps.
+    var round = false
 
     @State private var pressed = false
 
     var body: some View {
         ZStack {
-            KeyCap(dark: dark, tint: .alt, pressed: pressed)
+            if round {
+                ControlDisc(dark: dark, pressed: pressed)
+            } else {
+                KeyCap(dark: dark, tint: .alt, pressed: pressed)
+            }
             Image(systemName: "globe")
-                .font(.system(size: 17, weight: .regular))
-                .foregroundStyle(KBTheme.ink(dark))
+                .font(.system(size: round ? 16 : 17, weight: .regular))
+                .foregroundStyle(round ? KBTheme.inkSoft(dark) : KBTheme.ink(dark))
                 .accessibilityHidden(true)
             InputModeSwitchButton(controller: controller, pressed: $pressed)
         }
@@ -196,7 +223,7 @@ private struct InputModeSwitchButton: UIViewRepresentable {
         -> CGSize?
     {
         CGSize(
-            width: proposal.width ?? KBMetrics.quickKeyWidth,
+            width: proposal.width ?? KBMetrics.roundKey,
             height: proposal.height ?? KBMetrics.keyHeight)
     }
 

--- a/ios/Keyboard/KeyboardLetterPane.swift
+++ b/ios/Keyboard/KeyboardLetterPane.swift
@@ -116,16 +116,19 @@ struct LetterPane: View {
         }
     }
 
-    /// `123`/`ABC`, the globe, an optional `@`, the space bar, and return.
-    /// Space takes whatever the fixed keys leave, which lands it at roughly the
-    /// five-key width iOS gives it.
+    /// `123`/`ABC`, the globe when the system asks for one, an optional `@`,
+    /// the space bar, and return. Space takes whatever the fixed keys leave,
+    /// which lands it at roughly the five-key width iOS gives it — and a little
+    /// wider on the devices that draw their own globe below the keyboard.
     private func bottomRow(
         _ m: RowMetrics, planeLabel: String, planeTarget: KeyPlane, showsAtKey: Bool
     ) -> some View {
         row {
             planeKey(planeLabel, to: planeTarget, width: m.wide)
-            GlobeKey(controller: bridge.controller, dark: dark)
-                .frame(width: m.unit, height: KBMetrics.keyHeight)
+            if bridge.showsGlobe {
+                GlobeKey(controller: bridge.controller, dark: dark)
+                    .frame(width: m.unit, height: KBMetrics.keyHeight)
+            }
             if showsAtKey {
                 textKey("@", width: m.unit)
             }

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -2,40 +2,63 @@ import SwiftUI
 
 /// The Parley keyboard's face.
 ///
-/// Two panes under one strip, in the shape dictation keyboards have settled on
-/// (Typeless, Wispr Flow): the wordmark and a two-way mode picker on top, then
-/// either the dictation pane — a status line, the mic pill with `⌫` and `@`
-/// flanking it, and a wide return key — or a full QWERTY plane. A horizontal
-/// swipe across the body moves between them, so the picker is a signpost rather
-/// than the only way across.
+/// Two panes under one strip: the voice pane — a live-transcript slot, one
+/// round record button and the three controls a dictating user reaches for —
+/// or a full QWERTY plane. The panes sit side by side on a track that follows
+/// the finger, so a horizontal drag moves between them and the strip's dots are
+/// a signpost rather than the only way across.
+///
+/// The voice pane is drawn as a **control panel, not a keyboard**. Nothing on
+/// it types a letter, so it borrows none of UIKit's key-cap treatment: flat
+/// translucent discs, no shadows, and one colour — the record button. Filling
+/// the pane with caps (which it used to do) made it read as a broken keyboard
+/// rather than a place to speak.
 ///
 /// The view paints no background of its own. The system's `UIInputView` is
 /// already the right colour, already has the right corners and already covers
 /// exactly the right area; painting over it was what made the keyboard seam
 /// against the row below and sit a shade off from the system's.
 ///
-/// Everything here is presentation only — no audio, no transcript history — so
-/// the extension stays well under the jetsam limit keyboard processes run
-/// against.
+/// Everything here is presentation only — no audio, no transcript history
+/// beyond the short tail shown above the button — so the extension stays well
+/// under the jetsam limit keyboard processes run against.
 struct KeyboardRootView: View {
     @ObservedObject var bridge: KeyboardBridge
     @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// The host field's appearance, not the system's: a dark-themed app puts a
     /// dark keyboard on screen even in light mode.
     var dark: Bool
 
+    /// Live horizontal travel of the pane track while a drag is in flight.
+    @GestureState private var drag: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0) {
             modeStrip
-            pane
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // The swipe lives on the pane, not on a key, and demands real
-                // travel before it engages — otherwise a fat-fingered tap on
-                // `g` would throw the user into the other mode.
+            GeometryReader { geo in
+                let width = geo.size.width
+                HStack(spacing: 0) {
+                    voicePane.frame(width: width)
+                    LetterPane(bridge: bridge, dark: dark).frame(width: width)
+                }
+                .frame(width: width * 2, alignment: .leading)
+                // Follow the finger. Both panes are the same height now, so the
+                // track can slide without the keyboard resizing under it. The
+                // old gesture only committed on release, so nothing moved while
+                // the finger did — which is why nobody found the swipe.
+                .offset(x: (bridge.mode == .voice ? 0 : -width) + drag)
+                .animation(.interactiveSpring(response: 0.32, dampingFraction: 0.86), value: bridge.mode)
+                // The gesture lives on the track, not on a key, and demands
+                // real travel before it engages — otherwise a fat-fingered tap
+                // on `g` would throw the user into the other mode.
                 .contentShape(Rectangle())
                 .gesture(
                     DragGesture(minimumDistance: 24)
+                        .updating($drag) { value, state, _ in
+                            state = rubberBanded(value.translation.width, width: width)
+                        }
                         .onEnded { value in
                             let dx = value.translation.width
                             guard abs(dx) > KBMetrics.swipeThreshold,
@@ -44,203 +67,194 @@ struct KeyboardRootView: View {
                             select(dx < 0 ? .letters : .voice)
                         }
                 )
+            }
+            .clipped()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ViewBuilder
-    private var pane: some View {
-        switch bridge.mode {
-        case .voice: voicePane
-        case .letters: LetterPane(bridge: bridge, dark: dark)
-        }
+    /// Resist a drag that would pull the track past either end, so the pane
+    /// never detaches from the edge of the keyboard.
+    private func rubberBanded(_ dx: CGFloat, width: CGFloat) -> CGFloat {
+        let overshoot = (bridge.mode == .voice && dx > 0) || (bridge.mode == .letters && dx < 0)
+        return overshoot ? dx / 4 : max(-width, min(width, dx))
     }
 
     private func select(_ mode: KeyboardMode) {
         guard bridge.mode != mode else { return }
-        withAnimation(.easeInOut(duration: 0.18)) { bridge.setMode(mode) }
+        bridge.setMode(mode)
     }
 
-    // MARK: mode strip — wordmark + picker
+    // MARK: mode strip — wordmark + where you are
 
+    /// The wordmark, and the current pane named next to two dots.
+    ///
+    /// It used to be a segmented control, which read as the *only* way across
+    /// and hid the fact that the pane swipes at all. Dots say "there is another
+    /// one of these, sideways" — and they stay tappable, so nothing is lost.
     private var modeStrip: some View {
         HStack(spacing: 0) {
             Text(verbatim: "Parley")
                 .font(.footnote.weight(.bold))
                 .foregroundStyle(KBTheme.wordmark(dark))
             Spacer(minLength: 8)
-            HStack(spacing: 2) {
-                segment(.voice, label: Image(systemName: "waveform"))
-                    .accessibilityLabel(Text("Voice dictation"))
-                segment(.letters, label: Text(verbatim: "EN"))
-                    .accessibilityLabel(Text("English keyboard"))
+            Text(bridge.mode == .voice ? "Voice" : "Keyboard")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(KBTheme.inkSoft(dark))
+                .padding(.trailing, 8)
+                .accessibilityHidden(true)
+            HStack(spacing: 5) {
+                dot(.voice, label: Text("Voice dictation"))
+                dot(.letters, label: Text("English keyboard"))
             }
-            .padding(2)
-            .background(Capsule().fill(KBTheme.segmentTrack(dark)))
         }
         .frame(height: KBMetrics.strip)
         .padding(.horizontal, 12)
     }
 
-    private func segment<Label: View>(_ mode: KeyboardMode, label: Label) -> some View {
+    private func dot(_ mode: KeyboardMode, label: Text) -> some View {
         let selected = bridge.mode == mode
-        return PressableButton(action: { select(mode) }) { pressed in
-            label
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(selected ? KBTheme.ink(dark) : KBTheme.inkSoft(dark))
-                .frame(width: 42, height: 26)
-                .background(
-                    Capsule()
-                        .fill(selected ? KBTheme.key(dark) : .clear)
-                        .opacity(pressed ? 0.6 : 1))
+        return Button(action: { select(mode) }) {
+            Capsule()
+                .fill(selected ? KBTheme.accent : KBTheme.inkSoft(dark).opacity(0.35))
+                .frame(width: selected ? 14 : 5, height: 5)
+                // Keep a finger-sized target around a deliberately small mark.
+                .contentShape(Rectangle().inset(by: -12))
+                .animation(.easeInOut(duration: 0.2), value: selected)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
     // MARK: the voice pane
 
     private var voicePane: some View {
-        VStack(spacing: KBMetrics.voiceRowSpacing) {
-            caption
-            // The mic keeps the middle; delete and `@` flank it so the two
-            // edits a dictating user actually reaches for — take that back,
-            // type an address — never cost a trip through the EN pane.
-            HStack(spacing: 10) {
-                RepeatingKey(action: { bridge.backspace() }) { pressed in
-                    quickCap(pressed: pressed) {
-                        Image(systemName: "delete.left")
-                            .font(.system(size: 18, weight: .regular))
-                    }
-                }
-                .frame(width: KBMetrics.quickKeyWidth, height: KBMetrics.micHeight)
-                .accessibilityLabel(Text("Delete"))
-
-                micPill
-
-                PressableButton(action: { bridge.type("@") }) { pressed in
-                    quickCap(pressed: pressed) {
-                        Text(verbatim: "@").font(.system(size: 20))
-                    }
-                }
-                .frame(width: KBMetrics.quickKeyWidth, height: KBMetrics.micHeight)
-                .accessibilityLabel(Text("At sign"))
-            }
-            HStack(spacing: 10) {
-                // Always here, on every device: Parley ships no Bopomofo
-                // engine, so this key is a 注音 user's only way out.
-                GlobeKey(controller: bridge.controller, dark: dark)
-                    .frame(width: KBMetrics.quickKeyWidth, height: KBMetrics.quickRowHeight)
-                PressableButton(action: { bridge.newline() }) { pressed in
-                    ZStack {
-                        KeyCap(
-                            dark: dark, tint: bridge.returnKeyIsAccented ? .accent : .alt,
-                            pressed: pressed)
-                        Text(bridge.returnKeyLabel)
-                            .font(.system(size: 15))
-                            .foregroundStyle(
-                                bridge.returnKeyIsAccented ? .white : KBTheme.ink(dark))
-                    }
-                    .frame(maxWidth: .infinity)
-                    .frame(height: KBMetrics.quickRowHeight)
-                }
-                .accessibilityLabel(Text(bridge.returnKeyLabel))
-            }
+        VStack(spacing: KBMetrics.textToDeck) {
+            textSlot
+            deck
         }
-        .padding(.horizontal, 10)
-        .padding(.top, KBMetrics.paneTop)
-        .padding(.bottom, KBMetrics.paneBottom)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.horizontal, KBMetrics.voiceSide)
+        .padding(.top, KBMetrics.voiceTop)
+        .padding(.bottom, KBMetrics.voiceBottom)
     }
 
-    private func quickCap<Content: View>(
-        pressed: Bool, @ViewBuilder glyph: () -> Content
+    /// The controls, arranged around the record button rather than in a row:
+    /// delete top-right, return under it, `@` bottom-left. Top-left is left
+    /// empty on purpose — it is where the pane breathes, and it is the slot the
+    /// globe takes on the devices that still need one.
+    private var deck: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: KBMetrics.deckRowGap) {
+                if bridge.showsGlobe {
+                    atKey
+                } else {
+                    Color.clear.frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
+                }
+                if bridge.showsGlobe {
+                    // Bottom-left, where the system's own globe sits, so the
+                    // muscle memory carries over on the devices that show it.
+                    GlobeKey(controller: bridge.controller, dark: dark, round: true)
+                        .frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
+                } else {
+                    atKey
+                }
+            }
+            Spacer(minLength: 0)
+            recordButton
+            Spacer(minLength: 0)
+            VStack(spacing: KBMetrics.deckRowGap) {
+                deleteKey
+                returnKey
+            }
+        }
+        .frame(height: KBMetrics.deckHeight)
+    }
+
+    // MARK: the round controls
+
+    private var atKey: some View {
+        PressableButton(action: { bridge.type("@") }) { pressed in
+            disc(pressed: pressed, quiet: true) {
+                Text(verbatim: "@").font(.system(size: 18))
+            }
+        }
+        .accessibilityLabel(Text("At sign"))
+    }
+
+    private var deleteKey: some View {
+        RepeatingKey(action: { bridge.backspace() }) { pressed in
+            disc(pressed: pressed) {
+                Image(systemName: "delete.left").font(.system(size: 17))
+            }
+        }
+        .accessibilityLabel(Text("Delete"))
+    }
+
+    /// Return, as a glyph rather than a word.
+    ///
+    /// The host decides what this key is *called* — Go, Send, Search — and a
+    /// 44pt disc has no room for "Search". A glyph is the better trade twice
+    /// over: it is legible at this size where five letters would not be, and it
+    /// keeps the pane's single colour on the record button. What the key
+    /// actually does never changes; see `KeyboardBridge.newline()`.
+    private var returnKey: some View {
+        PressableButton(action: { bridge.newline() }) { pressed in
+            disc(pressed: pressed) {
+                Image(systemName: bridge.returnKeyGlyph).font(.system(size: 17))
+            }
+        }
+        .accessibilityLabel(Text(bridge.returnKeyLabel))
+    }
+
+    private func disc<Content: View>(
+        pressed: Bool, quiet: Bool = false, @ViewBuilder glyph: () -> Content
     ) -> some View {
         ZStack {
-            KeyCap(dark: dark, tint: .alt, pressed: pressed)
-            glyph().foregroundStyle(KBTheme.ink(dark))
+            ControlDisc(dark: dark, pressed: pressed)
+            glyph().foregroundStyle(quiet ? KBTheme.inkSoft(dark) : KBTheme.ink(dark))
         }
+        .frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
     }
 
-    // MARK: caption — the state line above the mic
+    // MARK: the record button
 
-    /// One fixed-height slot so the layout never jumps between states: the
-    /// Full Access explainer, the idle prompt, the listening indicator, or the
-    /// tentative tail (the words heard but not yet settled — settled text is
-    /// already in the document behind the keyboard, so it is never echoed).
-    private var caption: some View {
-        Group {
-            if !bridge.hasFullAccess {
-                VStack(spacing: 3) {
-                    Text("Voice typing needs Full Access")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(KBTheme.ink(dark))
-                    Text("Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.")
-                        .font(.caption2)
-                        .foregroundStyle(KBTheme.inkSoft(dark))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 12)
-                }
-            } else if let error = bridge.errorText, !bridge.listening {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(KBTheme.recording)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 16)
-            } else if bridge.listening && !bridge.partial.isEmpty {
-                Text(bridge.partial)
-                    .font(.callout)
-                    .foregroundStyle(KBTheme.ink(dark).opacity(0.8))
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 16)
-            } else if bridge.listening {
-                HStack(spacing: 7) {
-                    PulseBars(color: KBTheme.recording)
-                    Text("Listening…")
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(KBTheme.recording)
-                }
-            } else {
-                Text("Tap to speak")
-                    .font(.subheadline)
-                    .foregroundStyle(KBTheme.inkSoft(dark))
-            }
-        }
-        .frame(height: KBMetrics.captionHeight)
-        .frame(maxWidth: .infinity)
-        .animation(.easeInOut(duration: 0.15), value: bridge.listening)
-        .animation(.easeOut(duration: 0.15), value: bridge.partial)
-    }
-
-    // MARK: the mic pill
-
-    private var micPill: some View {
+    /// The one thing on this pane with a colour: idle it carries Pathors' brand
+    /// gradient, listening it goes flat recording red inside a breathing ring,
+    /// so "armed" is never something you have to read out of a gradient — and
+    /// never needs a second element saying "Listening…" beside it.
+    private var recordButton: some View {
         PressableButton(action: toggle) { pressed in
-            Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(micInk)
-                .frame(width: KBMetrics.micWidth, height: KBMetrics.micHeight)
-                .background(
-                    Capsule().fill(micFill).brightness(pressed ? -0.08 : 0))
+            ZStack {
+                if bridge.listening && !reduceMotion {
+                    PulseRing(color: KBTheme.recording)
+                }
+                Circle()
+                    .fill(recordFill)
+                    .frame(width: KBMetrics.recordSize, height: KBMetrics.recordSize)
+                    .brightness(pressed ? -0.06 : 0)
+                Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
+                    .font(.system(size: bridge.listening ? 24 : 28, weight: .medium))
+                    .foregroundStyle(recordInk)
+            }
+            .frame(width: KBMetrics.deckHeight, height: KBMetrics.deckHeight)
         }
         .disabled(!bridge.hasFullAccess)
         .accessibilityLabel(
-            bridge.listening
-                ? Text("Stop dictation") : Text("Start dictation"))
+            bridge.listening ? Text("Stop dictation") : Text("Start dictation"))
     }
 
-    /// Idle: Pathors' brand gradient, the one place on the keyboard where
-    /// Parley is allowed to look like Parley. Recording: the flat recording red,
-    /// so "armed" is never something you have to read out of a gradient.
-    /// Disabled (no Full Access): a key-coloured pill so it reads inert.
-    private var micFill: AnyShapeStyle {
-        if !bridge.hasFullAccess { return AnyShapeStyle(KBTheme.key(dark)) }
+    /// Disabled (no Full Access) reads inert rather than inviting: the button
+    /// can't record until the user has been through Settings.
+    private var recordFill: AnyShapeStyle {
+        if !bridge.hasFullAccess { return AnyShapeStyle(KBTheme.control(dark)) }
         if bridge.listening { return AnyShapeStyle(KBTheme.recording) }
         return AnyShapeStyle(KBTheme.micGradient)
     }
 
-    private var micInk: Color {
-        if !bridge.hasFullAccess { return KBTheme.inkSoft(dark) }
-        return .white
+    private var recordInk: Color {
+        bridge.hasFullAccess ? .white : KBTheme.inkSoft(dark)
     }
 
     private func toggle() {
@@ -259,30 +273,108 @@ struct KeyboardRootView: View {
             }
         }
     }
+
+    // MARK: the text slot
+
+    /// One fixed-height slot above the button, so the keyboard never changes
+    /// shape between states: the Full Access explainer, an error, the live
+    /// transcript, or the idle prompt.
+    ///
+    /// The live case shows the settled tail in a softer ink followed by the
+    /// words not yet settled. Settled text has already been inserted into the
+    /// document, but the document is usually behind the keyboard — echoing a
+    /// short tail is what makes dictation read as continuous instead of as
+    /// words that appear and then vanish.
+    private var textSlot: some View {
+        Group {
+            if !bridge.hasFullAccess {
+                fullAccessNotice
+            } else if let error = bridge.errorText, !bridge.listening {
+                centered {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(KBTheme.recording)
+                        .multilineTextAlignment(.center)
+                }
+            } else if bridge.listening || !bridge.tail.isEmpty {
+                liveText
+            } else {
+                centered {
+                    Text("Tap to speak")
+                        .font(.subheadline)
+                        .foregroundStyle(KBTheme.inkSoft(dark))
+                }
+            }
+        }
+        .frame(height: KBMetrics.textHeight)
+        .frame(maxWidth: .infinity)
+        .animation(.easeInOut(duration: 0.15), value: bridge.listening)
+        .animation(.easeOut(duration: 0.12), value: bridge.partial)
+    }
+
+    private var liveText: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer(minLength: 0)
+            (Text(bridge.tail).foregroundStyle(KBTheme.inkSoft(dark))
+                + Text(bridge.tail.isEmpty || bridge.partial.isEmpty ? "" : " ")
+                + Text(bridge.partial).foregroundStyle(KBTheme.ink(dark)))
+                .font(.system(size: 15))
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var fullAccessNotice: some View {
+        VStack(spacing: 3) {
+            Spacer(minLength: 0)
+            Text("Voice typing needs Full Access")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(KBTheme.ink(dark))
+            Text("Settings › General › Keyboard › Keyboards › Parley → Allow Full Access. Your voice is sent to your Parley account to be transcribed.")
+                .font(.caption2)
+                .foregroundStyle(KBTheme.inkSoft(dark))
+                .multilineTextAlignment(.center)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func centered<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack {
+            Spacer(minLength: 0)
+            content()
+            Spacer(minLength: 0)
+        }
+    }
 }
 
-/// Three bars that keep breathing while the app is listening. Deliberately not
-/// a level meter: the audio lives in the container app, and streaming real
-/// levels across the App Group at frame rate would cost far more than the
-/// reassurance is worth. It says "still running", and nothing it can't know.
-private struct PulseBars: View {
+/// Two rings breathing outwards from the record button while the app is
+/// listening. Deliberately not a level meter: the audio lives in the container
+/// app, and streaming real levels across the App Group at frame rate would cost
+/// far more than the reassurance is worth. It says "still running", and nothing
+/// it can't know — which is also why it replaced the old "Listening…" caption
+/// rather than joining it.
+private struct PulseRing: View {
     let color: Color
     @State private var animating = false
 
     var body: some View {
-        HStack(spacing: 2.5) {
-            ForEach(0..<3, id: \.self) { i in
-                Capsule()
-                    .fill(color)
-                    .frame(width: 2.5, height: animating ? 12 : 4)
-                    .animation(
-                        .easeInOut(duration: 0.5)
-                            .repeatForever()
-                            .delay(Double(i) * 0.15),
-                        value: animating)
-            }
+        ZStack {
+            ring(delay: 0)
+            ring(delay: 0.6)
         }
-        .frame(height: 14)
+        .frame(width: KBMetrics.deckHeight, height: KBMetrics.deckHeight)
+        .allowsHitTesting(false)
         .onAppear { animating = true }
+    }
+
+    private func ring(delay: Double) -> some View {
+        Circle()
+            .fill(color.opacity(animating ? 0 : 0.30))
+            .frame(width: KBMetrics.recordSize, height: KBMetrics.recordSize)
+            .scaleEffect(animating ? 1.25 : 1)
+            .animation(
+                .easeOut(duration: 1.2).repeatForever(autoreverses: false).delay(delay),
+                value: animating)
     }
 }

--- a/ios/Keyboard/KeyboardTheme.swift
+++ b/ios/Keyboard/KeyboardTheme.swift
@@ -60,6 +60,23 @@ enum KBTheme {
         dark ? Color(white: 0.30) : .white
     }
 
+    /// The voice pane's round control buttons.
+    ///
+    /// Deliberately *not* a key cap. The voice pane is a control panel, not a
+    /// keyboard — nothing on it types a letter — so it borrows none of UIKit's
+    /// cap treatment: no light fill, no hard shadow, no press inversion. A cap's
+    /// raised look says "there are twenty-six of these, start typing", which on
+    /// four control buttons is pure noise. A translucent wash over whatever the
+    /// input view is already showing also stays correct in both appearances
+    /// without a colour that has to be maintained twice.
+    static func control(_ dark: Bool) -> Color {
+        dark ? Color.white.opacity(0.10) : Color.black.opacity(0.075)
+    }
+
+    static func controlPressed(_ dark: Bool) -> Color {
+        dark ? Color.white.opacity(0.20) : Color.black.opacity(0.15)
+    }
+
     /// The trough behind the voice/EN segmented control in the mode strip.
     static func segmentTrack(_ dark: Bool) -> Color {
         dark ? Color(white: 0.20) : Color.black.opacity(0.06)
@@ -101,19 +118,36 @@ enum KBMetrics {
 
     static var lettersHeight: CGFloat { strip + lettersPane }
 
-    // The voice pane: one fixed-height status line, the mic flanked by its
-    // quick keys, then the globe + return row.
-    static let captionHeight: CGFloat = 48
-    static let micHeight: CGFloat = 52
-    static let micWidth: CGFloat = 150
-    static let quickKeyWidth: CGFloat = 56
-    static let quickRowHeight: CGFloat = 44
-    static let voiceRowSpacing: CGFloat = 12
+    // The voice pane. A control panel rather than a keyboard — nothing on it
+    // types a letter — so it is measured in round buttons and whitespace
+    // instead of caps and rows, and it is deliberately not full.
+    //
+    // The parts are chosen so the pane comes out at exactly `lettersPane`.
+    // That equality is the point: the two panes are one swipe apart, and a
+    // keyboard that changes height mid-swipe shoves the host app's content up
+    // and down every time the user crosses between them.
+    static let voiceTop: CGFloat = 16
+    static let voiceSide: CGFloat = 24
+    static let voiceBottom: CGFloat = 11
 
-    /// 8 + 48 + 12 + 52 + 12 + 44 + 4 = 180pt.
+    /// The live-transcript slot. Fixed height, so beginning to speak never
+    /// resizes the keyboard: idle it holds the prompt, listening it holds up to
+    /// three lines of what is being heard.
+    static let textHeight: CGFloat = 74
+    static let textToDeck: CGFloat = 12
+
+    /// The round control buttons: delete, return, `@`, and the globe on the
+    /// devices where the system doesn't already draw one.
+    static let roundKey: CGFloat = 44
+    static let deckRowGap: CGFloat = 12
+    /// The record button — the one thing on this pane carrying a colour.
+    static let recordSize: CGFloat = 80
+
+    static var deckHeight: CGFloat { roundKey * 2 + deckRowGap }
+
+    /// 16 + 74 + 12 + 100 + 11 = 213pt, which is `lettersPane` exactly.
     static var voicePane: CGFloat {
-        paneTop + captionHeight + voiceRowSpacing + micHeight + voiceRowSpacing
-            + quickRowHeight + paneBottom
+        voiceTop + textHeight + textToDeck + deckHeight + voiceBottom
     }
 
     static var voiceHeight: CGFloat { strip + voicePane }

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -41,6 +41,7 @@ final class KeyboardViewController: UIInputViewController {
         super.viewDidLoad()
         bridge.controller = self
         bridge.hasFullAccess = hasFullAccess
+        bridge.showsGlobe = needsInputModeSwitchKey
         // Without Full Access there is nothing to dictate with, so open on the
         // pane that still works. App Review 4.4.1 judges the keyboard in
         // exactly this state.
@@ -96,6 +97,14 @@ final class KeyboardViewController: UIInputViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         bridge.hasFullAccess = hasFullAccess
+        // Re-read every time: the user can add or remove keyboards while ours
+        // is loaded, and that flips whether the system draws the globe for us.
+        bridge.showsGlobe = needsInputModeSwitchKey
+        // The tail belongs to the field it was dictated into. Coming back to a
+        // *different* field it would read as text that is already there, so it
+        // is dropped unless a session is still running — `drainDownlink` below
+        // puts it straight back when one is.
+        if !bridge.listening { bridge.tail = "" }
         refreshAppearance()
         refreshReturnKey()
         drainDownlink()
@@ -184,6 +193,7 @@ final class KeyboardViewController: UIInputViewController {
                 insertedCount: 0))
         bridge.listening = true
         bridge.partial = ""
+        bridge.tail = ""
         bridge.errorText = nil
 
         let target = session
@@ -219,6 +229,12 @@ final class KeyboardViewController: UIInputViewController {
     /// anything older is a leftover — a crashed app's frozen `listening` file
     /// or a long-finished transcript that would land in the wrong field.
     private static let adoptionWindow: TimeInterval = 150
+
+    /// How much settled text the keyboard echoes above the record button. Long
+    /// enough to read as a continuing sentence in the three lines the slot has,
+    /// short enough that this is a window rather than the transcript history a
+    /// keyboard extension must not hold.
+    private static let tailLimit = 140
 
     /// Read the transcript the app has published and insert whatever is new.
     /// Idempotent: `insertedCount` is the high-water mark, so a keyboard that
@@ -265,15 +281,22 @@ final class KeyboardViewController: UIInputViewController {
         }
 
         bridge.partial = d.partial
+        // The echoed window follows the settled text, not what this process
+        // happened to insert: a keyboard that was killed mid-session and came
+        // back still shows the sentence in progress.
+        bridge.tail = String(d.committed.suffix(Self.tailLimit))
         switch d.state {
         case .starting, .listening: bridge.listening = true
         case .finishing: bridge.listening = true
         case .done:
             bridge.listening = false
             bridge.partial = ""
+            // The tail stays: the last thing said is worth still being able to
+            // read once the button has gone quiet.
         case .error:
             bridge.listening = false
             bridge.partial = ""
+            bridge.tail = ""
             // Surface the app's failure where the user actually is. Swallowing
             // it (the old behavior) read as "the mic button does nothing".
             bridge.errorText = d.errorMessage ?? String(localized: "Couldn't start. Try again.")
@@ -353,6 +376,19 @@ final class KeyboardBridge: ObservableObject {
     @Published var hasFullAccess = false
     @Published var listening = false
     @Published var partial = ""
+    /// The last stretch of settled text for the running session, shown above
+    /// the record button in a softer ink so dictation reads as continuous.
+    ///
+    /// It is a short window, not history: settled text is already in the host's
+    /// document, and this only exists because the document is usually behind
+    /// the keyboard. Capped at `tailLimit` characters, cleared with the
+    /// session — a few hundred bytes, nowhere near the transcript store the
+    /// extension deliberately doesn't keep.
+    @Published var tail = ""
+    /// Whether the system wants *us* to draw a next-keyboard key. False from
+    /// iPhone X onwards, where iOS draws its own beneath the keyboard and the
+    /// HIG asks us not to repeat it. See `GlobeKey`.
+    @Published var showsGlobe = false
     /// The app's failure for the last session (sign-in, mic permission,
     /// connection), shown in the caption slot until the next start.
     @Published var errorText: String?
@@ -379,6 +415,23 @@ final class KeyboardBridge: ObservableObject {
         case .search: return "Search"
         case .done: return "Done"
         case .next: return "Next"
+        default: return "return"
+        }
+    }
+
+    /// The same meaning as `returnKeyLabel`, as a glyph.
+    ///
+    /// The voice pane's return is a 44pt disc with no room for "Search", and
+    /// the pane keeps its only colour on the record button — so it says what
+    /// the key does with a symbol instead of a word. The letter pane, which has
+    /// a wide key and follows the system's look, still uses the label.
+    var returnKeyGlyph: String {
+        switch returnKeyType {
+        case .go: return "arrow.right"
+        case .send: return "paperplane.fill"
+        case .search: return "magnifyingglass"
+        case .done: return "checkmark"
+        case .next: return "arrow.right.to.line"
         default: return "return"
         }
     }

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -119,19 +119,19 @@
         }
       }
     },
-    "Listening…": {
+    "Keyboard": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Listening…"
+            "value": "Keyboard"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在聽…"
+            "value": "鍵盤"
           }
         }
       }
@@ -166,23 +166,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "切換鍵盤"
-          }
-        }
-      }
-    },
-    "return": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "return"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "換行"
           }
         }
       }
@@ -314,6 +297,23 @@
         }
       }
     },
+    "Voice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音"
+          }
+        }
+      }
+    },
     "Voice dictation": {
       "extractionState": "manual",
       "localizations": {
@@ -344,6 +344,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "語音輸入需要「完整取用權限」"
+          }
+        }
+      }
+    },
+    "return": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "return"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "換行"
           }
         }
       }


### PR DESCRIPTION
Nothing on the voice pane types a letter, but it was drawn as though everything did — raised key caps with hard shadows, a 56pt cap either side of the mic, and a full-width `return`, the widest key on the keyboard and the least-pressed one. It read as a broken keyboard rather than a place to speak.

It is now a fixed-height transcript slot over a round record button, with three translucent discs arranged around it. Delete and return stack on the right where a thumb falls; `@` takes the bottom-left corner; the top-left is left empty on purpose, because that is where the pane breathes.

| Before | After |
|---|---|
| <img src="https://assets.pathors.com/parley/pr-266/01-before-idle.jpg" width="440" alt="The old voice pane: a mic pill flanked by two grey key caps, above a globe key and a full-width return key"> | <img src="https://assets.pathors.com/parley/pr-266/02-after-idle.jpg" width="440" alt="The new voice pane: a round blue record button centred under the prompt, with delete and return as discs on the right and an at-sign disc bottom-left"> |
| <img src="https://assets.pathors.com/parley/pr-266/03-before-listening.jpg" width="440" alt="The old pane while listening: a red mic pill, with only the tentative words shown centred above it"> | <img src="https://assets.pathors.com/parley/pr-266/04-after-listening.jpg" width="440" alt="The new pane while listening: a red record button inside breathing rings, with the settled sentence in grey followed by the tentative words in black"> |

## Four things fall out of the same change

**The globe follows `needsInputModeSwitchKey` now, in both panes.** It used to be drawn unconditionally, on the reasoning that Parley ships no Bopomofo engine so a 注音 user needs a guaranteed exit. That was wrong: from iPhone X onwards iOS draws the Emoji/Globe and Dictation keys itself in the strip beneath the keyboard, over custom keyboards included, which is exactly why the flag returns false there — and the HIG asks not to repeat them ("Don't duplicate system-provided keyboard features … avoid causing confusion by repeating them in your keyboard"). Ours was a duplicate key costing a slot in both panes. Where the flag is true it still appears: bottom-left in the voice pane, in its usual place in the QWERTY row.

**Both panes are exactly 251pt.** They were 218 and 251, so crossing between them animated a 33pt height change and shoved the host app's content up and down. The QWERTY pane's numbers are untouched; the voice pane was measured to meet it.

**The swipe follows the finger.** The panes sit on a track whose offset is driven live by the drag and commits past the existing 56pt threshold. The old gesture only committed on release, so nothing moved while the finger did — which is why nobody found it. The segmented control became the current pane's name beside two dots, which say "there is another one of these, sideways" in a way a filled pill never did. The dots stay tappable.

**Settled text is echoed above the button**, in a softer ink ahead of the words not yet settled. The transcript was already streaming in through the App Group, but settled text was deliberately never echoed — and the document it had been inserted into is usually behind the keyboard, so dictation read as words that appear and then vanish. The window is capped at 140 characters and cleared with the session: a few hundred bytes, not the transcript history a keyboard extension must not hold.

Return is a glyph rather than a word on this pane — a 44pt disc has no room for "Search", and a symbol is legible where five letters would not be. What the key *does* is unchanged: it types a line break, because an extension cannot fire the host's return action.

## Verification

The real `KeyboardRootView` was hosted in a scratch app on an iPhone 16 Pro simulator and screenshotted in every state: idle, listening, no Full Access, a device that asks for the globe, and both QWERTY planes, light and dark. `xcodebuild` is clean for both targets; `bunx tsc --noEmit` and `bunx vitest run` (221 tests) pass.

## Deliberately not in this PR

- **Auto-return from the container app.** Apple closed it in iOS 26.4 — the host bundle id getters return nil, `sourceApplication` reports our own extension, and `suspend()` lands the user on the Home Screen. There is no App Store-safe replacement; Wispr Flow's own docs now teach the swipe. The Action Button intent (which never leaves the host app at all) is the real answer, so its Settings copy now sells that instead of "without switching keyboards".
- **Holding the app awake longer than the current ~30s linger**, which would cut the number of round trips further. It means keeping an audio session open with nothing recording, which is 2.5.4 territory — worth a decision, not worth assuming.
- **In-app history of past dictations.** `DictationCoordinator` discards `committed` when a session ends and never touches `CloudClient`, so those words exist nowhere once the session is over. Its own PR: it needs a store, a Library tab, a Settings switch, and a privacy-label update, and that last one has to line up with a submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)