### PR TITLE
[chore] CI: frontend gate + Rust check on both desktop targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,12 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Typecheck
-        run: bunx tsc --noEmit
+        # Local node_modules binaries (installed from the frozen lockfile) —
+        # no ad-hoc registry resolution.
+        run: bun run tsc --noEmit
 
       - name: Unit tests
-        run: bunx vitest run
+        run: bun run test
 
   rust-macos:
     name: Rust (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI
+
+# Pre-merge gate for the desktop app: the frontend typecheck + unit tests that
+# CLAUDE.md already requires before every PR, plus a Rust compile check on both
+# desktop targets. The Windows job exists to keep the codebase building for the
+# Windows port even before any Windows-specific feature lands — native build
+# regressions (audiopus_sys, knf-rs-sys, cfg-gated code) surface here instead of
+# at release time.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "android/**"
+      - "ios/**"
+      - "website/**"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - "android/**"
+      - "ios/**"
+      - "website/**"
+      - "docs/**"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend typecheck + tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install frontend dependencies
+        # --ignore-scripts blocks supply-chain attacks via package lifecycle
+        # scripts, matching the release workflow.
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+      - name: Unit tests
+        run: bunx vitest run
+
+  rust-macos:
+    name: Rust (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-apple-darwin
+          components: clippy
+
+      - name: Install Opus (for audiopus_sys)
+        # Same rationale as release.yml: link a native arm64 libopus via
+        # pkg-config instead of compiling Opus from source.
+        run: |
+          set -euxo pipefail
+          brew install opus pkg-config autoconf automake libtool
+          ln -sf "$(brew --prefix libtool)/bin/glibtoolize" "$(brew --prefix)/bin/libtoolize"
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: Provide placeholder build inputs
+        # tauri-build verifies that frontendDist and every bundle.resources
+        # entry exist at compile time; the Rust check needs neither the real
+        # frontend bundle nor a working ONNX Runtime, so empty stand-ins do.
+        run: |
+          mkdir -p dist src-tauri/onnxruntime
+          touch src-tauri/onnxruntime/libonnxruntime.dylib
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
+  rust-windows:
+    name: Rust (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: Provide placeholder build inputs
+        # Same stand-ins as the macOS job; the .dylib placeholder satisfies the
+        # base tauri.conf.json resource list until the per-platform config
+        # split lands with the Windows port.
+        run: |
+          mkdir -p dist src-tauri/onnxruntime
+          touch src-tauri/onnxruntime/libonnxruntime.dylib
+        shell: bash
+
+      - name: Check
+        run: cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc


### PR DESCRIPTION
## Why

Phase 0 of the Windows port plan: put a safety net under every subsequent PR before any platform work starts.

Until now **no CI ran the pre-merge gate** — `bunx tsc --noEmit` and `bunx vitest run` were manual (CLAUDE.md), and the Rust side only compiled inside the release workflow.

## What

New `.github/workflows/ci.yml` with three jobs on PRs and pushes to main:

| Job | Runner | What |
|---|---|---|
| `frontend` | ubuntu | `bun install --frozen-lockfile --ignore-scripts` → `tsc --noEmit` → `vitest run` |
| `rust-macos` | macos | `cargo clippy --all-targets -- -D warnings` (verified clean on today's main: 23 test files / 221 tests, zero clippy warnings) |
| `rust-windows` | windows | `cargo check --target x86_64-pc-windows-msvc` |

The Windows job is the de-risk step for the port: it surfaces native-build problems (`audiopus_sys` via pkg-config/autotools, `knf-rs-sys` via bindgen+cmake, cfg-gated code) on every PR instead of at release time. **It is expected to be the job to watch on this very PR** — if `audiopus_sys` can't build under MSVC we find out now, with fallbacks queued (vendored cmake build → prebuilt static opus → different opus binding).

Notes:
- `tauri-build` verifies `frontendDist` and every `bundle.resources` entry exist at compile time, so both Rust jobs create empty stand-ins (`dist/`, a zero-byte `libonnxruntime.dylib`). The real per-platform resource split lands with the port.
- Android/iOS/website/docs-only changes skip the workflow.
- Action SHAs match the pins already used in `release.yml`.

## Verification

- Frontend gate and clippy both run clean locally on this branch.
- The PR's own checks exercise all three jobs end to end.