### PR TITLE
[docs] drop the comment describing the skip that no longer happens

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -191,11 +191,9 @@ jobs:
           fail_on_unmatched_files: true
 
       # ── Play internal track ────────────────────────────────────────────────
-      # Skipped, silently and successfully, until PLAY_SERVICE_ACCOUNT_JSON
-      # exists. It cannot exist yet: the Play Developer API can only be enabled
-      # after the organization account clears identity verification. Everything
-      # above has already run by this point, so the bundle is on the GitHub
-      # release either way and can be uploaded through the Play Console UI.
+      # Reaching here means the precondition at the top of the job passed, so
+      # either the secret exists or the operator asked to skip. The mapping.txt
+      # rides along so Play can deobfuscate crash reports from this build.
       - name: Upload to the Play internal track
         if: ${{ !inputs.skip_play_upload }}
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3


### PR DESCRIPTION
Follow-up to #276/#277. The banner comment above the Play upload step survived those edits and still described the old behaviour — "skipped, silently and successfully, until `PLAY_SERVICE_ACCOUNT_JSON` exists… it cannot exist yet". Verification cleared on 2026-08-17 and the skip is now a hard precondition at the top of the job, so the comment said the opposite of the code, in the place someone debugging a failed release reads first.

Comment only; workflow parses as YAML and no step changed.