### PR TITLE
[feature] Play publishing authenticates keylessly, with no credential at rest

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -15,12 +15,18 @@ name: Android Release
 #
 # The final Play upload step is deliberately skippable. Pathors' Play account
 # (ID 6541030546953107772) is still going through organization identity
-# verification. That has since cleared, so a missing `PLAY_SERVICE_ACCOUNT_JSON`
-# is now a misconfiguration and fails the run rather than quietly skipping the
-# upload — a release that reports success without publishing is the worst kind
-# of green. The one genuinely manual case, the first bundle for a package
-# (Play refuses it over the API), is served by the `skip_play_upload` input,
-# which has to be asked for.
+# verification. That has since cleared, and the upload now authenticates through
+# Workload Identity Federation rather than a service-account key: the pathors.com
+# organization enforces `iam.disableServiceAccountKeyCreation`, so no JSON key
+# can be minted, and punching a project-level hole in that policy to store a
+# long-lived Play-publishing credential in a secret is the wrong trade when
+# GitHub's OIDC token does the job with nothing at rest.
+#
+# A misconfiguration fails the run rather than quietly skipping the upload — a
+# release that reports success without publishing is the worst kind of green.
+# The one genuinely manual case, the first bundle for a package (Play refuses it
+# over the API), is served by the `skip_play_upload` input, which has to be
+# asked for.
 #
 # Runs on Linux (unlike the two macOS release workflows) because nothing here
 # needs Xcode. That only works because gradle/verification-metadata.xml carries
@@ -47,9 +53,11 @@ on:
         default: false
         type: boolean
 
-# The bundle is attached to a GitHub Release.
+# `contents` attaches the bundle to a GitHub Release; `id-token` mints the OIDC
+# token that Google exchanges for a short-lived credential.
 permissions:
   contents: write
+  id-token: write
 
 # Play rejects a bundle whose versionCode it has already seen, so two runs of
 # the same tag racing each other end in a confusing error, not a merge conflict.
@@ -68,7 +76,8 @@ jobs:
     # itself while the service account does not yet exist.
     env:
       PLAY_UPLOAD_KEYSTORE_BASE64: ${{ secrets.PLAY_UPLOAD_KEYSTORE_BASE64 }}
-      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+      PLAY_WIF_PROVIDER: ${{ vars.PLAY_WIF_PROVIDER }}
+      PLAY_PUBLISHER_SERVICE_ACCOUNT: ${{ vars.PLAY_PUBLISHER_SERVICE_ACCOUNT }}
 
     steps:
       - name: Checkout
@@ -88,11 +97,11 @@ jobs:
       - name: Check this release can reach Play
         if: ${{ !inputs.skip_play_upload }}
         run: |
-          if [ -z "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
-            echo "::error title=PLAY_SERVICE_ACCOUNT_JSON is not set::This release cannot reach Play." \
-                 "Create the service account (android/RELEASING.md §7) and set the secret," \
-                 "or re-run this workflow with skip_play_upload=true if this is the first bundle" \
-                 "for the package, which Play refuses over the API until a release exists in the console."
+          if [ -z "$PLAY_WIF_PROVIDER" ] || [ -z "$PLAY_PUBLISHER_SERVICE_ACCOUNT" ]; then
+            echo "::error title=Play publishing is not configured::This release cannot reach Play." \
+                 "The repository variables PLAY_WIF_PROVIDER and PLAY_PUBLISHER_SERVICE_ACCOUNT must both be set" \
+                 "(android/RELEASING.md §7), or re-run this workflow with skip_play_upload=true if this is the" \
+                 "first bundle for the package, which Play refuses over the API until a release exists in the console."
             exit 1
           fi
 
@@ -192,13 +201,28 @@ jobs:
 
       # ── Play internal track ────────────────────────────────────────────────
       # Reaching here means the precondition at the top of the job passed, so
-      # either the secret exists or the operator asked to skip. The mapping.txt
-      # rides along so Play can deobfuscate crash reports from this build.
+      # either Play publishing is configured or the operator asked to skip. The
+      # mapping.txt rides along so Play can deobfuscate crash reports.
+      # Keyless. The OIDC token is minted for this run, exchanged for a
+      # credential that impersonates the publisher service account, and expires
+      # on its own; nothing long-lived exists to leak. The trust runs one way
+      # and is narrow — only `pathorsAI/parley` is bound to that account.
+      - name: Authenticate to Google
+        id: play_auth
+        if: ${{ !inputs.skip_play_upload }}
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.PLAY_WIF_PROVIDER }}
+          service_account: ${{ vars.PLAY_PUBLISHER_SERVICE_ACCOUNT }}
+
       - name: Upload to the Play internal track
         if: ${{ !inputs.skip_play_upload }}
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
         with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          # The action only points GOOGLE_APPLICATION_CREDENTIALS at this file
+          # and lets the Google auth library resolve it, so the external-account
+          # credentials written above work exactly like a key would.
+          serviceAccountJson: ${{ steps.play_auth.outputs.credentials_file_path }}
           packageName: com.pathors.parley
           releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
           mappingFile: android/app/build/outputs/mapping/release/mapping.txt

--- a/android/RELEASING.md
+++ b/android/RELEASING.md
@@ -17,7 +17,12 @@ commands):
 | `PLAY_UPLOAD_KEYSTORE_PASSWORD`   | signing the bundle       | **set**                         |
 | `PLAY_UPLOAD_KEY_ALIAS`           | signing the bundle       | **set** — `parley-upload`       |
 | `PLAY_UPLOAD_KEY_PASSWORD`        | signing the bundle       | **set**                         |
-| `PLAY_SERVICE_ACCOUNT_JSON`       | uploading to Play        | **required, not yet set** (§7)  |
+| _(no secret)_                     | uploading to Play        | keyless via WIF — **set** (§7)  |
+
+Play publishing carries no secret at all. It authenticates with GitHub's OIDC
+token through Workload Identity Federation, configured by two repository
+*variables* (not secrets — they identify, they do not authorize):
+`PLAY_WIF_PROVIDER` and `PLAY_PUBLISHER_SERVICE_ACCOUNT`.
 
 The upload keystore itself is not in this repo and never will be. It lives in
 Pathors' private secret store alongside the Apple signing keys, together with a
@@ -170,44 +175,68 @@ Recommended path for the first release:
    through full review (typically 1–7 days; first-ever review of a new
    developer account can take longer).
 
-### 7. Play service account (outstanding — the last piece)
+### 7. Play publishing (keyless, via Workload Identity Federation)
 
-Identity verification cleared on 2026-08-17, so nothing external blocks this any
-more; it is the one remaining step between pushing a tag and the build appearing
-on Play.
+Identity verification cleared on 2026-08-17 and the Google Cloud side is **done**
+(2026-08-20). What is left is two clicks in the Play Console that have no API —
+see the end of this section.
 
-**`android-release.yml` fails when `PLAY_SERVICE_ACCOUNT_JSON` is missing.** It
-used to skip the upload silently, which was defensible while the API was
-genuinely unreachable and is not any more: a release run that reports success
-without publishing anything is the worst kind of green — the tag is used up, the
-GitHub release exists, and nobody finds out until someone asks where the build
-went. The single case that legitimately cannot use the API is the *first* bundle
-for a package (below), and that is an explicit `skip_play_upload=true` on a
-manual run rather than something a missing secret decides.
+**There is no service-account key, and there will not be one.** The `pathors.com`
+organization enforces `iam.disableServiceAccountKeyCreation`, so
+`gcloud iam service-accounts keys create` fails with
+`FAILED_PRECONDITION: Key creation is not allowed on this service account`. That
+policy is Google's default for new organizations and it is a good one: a Play
+publishing key sitting in a GitHub secret is a long-lived credential that can
+ship code to users. Rather than granting the project an exception, the release
+authenticates with the OIDC token GitHub mints for each run, which Google
+exchanges for a credential that expires on its own.
 
-The Cloud side is scripted; the Play Console side cannot be, because linking a
-Cloud project to a Play account is what *enables* the Play Developer API and so
-cannot go through the API it enables.
+What exists in Google Cloud:
+
+| | |
+| --- | --- |
+| project | `pathors-play` (474482934105) — dedicated; a Play account links exactly one project and moving it later is a pain |
+| API | `androidpublisher`, plus `sts` and `iamcredentials` for the exchange |
+| service account | `parley-play-publisher@pathors-play.iam.gserviceaccount.com`, **no project-level IAM roles** — everything it may do is granted in the Play Console |
+| pool / provider | `github` / `pathorsai`, issuer `token.actions.githubusercontent.com`, attribute condition `assertion.repository_owner=='pathorsAI'` |
+| impersonation | `roles/iam.workloadIdentityUser` for `attribute.repository/pathorsAI/parley` — that repository and no other |
+
+and in GitHub, as repository variables rather than secrets, because neither
+value authorizes anything on its own:
+
+```
+PLAY_WIF_PROVIDER              projects/474482934105/locations/global/workloadIdentityPools/github/providers/pathorsai
+PLAY_PUBLISHER_SERVICE_ACCOUNT parley-play-publisher@pathors-play.iam.gserviceaccount.com
+```
+
+To rebuild all of that from nothing — after `gcloud auth login` as the Play
+account owner:
 
 ```bash
-gcloud auth login          # as contact@pathors.com, the Play account owner
 ./android/scripts/create-play-service-account.sh
 ```
 
-That creates the `pathors-play` project, enables `androidpublisher`, creates the
-`parley-play-publisher` service account with **no** project-level IAM roles
-(everything it may do is granted in the Play Console instead), mints a JSON key,
-sets `PLAY_SERVICE_ACCOUNT_JSON` on the repo, files the key in patchbay, and
-deletes the local copy. It is idempotent — re-running reuses the project and the
-account and only mints a fresh key — and it prints the two remaining steps:
+It is idempotent, so it is also the way to repair a piece of it.
+
+**`android-release.yml` fails when Play publishing is not configured.** It used
+to skip the upload silently, which was defensible while the Play API was
+genuinely unreachable and is not any more: a release run that reports success
+without publishing is the worst kind of green — the tag is used up, the GitHub
+release exists, and nobody finds out until someone asks where the build went.
+The check runs immediately after checkout, so a misconfigured release costs
+seconds and leaves no half-made release behind.
+
+#### The two steps with no API
+
+Linking a Cloud project to a Play account is what *enables* the Play Developer
+API, so it cannot go through the API it enables.
 
 1. Play Console → **Setup → API access** → link the Cloud project `pathors-play`.
-   A Play account links exactly one project and moving it later is a pain, which
-   is why the script makes a dedicated one rather than reusing an app's.
-2. Same page, under *Service accounts*, **Grant access** → **Release manager**
-   (upload and release to testing tracks and production, but no access to
-   payments or account settings) → restrict to Parley under *App permissions* →
-   **Invite user**.
+2. Same page, under *Service accounts*,
+   `parley-play-publisher@pathors-play.iam.gserviceaccount.com` appears →
+   **Grant access** → **Release manager** (upload and release to testing tracks
+   and production, but no access to payments or account settings) → restrict to
+   Parley under *App permissions* → **Invite user**.
 
 Permissions take minutes to hours to propagate on a fresh account. A
 `403 The caller does not have permission` on the first run is usually just that,
@@ -264,9 +293,8 @@ are easy to get wrong:
 
    `.github/workflows/android-release.yml` runs the tests, builds and signs the
    bundle with the upload key, attaches the `.aab` to a GitHub Release, and
-   uploads it to the Play **internal** track. Without
-   `PLAY_SERVICE_ACCOUNT_JSON` the run **fails** rather than publishing a
-   half-release (§7). `workflow_dispatch` re-runs an existing tag without
+   uploads it to the Play **internal** track. When Play publishing is not
+   configured the run **fails** rather than publishing a half-release (§7). `workflow_dispatch` re-runs an existing tag without
    needing a new commit, matching `ios-release.yml`, and takes a
    `skip_play_upload` input for the first-bundle case.
 3. To build the bundle by hand instead (Play requires `.aab`, not `.apk`):

--- a/android/scripts/create-play-service-account.sh
+++ b/android/scripts/create-play-service-account.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 #
-# Create the Google Cloud half of Play publishing and push the key into GitHub,
-# so `android-release.yml` can upload to Play (RELEASING.md §7).
+# Create the Google Cloud half of Play publishing — keyless — so
+# `android-release.yml` can upload to Play (RELEASING.md §7).
+#
+# No service-account key is minted. The pathors.com organization enforces
+# iam.disableServiceAccountKeyCreation, and that is the right default: a Play
+# publishing key in a GitHub secret is a long-lived credential that can ship
+# code to users. Instead this wires Workload Identity Federation, so each run
+# exchanges GitHub's own OIDC token for a credential that expires by itself.
 #
 # What this does NOT do, because there is no API for it: linking the Cloud
 # project to the Play developer account, and granting the service account the
@@ -9,8 +15,8 @@
 # cannot itself go through that API — it is Play Console web UI, by hand, and
 # the script prints the exact steps when it finishes.
 #
-# Idempotent: re-running reuses an existing project and service account, and
-# only ever mints a fresh key.
+# Idempotent: re-running reuses whatever already exists, so it is also the way
+# to repair one piece of the setup.
 #
 #   ./android/scripts/create-play-service-account.sh
 #
@@ -18,6 +24,8 @@ set -euo pipefail
 
 PROJECT_ID="${PLAY_PROJECT_ID:-pathors-play}"
 SA_NAME="parley-play-publisher"
+POOL="github"
+PROVIDER="pathorsai"
 REPO="${PLAY_SECRET_REPO:-pathorsAI/parley}"
 # The Play Console owner. A key minted from any other identity still works, but
 # a project owned by a personal account is a bus factor of one.
@@ -76,28 +84,54 @@ else
     --display-name="Parley Play publisher"
 fi
 
-step "Minting a JSON key"
-KEYFILE="$(mktemp -t play-sa-XXXXXX.json)"
-chmod 600 "$KEYFILE"
-# The key is the whole credential; keep it off disk for as long as possible and
-# never inside the repo.
-trap 'rm -f "$KEYFILE"' EXIT
-gcloud iam service-accounts keys create "$KEYFILE" \
-  --iam-account="$SA_EMAIL" --project="$PROJECT_ID"
+step "Workload Identity Federation for GitHub Actions"
+# No key is minted, and none can be: the pathors.com organization enforces
+# iam.disableServiceAccountKeyCreation. That is the right default — a Play
+# publishing key in a GitHub secret is a long-lived credential that can ship
+# code to users — so the release authenticates with the OIDC token GitHub mints
+# per run instead, and nothing is left at rest.
+gcloud services enable sts.googleapis.com iamcredentials.googleapis.com --project="$PROJECT_ID"
 
-step "Setting PLAY_SERVICE_ACCOUNT_JSON on $REPO"
-gh secret set PLAY_SERVICE_ACCOUNT_JSON --repo "$REPO" < "$KEYFILE"
-echo "set"
-
-if command -v pb >/dev/null; then
-  step "Filing the key in patchbay"
-  pb key store google-play-service-account-parley \
-    --label "Google Play publisher SA — Parley ($SA_EMAIL)" \
-    --purpose "Uploads app bundles to the Play internal track from android-release.yml; mirrors GitHub secret PLAY_SERVICE_ACCOUNT_JSON on $REPO" \
-    --value "$(cat "$KEYFILE")" --overwrite 2>/dev/null \
-    && echo "stored" \
-    || echo "skipped (store it by hand: pb key store google-play-service-account-parley)"
+if gcloud iam workload-identity-pools describe "$POOL" \
+     --project="$PROJECT_ID" --location=global >/dev/null 2>&1; then
+  echo "pool $POOL already exists — reusing"
+else
+  gcloud iam workload-identity-pools create "$POOL" --project="$PROJECT_ID" \
+    --location=global --display-name="GitHub Actions"
 fi
+
+if gcloud iam workload-identity-pools providers describe "$PROVIDER" \
+     --project="$PROJECT_ID" --location=global --workload-identity-pool="$POOL" >/dev/null 2>&1; then
+  echo "provider $PROVIDER already exists — reusing"
+else
+  # The attribute condition is the outer fence: without it any GitHub repository
+  # in the world can present a token to this provider.
+  gcloud iam workload-identity-pools providers create-oidc "$PROVIDER" \
+    --project="$PROJECT_ID" --location=global --workload-identity-pool="$POOL" \
+    --display-name="pathorsAI repos" \
+    --issuer-uri="https://token.actions.githubusercontent.com" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+    --attribute-condition="assertion.repository_owner=='${REPO%%/*}'"
+fi
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+WIF_PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}/providers/${PROVIDER}"
+
+step "Letting $REPO — and only $REPO — impersonate the publisher"
+# The inner fence. The provider trusts the whole org; this trusts one repo.
+gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" --project="$PROJECT_ID" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}/attribute.repository/${REPO}" \
+  >/dev/null
+echo "bound"
+
+step "Publishing the config to $REPO"
+# Variables, not secrets: neither value authorizes anything on its own, and
+# reading them out of the workflow logs is how you debug a failed release.
+gh variable set PLAY_WIF_PROVIDER --repo "$REPO" --body "$WIF_PROVIDER"
+gh variable set PLAY_PUBLISHER_SERVICE_ACCOUNT --repo "$REPO" --body "$SA_EMAIL"
+echo "PLAY_WIF_PROVIDER              $WIF_PROVIDER"
+echo "PLAY_PUBLISHER_SERVICE_ACCOUNT $SA_EMAIL"
 
 cat <<MANUAL
 
@@ -121,5 +155,5 @@ before assuming it is misconfigured.
 
 Remember the first bundle for the package cannot go through the API at all.
 If nothing has been uploaded to Play by hand yet, do that first — see
-android/RELEASING.md → "Play service account".
+android/RELEASING.md → "Play publishing".
 MANUAL


### PR DESCRIPTION
## What this changes

Play publishing authenticates through **Workload Identity Federation** instead of a service-account key. There is no `PLAY_SERVICE_ACCOUNT_JSON` secret, and there will not be one.

## Why

Setting the service account up hit a wall the plan in #276 did not account for:

```
FAILED_PRECONDITION: Key creation is not allowed on this service account
constraints/iam.disableServiceAccountKeyCreation
```

The `pathors.com` organization enforces that constraint. It is Google's default for new organizations, and it is a good one — a Play publishing key is a long-lived credential that can ship code to users, and the plan was to park exactly that in a GitHub secret.

Granting the project an exception would have meant overriding the org's own security decision in order to arrive somewhere strictly worse. WIF gets to the same place with nothing at rest: GitHub mints an OIDC token per run, Google exchanges it for a credential that impersonates the publisher account and expires on its own.

This works because `r0adkll/upload-google-play` never parses the credential — it only points `GOOGLE_APPLICATION_CREDENTIALS` at a file and lets the Google auth library resolve it ([`main.ts`](https://github.com/r0adkll/upload-google-play/blob/935ef9c68bb393a8e6116b1575626a7f5be3a7fb/src/main.ts#L101-L119)), so external-account credentials drop in exactly where a key used to.

| | key in a secret | WIF |
| --- | --- | --- |
| credential at rest | yes, indefinitely | none |
| org policy | needs an exception | satisfied as-is |
| rotation | manual, forever | per run |
| blast radius if the repo is compromised | key exfiltrates | token expires, and only from this repo |

## What was provisioned

Done and verified on 2026-08-20, by the script in this PR:

| | |
| --- | --- |
| project | `pathors-play` (474482934105) — dedicated, because a Play account links exactly one project and moving it later is painful |
| APIs | `androidpublisher`, `sts`, `iamcredentials` |
| service account | `parley-play-publisher@pathors-play.iam.gserviceaccount.com`, **no project-level IAM roles** — everything it may do is granted in the Play Console |
| pool / provider | `github` / `pathorsai`, issuer `token.actions.githubusercontent.com` |
| fence 1 | provider attribute condition `assertion.repository_owner=='pathorsAI'` |
| fence 2 | `roles/iam.workloadIdentityUser` for `attribute.repository/pathorsAI/parley` — that repository and no other |

Two fences because they answer different questions. Without the first, **any** repository on GitHub can present a token to the provider.

Config lands in repository **variables**, not secrets — neither value authorizes anything alone, and reading them out of a failed run's log is how you debug it:

```
PLAY_WIF_PROVIDER              projects/474482934105/locations/global/workloadIdentityPools/github/providers/pathorsai
PLAY_PUBLISHER_SERVICE_ACCOUNT parley-play-publisher@pathors-play.iam.gserviceaccount.com
```

## How it was verified

- [x] Ran `./android/scripts/create-play-service-account.sh` — it created all of the above against the live project
- [x] Ran it **twice more**: reuses project, service account, pool and provider; re-binds and re-publishes the variables. Idempotent, so it is also the repair path
- [x] `gh variable list` shows both variables set
- [x] Resolved `google-github-actions/auth` v3.0.0's SHA from the GitHub API rather than from memory, and confirmed v3 still exposes `credentials_file_path`
- [x] Workflow parses as YAML; `permissions` is `contents: write` + `id-token: write`
- [x] `bunx tsc --noEmit`, `bunx vitest run`
- [ ] The upload itself — **cannot be tested until the two Play Console steps below are done.** No API exists for them.

## The two steps left, which have no API

Linking a Cloud project to a Play account is what *enables* the Play Developer API, so it cannot go through the API it enables.

1. Play Console → **Setup → API access** → link the Cloud project `pathors-play`.
2. Same page → *Service accounts* → `parley-play-publisher@pathors-play.iam.gserviceaccount.com` → **Grant access** → **Release manager** → restrict to Parley under *App permissions* → **Invite user**.

Then `android-v0.1.1` proves the whole path. Note the **first** bundle for the package still has to be uploaded by hand (`skip_play_upload=true`) — Play refuses a package's first bundle over the API regardless of how it authenticates.
