### PR TITLE
[fix] release: Windows auto-update installs the NSIS build, not the MSI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,12 @@ jobs:
           tauriScript: bun run tauri
           args: --target x86_64-pc-windows-msvc
           assetNamePattern: "[name]-[version]-[platform]-[arch].[ext]"
+          # Point the generic `windows-x86_64` updater key at the NSIS
+          # installer rather than the MSI (tauri-action's default). NSIS
+          # updates install silently; MSI runs msiexec and prompts for UAC on
+          # every update. This also matches the cloud channel's latest.json,
+          # which serves the NSIS setup.exe.
+          updaterJsonPreferNsis: true
 
       - name: Build cloud edition
         env:


### PR DESCRIPTION
## Why

Found while verifying the v0.23.0 release (the first with Windows assets). The published `latest.json` resolves the generic `windows-x86_64` updater key to the **MSI**:

```
windows-x86_64      -> Parley-0.23.0-windows-x64.msi
windows-x86_64-msi  -> Parley-0.23.0-windows-x64.msi
windows-x86_64-nsis -> Parley-0.23.0-windows-x64.exe
```

That is tauri-action's default. An MSI update shells out to `msiexec` and prompts for UAC on every update; the NSIS installer updates silently. The cloud channel's `latest.json` (composed in `compose-updater`) already serves `Parley-setup.exe`, so the two feeds also disagreed about what a Windows update is.

## What

`updaterJsonPreferNsis: true` on the Windows `tauri-action` step. The `-msi`/`-nsis` suffixed keys stay available for anyone pinning a format.

## Scope

Takes effect from the **next** release. v0.23.0's live feed is deliberately left alone — updates through it work (they just prompt), and hand-rewriting a feed that every macOS client polls is not worth that trade. There are no Windows installs to migrate yet: v0.23.0 is the first Windows build and is not announced anywhere.

## Verification

- Parsed the resulting workflow and confirmed the input lands on the Windows tauri-action step.
- Real verification is the next release's `latest.json`; check that `windows-x86_64` and `windows-x86_64-nsis` both point at the `.exe`.