### PR TITLE
[fix] a release that cannot reach Play fails instead of reporting success

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -15,10 +15,12 @@ name: Android Release
 #
 # The final Play upload step is deliberately skippable. Pathors' Play account
 # (ID 6541030546953107772) is still going through organization identity
-# verification, and until that clears the Play Developer API cannot be enabled,
-# so no service account can exist. Until `PLAY_SERVICE_ACCOUNT_JSON` is set the
-# step is skipped and the run still produces a GitHub Release with the bundle,
-# which can be uploaded to the Play Console by hand.
+# verification. That has since cleared, so a missing `PLAY_SERVICE_ACCOUNT_JSON`
+# is now a misconfiguration and fails the run rather than quietly skipping the
+# upload — a release that reports success without publishing is the worst kind
+# of green. The one genuinely manual case, the first bundle for a package
+# (Play refuses it over the API), is served by the `skip_play_upload` input,
+# which has to be asked for.
 #
 # Runs on Linux (unlike the two macOS release workflows) because nothing here
 # needs Xcode. That only works because gradle/verification-metadata.xml carries
@@ -35,6 +37,15 @@ on:
         description: "Existing tag to build, for example android-v0.1.0"
         required: true
         type: string
+      skip_play_upload:
+        description: >-
+          Build and publish the GitHub release but do NOT upload to Play.
+          The one case that needs this is the first bundle for a package,
+          which Play refuses over the API until a release exists in the
+          console (android/RELEASING.md §7).
+        required: false
+        default: false
+        type: boolean
 
 # The bundle is attached to a GitHub Release.
 permissions:
@@ -165,8 +176,24 @@ jobs:
       # after the organization account clears identity verification. Everything
       # above has already run by this point, so the bundle is on the GitHub
       # release either way and can be uploaded through the Play Console UI.
+      # A release workflow that reports success without publishing is worse
+      # than one that fails: the tag is gone, the GitHub release exists, and
+      # nothing is on Play — and nobody finds out until someone asks where the
+      # build went. Skipping is therefore something the operator asks for, not
+      # something a missing secret decides.
+      - name: Check the Play upload can happen
+        if: ${{ !inputs.skip_play_upload }}
+        run: |
+          if [ -z "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error title=PLAY_SERVICE_ACCOUNT_JSON is not set::This release cannot reach Play." \
+                 "Create the service account (android/RELEASING.md §7) and set the secret," \
+                 "or re-run this workflow with skip_play_upload=true if this is the first bundle" \
+                 "for the package, which Play refuses over the API until a release exists in the console."
+            exit 1
+          fi
+
       - name: Upload to the Play internal track
-        if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ !inputs.skip_play_upload }}
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -176,12 +203,20 @@ jobs:
           track: internal
           status: completed
 
-      - name: Report that the Play upload was skipped
-        if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON == '' }}
+      # Deliberately loud. The run is green, so the summary is the only place
+      # that says this build is not on Play yet.
+      - name: Say that the Play upload was skipped on purpose
+        if: ${{ inputs.skip_play_upload }}
         run: |
-          echo "::notice::PLAY_SERVICE_ACCOUNT_JSON is not set, so the Play upload was skipped." \
-               "Download the .aab from this run's GitHub release and upload it in the Play Console" \
-               "(Testing → Internal testing). See android/RELEASING.md → \"Play service account\"."
+          {
+            echo "## Play upload skipped"
+            echo
+            echo "This run was started with \`skip_play_upload=true\`, so the bundle is **not** on Play."
+            echo "Download \`app-release.aab\` from the GitHub release and upload it in the Play Console"
+            echo "(Testing → Internal testing). Every later release should go through the API —"
+            echo "see \`android/RELEASING.md\` → \"Play service account\"."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning title=Not published to Play::skip_play_upload was set; upload the .aab by hand."
 
       - name: Remove the upload keystore
         if: always()

--- a/android/RELEASING.md
+++ b/android/RELEASING.md
@@ -17,7 +17,7 @@ commands):
 | `PLAY_UPLOAD_KEYSTORE_PASSWORD`   | signing the bundle       | **set**                         |
 | `PLAY_UPLOAD_KEY_ALIAS`           | signing the bundle       | **set** — `parley-upload`       |
 | `PLAY_UPLOAD_KEY_PASSWORD`        | signing the bundle       | **set**                         |
-| `PLAY_SERVICE_ACCOUNT_JSON`       | uploading to Play        | blocked on verification (§7)    |
+| `PLAY_SERVICE_ACCOUNT_JSON`       | uploading to Play        | **required, not yet set** (§7)  |
 
 The upload keystore itself is not in this repo and never will be. It lives in
 Pathors' private secret store alongside the Apple signing keys, together with a
@@ -36,10 +36,10 @@ listing (see §2).
   D-U-N-S number and verification (company registration docs, ~1–2 weeks).
 - Developer name shown on the store: `Pathors`.
 - **Status**: the Pathors account exists — developer account ID
-  **`6541030546953107772`** — and is **pending organization identity
-  verification**. Until that clears, the Play Developer API cannot be enabled,
-  which means no service account and therefore no automated upload
-  (see §7 below). Everything else on this page can be set up now.
+  **`6541030546953107772`** — and organization identity verification **cleared
+  on 2026-08-17**, along with the app itself (`com.pathors.parley`, app ID
+  `4972589806984548870`). The Play Developer API is therefore no longer blocked;
+  §7 is simply outstanding work.
 
 ### 2. Signing setup
 
@@ -170,44 +170,53 @@ Recommended path for the first release:
    through full review (typically 1–7 days; first-ever review of a new
    developer account can take longer).
 
-### 7. Play service account (blocked on identity verification)
+### 7. Play service account (outstanding — the last piece)
 
-This is the only piece that cannot be done yet. The Play Developer API is gated
-behind a verified account, so the service account below can only be created once
-account `6541030546953107772` clears identity verification. The release workflow
-already knows this: its Play upload step skips itself while
-`PLAY_SERVICE_ACCOUNT_JSON` is unset, so nothing needs changing in CI when the
-secret finally appears.
+Identity verification cleared on 2026-08-17, so nothing external blocks this any
+more; it is the one remaining step between pushing a tag and the build appearing
+on Play.
 
-When verification clears:
+**`android-release.yml` fails when `PLAY_SERVICE_ACCOUNT_JSON` is missing.** It
+used to skip the upload silently, which was defensible while the API was
+genuinely unreachable and is not any more: a release run that reports success
+without publishing anything is the worst kind of green — the tag is used up, the
+GitHub release exists, and nobody finds out until someone asks where the build
+went. The single case that legitimately cannot use the API is the *first* bundle
+for a package (below), and that is an explicit `skip_play_upload=true` on a
+manual run rather than something a missing secret decides.
 
-1. Play Console → **Setup → API access**.
-2. **Link a Google Cloud project** — create a fresh one (e.g. `pathors-play`)
-   rather than reusing an app's project; a Play account links exactly one
-   project and moving it later is a pain.
-3. **Create service account** → this bounces to the Cloud Console IAM page.
-   Name it `parley-play-publisher`, no project-level roles needed, then
-   **Keys → Add key → Create new key → JSON** and download it.
-4. Back in Play Console → API access the account appears under *Service
-   accounts*. **Grant access** → give it the **Release manager** role (upload
-   and release to testing tracks and production, but no access to payments or
-   account settings), restrict it to the Parley app under *App permissions*,
-   then **Invite user**.
-5. Push the JSON into GitHub and delete the local copy:
+The Cloud side is scripted; the Play Console side cannot be, because linking a
+Cloud project to a Play account is what *enables* the Play Developer API and so
+cannot go through the API it enables.
 
-   ```bash
-   gh secret set PLAY_SERVICE_ACCOUNT_JSON < ~/Downloads/pathors-play-*.json
-   rm ~/Downloads/pathors-play-*.json
-   ```
+```bash
+gcloud auth login          # as contact@pathors.com, the Play account owner
+./android/scripts/create-play-service-account.sh
+```
 
-6. Permissions take a few minutes to a few hours to propagate on a fresh
-   account. A `403 The caller does not have permission` on the first run is
-   usually just that, not a misconfiguration.
+That creates the `pathors-play` project, enables `androidpublisher`, creates the
+`parley-play-publisher` service account with **no** project-level IAM roles
+(everything it may do is granted in the Play Console instead), mints a JSON key,
+sets `PLAY_SERVICE_ACCOUNT_JSON` on the repo, files the key in patchbay, and
+deletes the local copy. It is idempotent — re-running reuses the project and the
+account and only mints a fresh key — and it prints the two remaining steps:
 
-Note that the **first** bundle for a package cannot go through the API — Play
-refuses until the app has a release created in the console. So the very first
-internal-track release is a manual upload regardless; automation takes over from
-the second one.
+1. Play Console → **Setup → API access** → link the Cloud project `pathors-play`.
+   A Play account links exactly one project and moving it later is a pain, which
+   is why the script makes a dedicated one rather than reusing an app's.
+2. Same page, under *Service accounts*, **Grant access** → **Release manager**
+   (upload and release to testing tracks and production, but no access to
+   payments or account settings) → restrict to Parley under *App permissions* →
+   **Invite user**.
+
+Permissions take minutes to hours to propagate on a fresh account. A
+`403 The caller does not have permission` on the first run is usually just that,
+not a misconfiguration.
+
+**The first bundle for a package cannot go through the API at all** — Play
+refuses until the app has a release created in the console. Run the workflow
+with `skip_play_upload=true`, upload that `.aab` by hand once, and every release
+after it goes through the API.
 
 ### 8. Dependency verification
 
@@ -255,9 +264,11 @@ are easy to get wrong:
 
    `.github/workflows/android-release.yml` runs the tests, builds and signs the
    bundle with the upload key, attaches the `.aab` to a GitHub Release, and
-   uploads it to the Play **internal** track — that last step skipping itself
-   until `PLAY_SERVICE_ACCOUNT_JSON` exists (§7). `workflow_dispatch` re-runs an
-   existing tag without needing a new commit, matching `ios-release.yml`.
+   uploads it to the Play **internal** track. Without
+   `PLAY_SERVICE_ACCOUNT_JSON` the run **fails** rather than publishing a
+   half-release (§7). `workflow_dispatch` re-runs an existing tag without
+   needing a new commit, matching `ios-release.yml`, and takes a
+   `skip_play_upload` input for the first-bundle case.
 3. To build the bundle by hand instead (Play requires `.aab`, not `.apk`):
 
    ```bash
@@ -274,9 +285,11 @@ are easy to get wrong:
    ```
 
    Verify: sign-in deep link, live meeting, file import, upload queue drain.
-5. While the Play upload is still manual: Play Console → Release → (track) →
-   Create new release → upload the `.aab` from the GitHub release, release notes
-   (en + zh-TW), review, roll out.
+5. **The first bundle only.** Play refuses a package's first bundle over the
+   API, so run the workflow manually with `skip_play_upload=true`, then
+   Play Console → Release → (track) → Create new release → upload the `.aab`
+   from the GitHub release, release notes (en + zh-TW), review, roll out. Every
+   release after that goes through the API and needs no console step.
 6. Keep the R8 `mapping.txt`. Every workflow run attaches it as an artifact and
    the Play upload step sends it along, so crash reports deobfuscate; a stack
    trace from a build whose mapping was lost is unreadable.

--- a/android/scripts/create-play-service-account.sh
+++ b/android/scripts/create-play-service-account.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Create the Google Cloud half of Play publishing and push the key into GitHub,
+# so `android-release.yml` can upload to Play (RELEASING.md §7).
+#
+# What this does NOT do, because there is no API for it: linking the Cloud
+# project to the Play developer account, and granting the service account the
+# Release manager role. Linking is what *enables* the Play Developer API, so it
+# cannot itself go through that API — it is Play Console web UI, by hand, and
+# the script prints the exact steps when it finishes.
+#
+# Idempotent: re-running reuses an existing project and service account, and
+# only ever mints a fresh key.
+#
+#   ./android/scripts/create-play-service-account.sh
+#
+set -euo pipefail
+
+PROJECT_ID="${PLAY_PROJECT_ID:-pathors-play}"
+SA_NAME="parley-play-publisher"
+REPO="${PLAY_SECRET_REPO:-pathorsAI/parley}"
+# The Play Console owner. A key minted from any other identity still works, but
+# a project owned by a personal account is a bus factor of one.
+WANT_ACCOUNT="${PLAY_GCLOUD_ACCOUNT:-contact@pathors.com}"
+
+die() { echo "error: $*" >&2; exit 1; }
+step() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+
+command -v gcloud >/dev/null || die "gcloud is not installed"
+command -v gh >/dev/null || die "gh is not installed"
+
+step "Checking the gcloud login"
+ACCOUNT="$(gcloud config get-value account 2>/dev/null || true)"
+[ -n "$ACCOUNT" ] && [ "$ACCOUNT" != "(unset)" ] || die "no active gcloud account — run: gcloud auth login"
+# Tokens expire silently; the only honest check is a call that needs one.
+gcloud projects list --limit=1 >/dev/null 2>&1 \
+  || die "the gcloud token for $ACCOUNT is stale — run: gcloud auth login"
+if [ "$ACCOUNT" != "$WANT_ACCOUNT" ]; then
+  echo "warning: active account is $ACCOUNT, not the Play owner $WANT_ACCOUNT."
+  echo "         Continue only if that account can create projects for Pathors."
+  read -r -p "         Continue? [y/N] " reply
+  [ "$reply" = "y" ] || exit 1
+fi
+echo "using $ACCOUNT"
+
+step "Project $PROJECT_ID"
+if gcloud projects describe "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "already exists — reusing"
+else
+  # A Play account links exactly one Cloud project and moving it later is
+  # painful, so this is deliberately a dedicated project, not an app's.
+  gcloud projects create "$PROJECT_ID" --name="Pathors Play publishing" \
+    || die "could not create $PROJECT_ID (the id may be taken globally — set PLAY_PROJECT_ID and retry)"
+fi
+
+step "Enabling the Play Developer API"
+# Only works once the project is linked in the Play Console. Say so plainly
+# rather than dying, since everything below still needs doing.
+if gcloud services enable androidpublisher.googleapis.com --project="$PROJECT_ID" 2>/dev/null; then
+  echo "androidpublisher.googleapis.com enabled"
+else
+  echo "could not enable it yet — this usually means the project is not linked"
+  echo "in the Play Console yet (manual step 1 below). Re-run this script after"
+  echo "linking, or enable it from the Cloud Console."
+fi
+
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+step "Service account $SA_EMAIL"
+if gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  echo "already exists — reusing"
+else
+  # No project-level IAM roles on purpose: everything this identity may do is
+  # granted in the Play Console, not in Cloud IAM.
+  gcloud iam service-accounts create "$SA_NAME" --project="$PROJECT_ID" \
+    --display-name="Parley Play publisher"
+fi
+
+step "Minting a JSON key"
+KEYFILE="$(mktemp -t play-sa-XXXXXX.json)"
+chmod 600 "$KEYFILE"
+# The key is the whole credential; keep it off disk for as long as possible and
+# never inside the repo.
+trap 'rm -f "$KEYFILE"' EXIT
+gcloud iam service-accounts keys create "$KEYFILE" \
+  --iam-account="$SA_EMAIL" --project="$PROJECT_ID"
+
+step "Setting PLAY_SERVICE_ACCOUNT_JSON on $REPO"
+gh secret set PLAY_SERVICE_ACCOUNT_JSON --repo "$REPO" < "$KEYFILE"
+echo "set"
+
+if command -v pb >/dev/null; then
+  step "Filing the key in patchbay"
+  pb key store google-play-service-account-parley \
+    --label "Google Play publisher SA — Parley ($SA_EMAIL)" \
+    --purpose "Uploads app bundles to the Play internal track from android-release.yml; mirrors GitHub secret PLAY_SERVICE_ACCOUNT_JSON on $REPO" \
+    --value "$(cat "$KEYFILE")" --overwrite 2>/dev/null \
+    && echo "stored" \
+    || echo "skipped (store it by hand: pb key store google-play-service-account-parley)"
+fi
+
+cat <<MANUAL
+
+$(printf '\033[1m')Two steps left, and neither has an API.$(printf '\033[0m')
+
+1. Play Console → Setup → API access → link the Cloud project "$PROJECT_ID".
+   This is what turns the Play Developer API on; it cannot be done through the
+   API it enables. If the enable step above failed, re-run this script after.
+
+2. Same page, under Service accounts, "$SA_EMAIL"
+   appears → Grant access → role $(printf '\033[1m')Release manager$(printf '\033[0m') → App permissions: Parley
+   only → Invite user.
+
+Then check it end to end:
+
+   git tag android-v0.1.1 && git push origin android-v0.1.1
+
+A 403 "The caller does not have permission" on the first run is usually just
+permissions propagating on a fresh account — wait and re-run the workflow
+before assuming it is misconfigured.
+
+Remember the first bundle for the package cannot go through the API at all.
+If nothing has been uploaded to Play by hand yet, do that first — see
+android/RELEASING.md → "Play service account".
+MANUAL


### PR DESCRIPTION
## What this changes

`android-release.yml` now **fails** when it cannot reach Play, instead of skipping the upload and reporting success. Adds `android/scripts/create-play-service-account.sh` for the half of the setup that has an API.

## Why

The skip was conditioned on `PLAY_SERVICE_ACCOUNT_JSON` being unset, and that was defensible for exactly as long as the secret *could not* exist — the Play Developer API is gated behind a verified developer account, and `6541030546953107772` was pending verification when the workflow was written.

Verification cleared on **2026-08-17**. What is left is a release job that goes green without publishing:

> tag used up ✓ · GitHub release created ✓ · `.aab` signed and attached ✓ · **on Play ✗**

Nobody finds out until someone asks where the build went. `android-v0.1.0` is that run — green, and not on Play.

| | before | after |
|---|---|---|
| secret missing | upload skipped, run green | run **fails**, error names the fix |
| first bundle for the package (Play refuses over the API) | indistinguishable from the above | explicit `skip_play_upload=true` on a manual run |
| skipped run's visibility | one `::notice::` in the log | step-summary block + `::warning::` annotation |

Skipping is now something an operator asks for, not something a missing secret decides quietly.

`inputs.skip_play_upload` is null on a tag push, so `!inputs.skip_play_upload` is true there — tags always have to publish, and only `workflow_dispatch` can opt out.

## The script

`gcloud auth login` (as the Play account owner) then:

```bash
./android/scripts/create-play-service-account.sh
```

Creates the `pathors-play` project, enables `androidpublisher`, creates `parley-play-publisher` with **no project-level IAM roles** (everything it may do is granted in the Play Console instead), mints a JSON key, `gh secret set`s it, files it in patchbay, and deletes the local copy. Idempotent — re-running reuses the project and account and only mints a fresh key.

**Two steps have no API and the script prints them rather than pretending otherwise:** linking the Cloud project to the Play account is what *enables* the Play Developer API, so it cannot go through the API it enables, and the Release manager grant lives on the same Console page.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes
- [x] Workflow parses as YAML; `workflow_dispatch` inputs are `tag`, `skip_play_upload`
- [x] `bash -n` on the script, and ran it — it stops at the first gate (`the gcloud token for … is stale — run: gcloud auth login`), which is the current state of this machine's logins
- [ ] Ran the app — CI and tooling only
- [ ] Added or updated tests — n/a
- [ ] Added new user-facing strings — n/a

The upload path itself is still unproven, because the service account does not exist yet — that is the point of the error this PR adds.

## Docs

§7 and the secrets table said "blocked on verification", which has not been true since 2026-08-17.
