### PR TITLE
[fix] iOS dictation: the mic permission prompt survives the hand-off, and recent foregrounding buys a no-jump start

### DIFF
--- a/ios/App/Parley/AudioCapture.swift
+++ b/ios/App/Parley/AudioCapture.swift
@@ -108,6 +108,14 @@ final class AudioCapture: @unchecked Sendable {
         await AVAudioApplication.requestRecordPermission()
     }
 
+    /// The standing grant, read without ever prompting. Callers that may be in
+    /// the background need this: `requestPermission()` on an undetermined grant
+    /// can only show its prompt from a foreground app — from the background it
+    /// fails as if the user had said no, without the user ever being asked.
+    static var permission: AVAudioApplication.recordPermission {
+        AVAudioApplication.shared.recordPermission
+    }
+
     /// Configure the session and open the microphone.
     ///
     /// `async` rather than `throws` alone because the work underneath is

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -31,6 +31,12 @@ final class DictationCoordinator: ObservableObject {
     /// this iOS still allows the jump (see `HostReturn`). `nil` → show the
     /// manual "swipe to go back" guidance instead.
     @Published private(set) var returnableHost: String?
+    /// The system microphone prompt is up. The dictation screen must not say
+    /// "swipe back to your app" while it shows: obeying that guidance
+    /// backgrounds the app, which cancels the prompt as a refusal — the loop
+    /// that ended with users told to visit Settings for a permission they were
+    /// never actually asked for.
+    @Published private(set) var awaitingMicPermission = false
 
     private var session = ""
     private var capture: AudioCapture?
@@ -40,10 +46,14 @@ final class DictationCoordinator: ObservableObject {
     /// requests for the running session, and — the no-jump path — start
     /// requests from a keyboard while this process is awake in the background.
     private var requestObserver: DarwinObserver?
-    /// Keeps the process awake ~30 s after a session ends so an immediate
-    /// re-tap of the keyboard's mic starts over the Darwin channel with no
-    /// app switch. `.invalid` when no window is open.
+    /// Keeps the process awake ~30 s after a session ends — and after any trip
+    /// to the background (see `armLifecycleLinger`) — so the keyboard's next
+    /// mic tap starts over the Darwin channel with no app switch. `.invalid`
+    /// when no window is open.
     private var lingerTask: UIBackgroundTaskIdentifier = .invalid
+    /// See `armLifecycleLinger`. Held for the process's whole life, like
+    /// `requestObserver`.
+    private var lifecycleObservers: [NSObjectProtocol] = []
 
     /// Flatten the diarized segment stream to plain text: non-tail segments are
     /// settled runs (`mix-0`, `mix-1`, …) kept by id in arrival order; `mix-tail`
@@ -57,6 +67,7 @@ final class DictationCoordinator: ObservableObject {
 
     private init() {
         armRequestObserver()
+        armLifecycleLinger()
     }
 
     // MARK: entry points
@@ -139,12 +150,41 @@ final class DictationCoordinator: ObservableObject {
             return
         }
 
-        guard await AudioCapture.requestPermission() else {
+        switch AudioCapture.permission {
+        case .granted:
+            break
+        case .denied:
             fail(
                 String(
                     localized:
                         "Dictation needs microphone access. Turn it on in Settings › Parley."))
             return
+        default:
+            // First ask. The flag swaps the dictation screen's guidance from
+            // "swipe back" to "allow the prompt" while the system alert is up —
+            // swiping away would cancel the alert as a refusal.
+            awaitingMicPermission = true
+            let granted = await AudioCapture.requestPermission()
+            awaitingMicPermission = false
+            guard granted else {
+                // Re-read to name the actual situation: a refusal in the
+                // prompt is a Settings trip; a prompt that never got answered
+                // (backgrounding dismisses it) stays undetermined, and the
+                // next tap will simply ask again.
+                if AudioCapture.permission == .denied {
+                    fail(
+                        String(
+                            localized:
+                                "Dictation needs microphone access. Turn it on in Settings › Parley."
+                        ))
+                } else {
+                    fail(
+                        String(
+                            localized:
+                                "Microphone access wasn't granted. Tap the mic to try again."))
+                }
+                return
+            }
         }
 
         let client = SttRelayClient(
@@ -211,10 +251,48 @@ final class DictationCoordinator: ObservableObject {
                 if up.stopRequested {
                     if self.active, up.session == self.session { await self.stop() }
                 } else if !up.session.isEmpty, up.session != self.session {
+                    // Only honor a start here if the mic can actually open.
+                    // A background process cannot show the permission prompt —
+                    // answering the request anyway published "no microphone
+                    // access" for a permission the user had never been asked
+                    // for. Staying silent instead lets the keyboard's URL
+                    // fallback bring the app forward, where the prompt (or the
+                    // Settings guidance) can actually be seen.
+                    guard AudioCapture.permission == .granted
+                        || UIApplication.shared.applicationState == .active
+                    else { return }
                     await self.begin(session: up.session)
                 }
             }
         }
+    }
+
+    /// Arm the ~30 s linger every time the app leaves the foreground, not only
+    /// after a dictation session. The linger used to arm only in
+    /// `finishUp`/`fail`, so the most common beat — open Parley, switch to
+    /// another app, tap the keyboard's mic — always found this process
+    /// suspended and bounced the user through the app, even seconds after they
+    /// had it open. Thirty seconds is the platform's ceiling for a background
+    /// task; past it the URL round trip is the only way to wake us.
+    private func armLifecycleLinger() {
+        let center = NotificationCenter.default
+        lifecycleObservers = [
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    // A live session's audio keeps the process awake already.
+                    guard let self, !self.active else { return }
+                    self.beginLinger()
+                }
+            },
+            center.addObserver(
+                forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                // Foreground needs no assertion; the next backgrounding re-arms.
+                Task { @MainActor in self?.endLinger() }
+            },
+        ]
     }
 
     private func armCap() {

--- a/ios/App/Parley/DictationView.swift
+++ b/ios/App/Parley/DictationView.swift
@@ -19,9 +19,12 @@ struct DictationView: View {
     @ObservedObject var coordinator = DictationCoordinator.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    /// The user is stranded here and has to swipe back themselves.
+    /// The user is stranded here and has to swipe back themselves. Never while
+    /// the microphone prompt is up: swiping away would cancel the prompt as a
+    /// refusal, and the guidance was actively steering people into doing so.
     private var needsManualReturn: Bool {
-        coordinator.returnableHost == nil
+        !coordinator.awaitingMicPermission
+            && coordinator.returnableHost == nil
             && (coordinator.state == .starting || coordinator.state == .listening)
     }
 
@@ -88,6 +91,9 @@ struct DictationView: View {
     /// The headline is whatever the user must do next. Stranded here, that is
     /// the swipe back — "Listening…" would be answering the wrong question.
     private var statusTitle: String {
+        if coordinator.awaitingMicPermission {
+            return String(localized: "Allow microphone access")
+        }
         if needsManualReturn {
             return String(localized: "Swipe back to your app")
         }
@@ -101,6 +107,12 @@ struct DictationView: View {
     }
 
     private var statusSubtitle: String {
+        if coordinator.awaitingMicPermission {
+            return String(
+                localized:
+                    "Parley records here and types your words at the cursor. Answer the prompt first — dictation can't start without it."
+            )
+        }
         if coordinator.state == .error {
             return coordinator.errorMessage ?? String(localized: "Please try again.")
         }

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -256,6 +256,23 @@
         }
       }
     },
+    "Allow microphone access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow microphone access"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請允許使用麥克風"
+          }
+        }
+      }
+    },
     "Appearance": {
       "extractionState": "manual",
       "localizations": {
@@ -1103,6 +1120,23 @@
         }
       }
     },
+    "Microphone access wasn't granted. Tap the mic to try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access wasn't granted. Tap the mic to try again."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未取得麥克風權限，請再點一次麥克風重試。"
+          }
+        }
+      }
+    },
     "Microphone is back — still recording": {
       "extractionState": "manual",
       "localizations": {
@@ -1388,6 +1422,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Parley 會用麥克風收取房間的聲音，將音訊送往你的 Parley 帳號進行即時轉錄，並把錄音與逐字稿同步到雲端。請先確認在場所有人都同意錄音。"
+          }
+        }
+      }
+    },
+    "Parley records here and types your words at the cursor. Answer the prompt first — dictation can't start without it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley records here and types your words at the cursor. Answer the prompt first — dictation can't start without it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley 會在這裡錄音，把你說的話即時輸入到游標處。請先回應權限詢問，聽寫才能開始。"
           }
         }
       }


### PR DESCRIPTION
## What this changes

Two fixes to the keyboard-dictation hand-off, both live on `ios-v1.4`:

1. **First-run permission no longer eats itself.** `DictationView` used to headline "Swipe back to your app" while the system microphone prompt was still up (`state == .starting`). Obeying it backgrounded the app, which cancels the prompt as a refusal — and the follow-up tap reached the app over the Darwin channel in the *background*, where the prompt can't be shown at all, so `requestRecordPermission()` failed and the keyboard was told "Turn it on in Settings" for a permission the user was never actually asked for. Now:
   - `launch()` reads the standing grant first; an undetermined grant asks under a new `awaitingMicPermission` state whose on-screen guidance is "Allow microphone access", not "swipe back".
   - The Darwin start observer declines requests it cannot serve (not granted + backgrounded), so the keyboard's `parley://dictate` fallback brings the app forward where the prompt can be seen.
   - Error copy distinguishes *denied* (Settings trip) from *never answered* (tap to try again).
2. **The 30 s background linger arms on every `didEnterBackground`,** not only after a dictation session. The most common beat — open Parley, switch to the app you're typing in, tap the keyboard's mic — always found the process suspended and bounced the user through the app; now any recent foregrounding of Parley buys the next tap its no-jump window. (30 s is the platform ceiling for a background task; beyond it the URL round trip remains the only wake path.)

## Why

Field report (via Jack): tapping the keyboard's mic always jumps to Parley even when the app was just open, and after coming back the keyboard claims there is no microphone permission. The permission claim traced to the prompt/guidance race above; the constant jumping traced to the linger only ever arming after a *session*, which first-time and casual flows never reach.

## How it was verified

- [x] `cd ios/ParleyKit && swift test` — 20 tests pass
- [x] `xcodegen generate` + `xcodebuild -scheme Parley -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — app + keyboard extension build clean
- [x] New user-facing strings added to `Localizable.xcstrings` with both `en` and `zh-Hant` entries
- [ ] Device pass (prompt/backgrounding behaviour needs real hardware; will ride the next TestFlight build)

*(Desktop checkboxes — tsc/vitest/tauri — not applicable: iOS-only change.)*

## Screenshots

The only UI change is the `DictationView` headline while the system mic prompt is up ("Allow microphone access" + explainer instead of "Swipe back to your app"). The state exists only under a live, undetermined permission prompt with a signed-in account, which the screenshot demo harness can't fake — copy change is in `DictationView.swift:110`.