### PR TITLE
[chore] iOS 1.4.1 (build 11)

### DIFF
--- a/ios/App/Parley/Info.plist
+++ b/ios/App/Parley/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.4.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/project.yml
+++ b/ios/App/project.yml
@@ -34,8 +34,8 @@ targets:
       path: Parley/Info.plist
       properties:
         CFBundleDisplayName: Parley
-        CFBundleShortVersionString: "1.4"
-        CFBundleVersion: "10"
+        CFBundleShortVersionString: "1.4.1"
+        CFBundleVersion: "11"
         UILaunchScreen: {}
         # Localized in Parley/InfoPlist.xcstrings; this is the fallback value.
         NSMicrophoneUsageDescription: Parley records the meeting in the room so it can transcribe it live. Audio goes only to the transcription provider tied to your account.
@@ -81,8 +81,8 @@ targets:
       properties:
         # Localized in ../Keyboard/InfoPlist.xcstrings; this is the fallback.
         CFBundleDisplayName: Parley Voice
-        CFBundleShortVersionString: "1.4"
-        CFBundleVersion: "10"
+        CFBundleShortVersionString: "1.4.1"
+        CFBundleVersion: "11"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.keyboard-service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).KeyboardViewController

--- a/ios/Keyboard/Info.plist
+++ b/ios/Keyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
## What this changes

Version bump only: `1.4` (10) → `1.4.1` (11) in `project.yml` and both Info.plists, so the dictation-permission fixes in #281 can ship to TestFlight. `1.4.1` rather than a new build of `1.4` because `ios-release.yml` requires the tag to equal `CFBundleShortVersionString`, and `ios-v1.4` is already spent on build 10.

## Why

#281 fixed the first-run mic-permission race and the always-jumping keyboard start; it needs a device pass on TestFlight.

## How it was verified

- [x] Diff mirrors the `1.3 → 1.4` bump (#274): same three files, same fields
- [ ] `ios-v1.4.1` tag will drive the release workflow after merge

*(Desktop checkboxes not applicable: version metadata only.)*