### PR TITLE
[chore] iOS 1.4 (build 10)

### DIFF
--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>1.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -34,8 +34,8 @@ targets:
       path: Parley/Info.plist
       properties:
         CFBundleDisplayName: Parley
-        CFBundleShortVersionString: "1.3"
-        CFBundleVersion: "9"
+        CFBundleShortVersionString: "1.4"
+        CFBundleVersion: "10"
         UILaunchScreen: {}
         # Localized in Parley/InfoPlist.xcstrings; this is the fallback value.
         NSMicrophoneUsageDescription: Parley records the meeting in the room so it can transcribe it live. Audio goes only to the transcription provider tied to your account.
@@ -81,8 +81,8 @@ targets:
       properties:
         # Localized in ../Keyboard/InfoPlist.xcstrings; this is the fallback.
         CFBundleDisplayName: Parley Voice
-        CFBundleShortVersionString: "1.3"
-        CFBundleVersion: "9"
+        CFBundleShortVersionString: "1.4"
+        CFBundleVersion: "10"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.keyboard-service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).KeyboardViewController

--- a/ios/Keyboard/Info.plist
+++ b/ios/Keyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>1.4</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
## What this changes

iOS goes to **1.4 (build 10)** in `ios/App/project.yml`, with `Info.plist` regenerated for both targets.

## Why

App Store Connect refuses a `CFBundleVersion` it has already seen, and 1.3 (9) is already on TestFlight, so nothing can be uploaded until the number moves. `ios-release.yml` also refuses to build when the tag disagrees with `CFBundleShortVersionString`, so the tag and the plist have to move together.

1.4 rather than 1.3 (10) because the build carries behaviour, not a rebuild — #272:

- the microphone survives the app leaving the foreground (interruptions, route changes, engine reconfiguration, media-server resets are all handled and recovered from)
- one tap can no longer start two recordings streaming into one transcript
- recording starts on the tap instead of after the relay handshake
- a dropped relay reconnects instead of ending live transcription for good

`Info.plist` is regenerated from `project.yml` rather than hand-edited — the next `xcodegen generate` would overwrite an edit — and committed alongside, as `ios/RELEASING.md` asks.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes
- [ ] Ran the app — no code changes, version metadata only
- [ ] Added or updated tests — n/a
- [ ] Added new user-facing strings — n/a

`xcodegen generate` reproduces exactly the two plists committed here; both targets report `1.4` / `10`.

## After merge

`git tag ios-v1.4 && git push origin ios-v1.4` to archive, export and upload to TestFlight. This will be the first run since `APPLE_IOS_DIST_P12` was added — the previous five `ios-release` runs all failed on the missing iOS Distribution certificate, and the fix has not yet been proven end to end.
