### PR TITLE
[fix] check Play reachability before building, not after publishing

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -76,6 +76,26 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
+      # Checked before anything is built, and before the GitHub release exists.
+      # A release workflow that reports success without publishing is worse than
+      # one that fails — the tag is used up, the release is half-made, and
+      # nobody finds out until someone asks where the build went. Failing here
+      # costs seconds and leaves nothing behind to clean up.
+      #
+      # Skipping is therefore something the operator asks for, not something a
+      # missing secret decides. `inputs` is null on a tag push, so
+      # `!inputs.skip_play_upload` is true there: a tag always has to publish.
+      - name: Check this release can reach Play
+        if: ${{ !inputs.skip_play_upload }}
+        run: |
+          if [ -z "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error title=PLAY_SERVICE_ACCOUNT_JSON is not set::This release cannot reach Play." \
+                 "Create the service account (android/RELEASING.md §7) and set the secret," \
+                 "or re-run this workflow with skip_play_upload=true if this is the first bundle" \
+                 "for the package, which Play refuses over the API until a release exists in the console."
+            exit 1
+          fi
+
       - name: Set up JDK 17
         uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
@@ -176,22 +196,6 @@ jobs:
       # after the organization account clears identity verification. Everything
       # above has already run by this point, so the bundle is on the GitHub
       # release either way and can be uploaded through the Play Console UI.
-      # A release workflow that reports success without publishing is worse
-      # than one that fails: the tag is gone, the GitHub release exists, and
-      # nothing is on Play — and nobody finds out until someone asks where the
-      # build went. Skipping is therefore something the operator asks for, not
-      # something a missing secret decides.
-      - name: Check the Play upload can happen
-        if: ${{ !inputs.skip_play_upload }}
-        run: |
-          if [ -z "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
-            echo "::error title=PLAY_SERVICE_ACCOUNT_JSON is not set::This release cannot reach Play." \
-                 "Create the service account (android/RELEASING.md §7) and set the secret," \
-                 "or re-run this workflow with skip_play_upload=true if this is the first bundle" \
-                 "for the package, which Play refuses over the API until a release exists in the console."
-            exit 1
-          fi
-
       - name: Upload to the Play internal track
         if: ${{ !inputs.skip_play_upload }}
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3


### PR DESCRIPTION
## What this changes

Moves the `PLAY_SERVICE_ACCOUNT_JSON` precondition from just-before-the-upload to just-after-checkout.

## Why

Follow-up to #276, fixing a placement mistake in it. The guard sat between **Create the GitHub release** and **Upload to the Play internal track** — the one position where it barely helps. By the time it fires:

- ~5 minutes of build have been spent
- the `.aab` is built and signed
- **a GitHub release for the tag already exists**

which is precisely the half-made state the guard exists to prevent. It just makes it red instead of green. A precondition belongs before the work it protects: it now runs immediately after checkout, fails in seconds, and leaves nothing behind to clean up or re-tag around.

No behaviour change otherwise — same condition, same message, same `skip_play_upload` opt-out.

## How it was verified

- [x] Workflow parses as YAML; step order is Checkout → **Check this release can reach Play** → JDK → SDK → tag check → Test → build → …
- [x] `bunx tsc --noEmit` / `bunx vitest run` pass
- [ ] Ran the app — CI only
- [ ] Tests / strings — n/a