### PR TITLE
[fix] a dropped relay socket is a pause in the live transcript, not the end of it

### DIFF
--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -41,6 +41,22 @@ final class DictationCoordinator: ObservableObject {
     private var session = ""
     private var capture: AudioCapture?
     private var relay: SttRelayClient?
+    /// The microphone's only counterparty. It forwards to the current relay
+    /// leg and *holds* what is spoken while there is none, so a dropped socket
+    /// costs a pause in the words appearing rather than the sentence said
+    /// during it. See `RelayAudioBridge`.
+    private let audio = RelayAudioBridge(holdLimit: .seconds(20))
+    /// Bumped per relay connection. Events carry their leg, so a socket dying
+    /// slowly cannot write into a session its replacement has moved on from,
+    /// and each leg's committed ids get their own prefix (a leg numbers its
+    /// segments from zero — without the prefix leg 2's first sentence would
+    /// overwrite leg 1's).
+    private var leg = 0
+    private var reconnectTask: Task<Void, Never>?
+    private var reconnectAttempts = 0
+    /// The session is ending on purpose, so a socket close is the expected end
+    /// of the stream rather than something to redial.
+    private var finishRequested = false
     private var capTimer: Task<Void, Never>?
     /// Persistent uplink listener (armed for the process's whole life): stop
     /// requests for the running session, and — the no-jump path — start
@@ -64,6 +80,11 @@ final class DictationCoordinator: ObservableObject {
     /// session the user forgets to stop can't quietly burn the whole hosted
     /// quota. The backstop stops the mic; the tail still flushes.
     private let maxSeconds: UInt64 = 120
+
+    /// Dictation redials faster and gives up sooner than a meeting does:
+    /// someone is standing there mid-sentence, and the whole session is capped
+    /// at two minutes. `ReconnectPolicy.dictation` is that ladder.
+    private static let reconnect = ReconnectPolicy.dictation
 
     private init() {
         armRequestObserver()
@@ -121,6 +142,12 @@ final class DictationCoordinator: ObservableObject {
         partial = ""
         state = .starting
         active = true
+        leg = 0
+        reconnectAttempts = 0
+        finishRequested = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        audio.reset()
         publish()
 
         #if DEBUG
@@ -187,25 +214,19 @@ final class DictationCoordinator: ObservableObject {
             }
         }
 
-        let client = SttRelayClient(
-            // "voice_typing" is the cloud's whitelisted tag for this flow (the
-            // relay only attributes meeting | voice_typing | realtime; anything
-            // else is billed unattributed).
-            options: .init(bearerToken: token, feature: "voice_typing")
-        ) { [weak self] event in
-            Task { @MainActor in self?.handle(event) }
-        }
+        let client = makeRelay(token: token, leg: 0, timeOffsetMs: 0)
         relay = client
+        audio.attach(client)
 
-        // Microphone first, socket second. The client buffers whatever the
+        // Microphone first, socket second. The bridge buffers whatever the
         // microphone hands it while the handshake is still in flight, so the
         // round trip to the relay stops being a round trip the user waits
         // through before their first word is captured. `AudioCapture.start()`
         // is `async` for the same reason: activating the audio session is slow
         // enough to be felt if it runs on the main actor.
         let cap = AudioCapture(
-            onChunk: { [weak self] samples, level in
-                client.enqueue(pcm: samples)
+            onChunk: { [weak self, audio] samples, level in
+                audio.send(samples)
                 Task { @MainActor in self?.micLevel = level }
             },
             onStatus: { [weak self] status in
@@ -216,6 +237,7 @@ final class DictationCoordinator: ObservableObject {
             capture = cap
         } catch {
             relay = nil
+            audio.discard()
             client.cancel()
             fail(String(localized: "Couldn't open the microphone."))
             return
@@ -226,6 +248,7 @@ final class DictationCoordinator: ObservableObject {
         } catch {
             capture = nil
             relay = nil
+            audio.discard()
             client.cancel()
             await cap.stop()
             fail(String(localized: "Connection failed. Please try again."))
@@ -235,6 +258,24 @@ final class DictationCoordinator: ObservableObject {
         state = .listening
         publish()
         armCap()
+    }
+
+    /// One relay leg. `feature: "voice_typing"` is the cloud's whitelisted tag
+    /// for this flow (the relay attributes meeting | voice_typing | realtime;
+    /// anything else is billed unattributed).
+    ///
+    /// A relay session cannot be resumed, so a reconnect is a new leg with its
+    /// own Soniox session — hence the per-leg id prefix and the offset, which
+    /// keep the second leg's segments from overwriting the first's.
+    private func makeRelay(token: String, leg: Int, timeOffsetMs: UInt64) -> SttRelayClient {
+        SttRelayClient(
+            options: .init(
+                bearerToken: token, feature: "voice_typing",
+                idPrefix: leg == 0 ? nil : "mix@\(leg)",
+                timeOffsetMs: timeOffsetMs)
+        ) { [weak self] event in
+            Task { @MainActor in self?.handle(event, from: leg) }
+        }
     }
 
     /// The uplink channel, listened to for the process's whole life:
@@ -318,7 +359,10 @@ final class DictationCoordinator: ObservableObject {
         }
     }
 
-    private func handle(_ event: SttRelayEvent) {
+    private func handle(_ event: SttRelayEvent, from eventLeg: Int) {
+        // A leg that dies slowly can still deliver: ignore anything from a leg
+        // this session has already replaced.
+        guard eventLeg == leg else { return }
         switch event {
         case .segment(let seg):
             if seg.id.hasSuffix("-tail") {
@@ -331,10 +375,137 @@ final class DictationCoordinator: ObservableObject {
             committed = runs.map(\.text).joined()
             publish()
         case .closed:
-            if active { finishUp() }
-        case .error(let message):
-            fail(message)
+            // After `finish()` this is the relay signing off, which is the end
+            // of the session. Any other time it is a dropped socket, and the
+            // microphone is still open — so redial instead of ending a session
+            // the user is still speaking into.
+            guard active else { return }
+            if finishRequested {
+                finishUp()
+            } else {
+                scheduleReconnect()
+            }
+        case .error:
+            // The message is wire text ("relay error 402: …"), never something
+            // to put in front of someone; the reconnect path owns the copy.
+            guard active else { return }
+            if finishRequested {
+                finishUp()
+            } else if event.isQuotaExceeded {
+                // The one failure a redial cannot fix — the next handshake is
+                // refused the same way, so say what actually happened instead
+                // of spending the ladder to arrive at "lost the connection".
+                foldPartialIn()
+                fail(
+                    String(
+                        localized:
+                            "You're out of transcription quota. Dictation works again once it resets."
+                    ))
+            } else {
+                scheduleReconnect()
+            }
         }
+    }
+
+    // MARK: reconnect
+
+    /// Redial the relay while the microphone keeps running.
+    ///
+    /// The gap is what this is really about: the bridge holds what is said
+    /// while there is no socket and hands it to the next leg, so a five-second
+    /// blip costs a pause in the words appearing, not the words. Only when the
+    /// ladder runs out does the session end — and it ends holding on to
+    /// everything that was already typed.
+    private func scheduleReconnect() {
+        guard reconnectTask == nil, active, !finishRequested else { return }
+
+        let previous = relay
+        relay = nil
+        audio.hold()
+        previous?.cancel()
+
+        // The tentative tail died with the socket: the relay will never settle
+        // it, and its audio was already sent to the leg that is gone. Folding
+        // it into the settled text is what `finishUp` does at the end of every
+        // session, for the same reason — it is the best record there is of
+        // what was said.
+        foldPartialIn()
+        publish()
+
+        guard let token = KeychainStore.get(AppState.tokenKey) else {
+            // The session expired mid-dictation. Redialling would only be
+            // refused, and the user needs to be told the actual reason.
+            audio.discard()
+            fail(String(localized: "Sign in to the Parley app before using the voice keyboard."))
+            return
+        }
+        guard case .retry(let backoff) = Self.reconnect.decide(attempt: reconnectAttempts + 1)
+        else {
+            endAfterLostConnection()
+            return
+        }
+
+        reconnectAttempts += 1
+        leg += 1
+        let nextLeg = leg
+        state = .reconnecting
+        publish()
+
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: backoff)
+            guard !Task.isCancelled, let self else { return }
+            await self.performReconnect(token: token, leg: nextLeg)
+        }
+    }
+
+    private func performReconnect(token: String, leg targetLeg: Int) async {
+        reconnectTask = nil
+        guard leg == targetLeg, active, !finishRequested else { return }
+        // The bridge decides the offset: it is what knows where in the session
+        // the audio it held was actually spoken.
+        guard
+            let client = audio.attach({ offsetMs in
+                self.makeRelay(token: token, leg: targetLeg, timeOffsetMs: offsetMs)
+            })
+        else { return }
+        relay = client
+        do {
+            try await client.start()
+            guard leg == targetLeg, active, !finishRequested else { return }
+            reconnectAttempts = 0
+            state = .listening
+            publish()
+        } catch {
+            guard leg == targetLeg else { return }
+            audio.hold()
+            scheduleReconnect()
+        }
+    }
+
+    /// Out of redials. End the session rather than leave a microphone running
+    /// into nothing — but keep every word already settled, which the keyboard
+    /// has already typed into the user's document.
+    private func endAfterLostConnection() {
+        audio.discard()
+        fail(
+            String(
+                localized:
+                    "Lost the connection. What you already said has been typed — tap the mic to carry on."
+            ))
+    }
+
+    /// Move the tentative tail into the settled text, as a run of its own.
+    ///
+    /// It has to become a *run*, not just an append to `committed`: `committed`
+    /// is rebuilt from `runs` on every segment, so text appended to it directly
+    /// would vanish the moment the next leg said anything. The id cannot
+    /// collide with a relay's (`mix-N`, `mix@L-N`), and only one tail per leg
+    /// is ever folded. Callers publish.
+    private func foldPartialIn() {
+        guard !partial.isEmpty else { return }
+        runs.append((id: "folded@\(leg)", text: partial))
+        partial = ""
+        committed = runs.map(\.text).joined()
     }
 
     // MARK: stop / teardown
@@ -345,11 +516,19 @@ final class DictationCoordinator: ObservableObject {
             demoTask?.cancel()
             demoTask = nil
         #endif
+        // From here a socket close is the expected end of the stream, not
+        // something to redial, and no redial already in flight should land.
+        finishRequested = true
+        reconnectTask?.cancel()
+        reconnectTask = nil
         capTimer?.cancel()
         capTimer = nil
         let cap = capture
         capture = nil
         await cap?.stop()
+        // Anything still held belongs to a leg that will never exist; the
+        // finalize below drains what actually reached the relay.
+        audio.discard()
         micLevel = 0
         state = .finishing
         publish()
@@ -361,13 +540,13 @@ final class DictationCoordinator: ObservableObject {
 
     private func finishUp() {
         relay = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        audio.discard()
         state = .done
         // Fold the last partial into the committed text so nothing said right
         // before the endpoint is dropped from what the keyboard inserts.
-        if !partial.isEmpty {
-            committed += partial
-            partial = ""
-        }
+        foldPartialIn()
         publish()
         active = false
         beginLinger()
@@ -378,6 +557,12 @@ final class DictationCoordinator: ObservableObject {
         state = .error
         capTimer?.cancel()
         capTimer = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        let dying = relay
+        relay = nil
+        audio.discard()
+        dying?.cancel()
         let cap = capture
         capture = nil
         // Detached because `fail` is the sync tail of half a dozen paths and

--- a/ios/App/Parley/DictationView.swift
+++ b/ios/App/Parley/DictationView.swift
@@ -25,7 +25,8 @@ struct DictationView: View {
     private var needsManualReturn: Bool {
         !coordinator.awaitingMicPermission
             && coordinator.returnableHost == nil
-            && (coordinator.state == .starting || coordinator.state == .listening)
+            && (coordinator.state == .starting || coordinator.state == .listening
+                || coordinator.state == .reconnecting)
     }
 
     var body: some View {
@@ -77,13 +78,16 @@ struct DictationView: View {
     }
 
     private var pulse: CGFloat {
-        coordinator.state == .listening ? 1.06 : 1
+        coordinator.state == .listening || coordinator.state == .reconnecting ? 1.06 : 1
     }
 
     private var statusIcon: String {
         switch coordinator.state {
         case .error: return "exclamationmark.triangle"
         case .finishing, .done: return "checkmark"
+        // Deliberately not the warning triangle: the microphone is still open
+        // and the words are being kept. This is a pause, not a failure.
+        case .reconnecting: return "arrow.triangle.2.circlepath"
         default: return "waveform"
         }
     }
@@ -94,6 +98,11 @@ struct DictationView: View {
         if coordinator.awaitingMicPermission {
             return String(localized: "Allow microphone access")
         }
+        // Ahead of the swipe guidance: a user watching this screen while it
+        // redials should be told what it is doing, not asked to leave.
+        if coordinator.state == .reconnecting {
+            return String(localized: "Reconnecting…")
+        }
         if needsManualReturn {
             return String(localized: "Swipe back to your app")
         }
@@ -103,6 +112,8 @@ struct DictationView: View {
         case .finishing: return String(localized: "Wrapping up…")
         case .done: return String(localized: "Done")
         case .error: return String(localized: "Couldn't start")
+        // Handled above, before the swipe guidance.
+        case .reconnecting: return String(localized: "Reconnecting…")
         }
     }
 
@@ -115,6 +126,12 @@ struct DictationView: View {
         }
         if coordinator.state == .error {
             return coordinator.errorMessage ?? String(localized: "Please try again.")
+        }
+        if coordinator.state == .reconnecting {
+            return String(
+                localized:
+                    "Keep talking — the microphone is still on and what you say is kept until the connection is back."
+            )
         }
         if needsManualReturn {
             return String(

--- a/ios/App/Parley/LiveView.swift
+++ b/ios/App/Parley/LiveView.swift
@@ -120,14 +120,50 @@ struct LiveView: View {
         .padding(.bottom, 24)
     }
 
+    /// The one line under the transcript. Its *look* is the transcription's
+    /// health, not just its words: a reconnect is a spinner in amber, because
+    /// it is a pause the recording will come back from, while the sentence
+    /// that says live transcription is over gets the icon and the weight of
+    /// something the user may want to act on. Both are still only about the
+    /// live transcript — the recording itself is unaffected either way.
+    @ViewBuilder
+    private func statusLine(_ status: String) -> some View {
+        let health = recorder.transcription
+        HStack(spacing: 6) {
+            switch health {
+            case .reconnecting:
+                ProgressView()
+                    .controlSize(.mini)
+                    .tint(Theme.warning)
+            case .stopped:
+                Image(systemName: "bolt.horizontal.circle")
+                    .font(.parley.caption)
+            default:
+                EmptyView()
+            }
+            Text(status)
+                .font(.parley.caption)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+        }
+        .foregroundStyle(
+            {
+                switch health {
+                case .reconnecting: return Theme.warning
+                // Full-weight ink rather than red: the live transcript is
+                // over, but the recording is not, and colouring this like a
+                // failure would say the opposite of what the sentence says.
+                case .stopped: return Theme.foreground
+                default: return Theme.mutedForeground
+                }
+            }())
+        .accessibilityElement(children: .combine)
+    }
+
     private var controls: some View {
         VStack(spacing: 12) {
             if let status = recorder.status {
-                Text(status)
-                    .font(.parley.caption)
-                    .foregroundStyle(Theme.mutedForeground)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
+                statusLine(status)
             }
             Button(action: toggle) {
                 Label(buttonTitle, systemImage: buttonIcon)

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -850,6 +850,23 @@
         }
       }
     },
+    "Keep talking — the microphone is still on and what you say is kept until the connection is back.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep talking — the microphone is still on and what you say is kept until the connection is back."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續說沒關係——麥克風還開著，這段話會先留著，等連線回來就送出。"
+          }
+        }
+      }
+    },
     "LIVE": {
       "extractionState": "manual",
       "localizations": {
@@ -1032,6 +1049,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在載入 Parley"
+          }
+        }
+      }
+    },
+    "Lost the connection. What you already said has been typed — tap the mic to carry on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lost the connection. What you already said has been typed — tap the mic to carry on."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連線中斷了。剛才說過的內容已經打出來，點一下麥克風就能接著說。"
           }
         }
       }
@@ -1575,6 +1609,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "季度檢討 — 子午線"
+          }
+        }
+      }
+    },
+    "Reconnecting…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecting…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新連線中…"
           }
         }
       }
@@ -2606,6 +2657,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "額度已用完。錄音已安全保留在手機上，額度恢復後會自動同步。"
+          }
+        }
+      }
+    },
+    "You're out of transcription quota — live transcription stopped. The recording is still running and will be transcribed once the quota resets.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're out of transcription quota — live transcription stopped. The recording is still running and will be transcribed once the quota resets."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉錄額度已用完，即時字幕停止了。錄音仍在繼續，額度重置後會自動轉錄。"
+          }
+        }
+      }
+    },
+    "You're out of transcription quota. Dictation works again once it resets.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're out of transcription quota. Dictation works again once it resets."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉錄額度已用完，額度重置後語音輸入就會恢復。"
           }
         }
       }

--- a/ios/App/Parley/MeetingRecorder.swift
+++ b/ios/App/Parley/MeetingRecorder.swift
@@ -52,6 +52,25 @@ final class MeetingRecorder: ObservableObject {
     /// the meeting, which is what gets the audio captured so far onto disk and
     /// into the cloud instead of leaving a dead recording on screen.
     @Published private(set) var lostMicrophone = false
+    /// How the live transcript is doing, separately from `status`, so the view
+    /// can draw "reconnecting" as the temporary state it is instead of styling
+    /// it like the sentence that says the transcript is over.
+    @Published private(set) var transcription: TranscriptionHealth = .idle
+
+    /// The live transcript's side of the meeting. None of these ends the
+    /// recording: the audio file is written from the tap and uploaded either
+    /// way (see the type doc).
+    enum TranscriptionHealth: Equatable {
+        /// No relay this meeting — signed out, or nothing started yet.
+        case idle
+        case connecting
+        case live
+        /// The socket dropped; audio is being held for the next leg.
+        case reconnecting
+        /// Out of reach. The recording continues and the cloud transcribes the
+        /// upload; only the *live* transcript is over.
+        case stopped
+    }
 
     /// What the record button reflects. True from the tap, not from the moment
     /// the socket came up.
@@ -64,8 +83,10 @@ final class MeetingRecorder: ObservableObject {
     private var uploader: MeetingUploader?
     /// The audio thread writes here, not to a client it captured once. A
     /// reconnect swaps the client behind it; a tap closure holding the old one
-    /// directly would keep feeding a socket nobody reads.
-    private let sink = RelaySink()
+    /// directly would keep feeding a socket nobody reads. It also *holds* the
+    /// audio spoken while there is no socket, so a blip costs a pause in the
+    /// live transcript rather than the sentence that was said during it.
+    private let audio = RelayAudioBridge()
 
     /// Bumped for every relay connection this recording makes. Events carry the
     /// leg they came from so a socket that dies slowly cannot write into a
@@ -76,11 +97,11 @@ final class MeetingRecorder: ObservableObject {
     /// The user asked to stop, so a socket close is the expected end of the
     /// stream rather than something to reconnect from.
     private var finishRequested = false
-    /// Monotonic start of capture, for the offset a reconnected leg needs to
-    /// place its timestamps after the audio that came before it.
-    private var captureStartedAt: TimeInterval = 0
 
-    private static let maxReconnectAttempts = 8
+    /// How often and how fast to redial. The offset each new leg needs comes
+    /// from the bridge rather than the wall clock — the bridge is what knows
+    /// where in the recording the audio it held was spoken.
+    private static let reconnect = ReconnectPolicy()
 
     // MARK: control
 
@@ -95,6 +116,8 @@ final class MeetingRecorder: ObservableObject {
         lostMicrophone = false
         leg = 0
         reconnectAttempts = 0
+        transcription = .idle
+        audio.reset()
 
         guard await AudioCapture.requestPermission() else {
             phase = .idle
@@ -112,12 +135,12 @@ final class MeetingRecorder: ObservableObject {
         // first: the handshake stops being something the user waits through.
         let client = token.map { makeRelay(token: $0, leg: 0, timeOffsetMs: 0) }
         relay = client
+        if let client { audio.attach(client) }
 
-        sink.swap(client)
         let cap = AudioCapture(
-            onChunk: { [weak self, sink] samples, level in
+            onChunk: { [weak self, audio] samples, level in
                 recorder?.append(samples)
-                sink.send(samples)
+                audio.send(samples)
                 Task { @MainActor in self?.micLevel = level }
             },
             onStatus: { [weak self] captureStatus in
@@ -129,7 +152,7 @@ final class MeetingRecorder: ObservableObject {
         } catch {
             uploader = nil
             relay = nil
-            sink.swap(nil)
+            audio.discard()
             client?.cancel()
             phase = .idle
             status = String(localized: "Audio error: \(error.localizedDescription)")
@@ -142,13 +165,13 @@ final class MeetingRecorder: ObservableObject {
         }
 
         capture = cap
-        captureStartedAt = ProcessInfo.processInfo.systemUptime
         phase = .recording
 
         guard let client else {
             status = String(localized: "Not signed in — microphone test only")
             return
         }
+        transcription = .connecting
         status = String(localized: "Connecting transcription…")
         await connect(client, leg: 0)
     }
@@ -166,7 +189,9 @@ final class MeetingRecorder: ObservableObject {
         let cap = capture
         capture = nil
         await cap?.stop()
-        sink.swap(nil)
+        // Whatever the bridge is still holding belongs to no leg now; the
+        // finalize below drains what actually reached the relay.
+        audio.discard()
         micLevel = 0
 
         if let relay {
@@ -199,9 +224,13 @@ final class MeetingRecorder: ObservableObject {
             try await client.start()
             guard self.leg == leg, phase == .recording else { return }
             reconnectAttempts = 0
+            transcription = .live
             status = String(localized: "Transcribing live")
         } catch {
             guard self.leg == leg else { return }
+            // The handshake failed, so this leg never carried anything: hand
+            // the audio back to the hold buffer for the next one.
+            audio.hold()
             scheduleReconnect()
         }
     }
@@ -220,55 +249,86 @@ final class MeetingRecorder: ObservableObject {
             // owns the copy; once the meeting is winding down the stop path
             // does, and neither wants this overwriting it.
             guard !finishRequested, isRecording else { return }
+            guard !event.isQuotaExceeded else {
+                // Out of quota is the one failure a redial cannot fix: the
+                // next handshake is refused the same way.
+                let dying = relay
+                relay = nil
+                dying?.cancel()
+                giveUpOnTranscription(
+                    String(
+                        localized:
+                            "You're out of transcription quota — live transcription stopped. The recording is still running and will be transcribed once the quota resets."
+                    ))
+                return
+            }
             scheduleReconnect()
         }
     }
 
     /// Reopen the relay while the microphone keeps running. The audio file is
     /// untouched by any of this — the only thing at stake is how much of the
-    /// transcript appears live rather than after the upload.
+    /// transcript appears live rather than after the upload, and the bridge
+    /// keeps the words spoken in between for the leg that comes next.
     private func scheduleReconnect() {
         guard reconnectTask == nil, isRecording, !finishRequested else { return }
-        guard let token = KeychainStore.get(AppState.tokenKey) else {
-            status = String(localized: "Live transcription stopped — the recording is still running")
-            return
-        }
-        guard reconnectAttempts < Self.maxReconnectAttempts else {
-            status = String(
-                localized:
-                    "Live transcription stopped, but the recording is still running and will be transcribed after it syncs."
-            )
-            return
-        }
 
         let previous = relay
         relay = nil
-        sink.swap(nil)
+        audio.hold()
         previous?.cancel()
+
+        guard let token = KeychainStore.get(AppState.tokenKey) else {
+            giveUpOnTranscription(
+                String(
+                    localized: "Live transcription stopped — the recording is still running"))
+            return
+        }
+        guard case .retry(let backoff) = Self.reconnect.decide(attempt: reconnectAttempts + 1)
+        else {
+            giveUpOnTranscription(
+                String(
+                    localized:
+                        "Live transcription stopped, but the recording is still running and will be transcribed after it syncs."
+                ))
+            return
+        }
 
         reconnectAttempts += 1
         leg += 1
-        let attempt = reconnectAttempts
         let nextLeg = leg
-        // 1, 2, 4, 8 … capped at 15 s. Long enough not to hammer a relay that
-        // is down, short enough that walking back into Wi-Fi picks up quickly.
-        let backoff = min(15.0, pow(2.0, Double(attempt - 1)))
+        transcription = .reconnecting
         status = String(localized: "Transcription dropped — reconnecting…")
 
         reconnectTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(backoff))
+            try? await Task.sleep(for: backoff)
             guard !Task.isCancelled, let self else { return }
             await self.performReconnect(token: token, leg: nextLeg)
         }
     }
 
+    /// No leg is coming. Drop the held audio rather than carry a buffer nobody
+    /// will ever read for the rest of the meeting — the recording itself is
+    /// unaffected, and the cloud transcribes it after the upload.
+    private func giveUpOnTranscription(_ message: String) {
+        audio.discard()
+        transcription = .stopped
+        status = message
+    }
+
     private func performReconnect(token: String, leg targetLeg: Int) async {
         reconnectTask = nil
         guard leg == targetLeg, isRecording, !finishRequested else { return }
-        let offset = UInt64(max(0, (ProcessInfo.processInfo.systemUptime - captureStartedAt) * 1000))
-        let client = makeRelay(token: token, leg: targetLeg, timeOffsetMs: offset)
+        // The bridge decides the offset, because the bridge is what knows where
+        // in the recording the audio it is holding was actually spoken. A leg
+        // offset to "now" would file a gap's worth of speech after the words
+        // that followed it.
+        guard
+            let client = audio.attach({ offsetMs in
+                self.makeRelay(token: token, leg: targetLeg, timeOffsetMs: offsetMs)
+            })
+        else { return }
         relay = client
-        sink.swap(client)
         await connect(client, leg: targetLeg)
     }
 
@@ -372,30 +432,8 @@ final class MeetingRecorder: ObservableObject {
             self.segments = segments
             self.status = status
             phase = .recording
+            transcription = .live
             micLevel = 0.11
         }
     #endif
-}
-
-/// Hands microphone chunks to whichever relay leg is current.
-///
-/// Lives outside the actor on purpose: `send` runs on the audio render thread,
-/// where hopping to the main actor to look up a property is not an option. The
-/// lock is held only long enough to read a reference.
-private final class RelaySink: @unchecked Sendable {
-    private let lock = NSLock()
-    private var client: SttRelayClient?
-
-    func swap(_ next: SttRelayClient?) {
-        lock.lock()
-        client = next
-        lock.unlock()
-    }
-
-    func send(_ samples: [Int16]) {
-        lock.lock()
-        let current = client
-        lock.unlock()
-        current?.enqueue(pcm: samples)
-    }
 }

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -296,6 +296,8 @@ struct KeyboardRootView: View {
                         .foregroundStyle(KBTheme.recording)
                         .multilineTextAlignment(.center)
                 }
+            } else if bridge.reconnecting {
+                reconnectingText
             } else if bridge.listening || !bridge.tail.isEmpty {
                 liveText
             } else {
@@ -309,7 +311,28 @@ struct KeyboardRootView: View {
         .frame(height: KBMetrics.textHeight)
         .frame(maxWidth: .infinity)
         .animation(.easeInOut(duration: 0.15), value: bridge.listening)
+        .animation(.easeInOut(duration: 0.15), value: bridge.reconnecting)
         .animation(.easeOut(duration: 0.12), value: bridge.partial)
+    }
+
+    /// The connection dropped mid-sentence. The transcript stays exactly where
+    /// it was — nothing typed is taken back — with one line above it saying
+    /// why it stopped growing. Amber rather than the error red: the session is
+    /// still alive and the words are being kept.
+    private var reconnectingText: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Spacer(minLength: 0)
+            Text("Reconnecting… keep talking")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(KBTheme.reconnecting)
+            Text(bridge.tail)
+                .font(.system(size: 15))
+                .foregroundStyle(KBTheme.inkSoft(dark))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var liveText: some View {

--- a/ios/Keyboard/KeyboardTheme.swift
+++ b/ios/Keyboard/KeyboardTheme.swift
@@ -19,6 +19,9 @@ enum KBTheme {
     /// return key (Go / Send / Search / Done), the way iOS tints it.
     static let accent = Color(red: 0.04, green: 0.52, blue: 1.0)
     static let recording = Color(red: 0.90, green: 0.27, blue: 0.24)
+    /// The relay dropped and the app is redialling. Amber on purpose: red is
+    /// reserved for a session that actually ended, and a reconnect has not.
+    static let reconnecting = Color(red: 0.85, green: 0.55, blue: 0.09)
 
     /// Pathors' two brand blues, mirroring the tokens on the landing site
     /// (`#1469D4` deep and `#2DB6F3` sky). They are used sparingly and only

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -286,15 +286,28 @@ final class KeyboardViewController: UIInputViewController {
         // back still shows the sentence in progress.
         bridge.tail = String(d.committed.suffix(Self.tailLimit))
         switch d.state {
-        case .starting, .listening: bridge.listening = true
-        case .finishing: bridge.listening = true
+        case .starting, .listening: 
+            bridge.listening = true
+            bridge.reconnecting = false
+        case .reconnecting:
+            // Still a live session: the app's microphone is open and the audio
+            // is being held for the next relay leg. Saying so — rather than
+            // going quiet, or showing the red error copy — is the difference
+            // between "hold on" and "that didn't work".
+            bridge.listening = true
+            bridge.reconnecting = true
+        case .finishing:
+            bridge.listening = true
+            bridge.reconnecting = false
         case .done:
             bridge.listening = false
+            bridge.reconnecting = false
             bridge.partial = ""
             // The tail stays: the last thing said is worth still being able to
             // read once the button has gone quiet.
         case .error:
             bridge.listening = false
+            bridge.reconnecting = false
             bridge.partial = ""
             bridge.tail = ""
             // Surface the app's failure where the user actually is. Swallowing
@@ -375,6 +388,10 @@ final class KeyboardBridge: ObservableObject {
 
     @Published var hasFullAccess = false
     @Published var listening = false
+    /// The app lost the relay socket and is redialling it. Still listening —
+    /// this only changes what the caption says, never whether the session is
+    /// alive.
+    @Published var reconnecting = false
     @Published var partial = ""
     /// The last stretch of settled text for the running session, shown above
     /// the record button in a softer ink so dictation reads as continuous.

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -170,6 +170,23 @@
         }
       }
     },
+    "Reconnecting… keep talking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecting… keep talking"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新連線中…可以繼續說"
+          }
+        }
+      }
+    },
     "Search": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
@@ -60,6 +60,11 @@ public enum DictationChannel {
 
         public enum State: String, Codable, Sendable {
             case starting, listening, finishing, done, error
+            /// The relay socket dropped and the app is redialling it. The
+            /// microphone is still open and the audio is being held, so this
+            /// is a pause in the words arriving — deliberately not `error`,
+            /// which is where the session actually ends.
+            case reconnecting
         }
 
         public init(

--- a/ios/ParleyKit/Sources/ParleyKit/ReconnectPolicy.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/ReconnectPolicy.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// When to redial the relay, how long to wait, and when to stop trying.
+///
+/// A relay session is not resumable — every reconnect is a fresh Soniox leg —
+/// so redialling costs a handshake and a new billing session, and hammering a
+/// relay that is down helps nobody. The ladder doubles from one second and
+/// caps, which is long enough to stop hammering and short enough that walking
+/// back into Wi-Fi picks the transcript up within a breath.
+///
+/// Extracted from the recorders so the arithmetic is testable without a socket:
+/// the failure this guards against (a session that gives up on the first blip,
+/// or one that never gives up at all) is invisible in a UI test and obvious in
+/// a unit test.
+public struct ReconnectPolicy: Sendable, Equatable {
+    /// Attempts allowed per session. Eight covers a genuinely flaky hour;
+    /// past it the relay is not coming back for this recording, and the audio
+    /// file is transcribed after the upload anyway.
+    public var maxAttempts: Int
+    public var base: Duration
+    public var cap: Duration
+
+    public init(
+        maxAttempts: Int = 8, base: Duration = .seconds(1), cap: Duration = .seconds(15)
+    ) {
+        self.maxAttempts = maxAttempts
+        self.base = base
+        self.cap = cap
+    }
+
+    /// Dictation is a two-minute session someone is standing there waiting on,
+    /// so it redials faster and gives up sooner than a meeting: past a few
+    /// seconds the user has already stopped and tried again.
+    public static let dictation = ReconnectPolicy(
+        maxAttempts: 4, base: .milliseconds(500), cap: .seconds(4))
+
+    /// What to do after the `attempt`-th consecutive failure (1-based).
+    public func decide(attempt: Int) -> Decision {
+        guard attempt >= 1, attempt <= maxAttempts else { return .giveUp }
+        return .retry(after: delay(forAttempt: attempt))
+    }
+
+    /// 1×, 2×, 4×, 8× `base`, capped. Deterministic on purpose: one phone
+    /// dialling one relay has no thundering herd to jitter away from, and a
+    /// fixed ladder is a ladder that can be tested.
+    public func delay(forAttempt attempt: Int) -> Duration {
+        guard attempt >= 1 else { return base }
+        // Shift rather than `pow`: exact, and it cannot drift past the cap
+        // through floating point. 62 keeps the shift defined for any attempt
+        // count someone might set.
+        let steps = min(attempt - 1, 62)
+        let scaled = base * (1 << steps)
+        return scaled > cap ? cap : scaled
+    }
+
+    public enum Decision: Sendable, Equatable {
+        case retry(after: Duration)
+        /// Out of attempts: the live transcript is over for this session.
+        case giveUp
+    }
+}

--- a/ios/ParleyKit/Sources/ParleyKit/RelayAudioBridge.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/RelayAudioBridge.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Anything that can accept a chunk of 16 kHz mono PCM from the audio thread.
+/// `SttRelayClient` is the only production conformer; tests use a recorder.
+public protocol PcmSink: AnyObject, Sendable {
+    func enqueue(pcm samples: [Int16])
+}
+
+extension SttRelayClient: PcmSink {}
+
+/// Routes microphone chunks to whichever relay leg is current — and **holds
+/// them while there is none**.
+///
+/// A relay session cannot be resumed: the socket carries one Soniox session,
+/// and a dropped socket means a fresh leg with its own clock starting at zero
+/// (which is what `SttRelayClient.Options.idPrefix` and `timeOffsetMs` are
+/// for). The gap between the two legs is the interesting part. Without this
+/// type it is simply thrown away: the recording keeps a perfect audio file,
+/// but the words spoken during a five-second blip never reach the relay and
+/// never appear in the live transcript.
+///
+/// So the bridge is the audio thread's only counterparty, and it is always
+/// there:
+///
+/// ```
+/// mic ──▶ bridge ──┬── attached  ──▶ current leg
+///                  └── holding   ──▶ ring of held chunks, flushed into the
+///                                    next leg the moment it is created
+/// ```
+///
+/// ## The clock
+///
+/// The bridge counts every sample it is ever handed, so it always knows the
+/// position of the audio passing through it (`capturedMilliseconds`). When a
+/// new leg is attached, the offset that leg must use is not "now" — it is the
+/// position of the **oldest sample the new leg will actually receive**, which
+/// is the front of the hold buffer. Using "now" would place a whole gap's
+/// worth of speech in the future, after the audio that follows it.
+///
+/// ## The bound
+///
+/// Holding is capped (`holdLimitMilliseconds`) and overflow drops the *oldest*
+/// chunk, which also advances the front of the buffer — so the offset handed
+/// to the next leg stays honest about what that leg is being fed. The audio
+/// file is written straight from the tap and is never at risk here; the worst
+/// case is that the live transcript is missing the beginning of a very long
+/// outage, and the cloud transcribes the upload anyway.
+///
+/// `@unchecked Sendable` because the single mutable box is guarded by `lock`.
+/// The lock is held only for pointer swaps and array appends — never across a
+/// socket write, which happens inside the sink's own queue.
+///
+/// One producer: `send` expects the single audio thread `AudioCapture` calls
+/// it from. Ordering across two concurrent producers is not something a lock
+/// this shallow can promise, and the pipeline has never had two.
+public final class RelayAudioBridge: @unchecked Sendable {
+    /// Default hold window. 45 s comfortably covers the reconnect backoff
+    /// ladder (1, 2, 4, 8, 15, 15 …) plus a slow handshake on a cold radio,
+    /// and costs at most 16 000 × 2 × 45 ≈ 1.4 MB of Int16 while it is full.
+    public static let defaultHoldLimit: Duration = .seconds(45)
+
+    private let sampleRate: UInt64
+    private let holdLimitSamples: UInt64
+    private let lock = NSLock()
+
+    /// The leg audio is flowing to, or nil while holding.
+    private var sink: PcmSink?
+    /// True between `hold()` and the next `attach`/`discard`.
+    private var holding = false
+    private var held: [[Int16]] = []
+    private var heldSamples: UInt64 = 0
+    /// Samples handed to the bridge since `reset()`, i.e. the position of the
+    /// next sample to arrive.
+    private var totalSamples: UInt64 = 0
+    /// Position of the oldest sample still in `held`.
+    private var heldStartSample: UInt64 = 0
+
+    public init(
+        holdLimit: Duration = RelayAudioBridge.defaultHoldLimit,
+        sampleRate: UInt32 = SonioxProtocol.sampleRate
+    ) {
+        self.sampleRate = UInt64(sampleRate)
+        let seconds = holdLimit.components.seconds
+        self.holdLimitSamples = UInt64(max(0, seconds)) * UInt64(sampleRate)
+    }
+
+    // MARK: audio thread
+
+    /// Hand one chunk to the current leg, or to the hold buffer. Safe from the
+    /// audio render thread: no allocation beyond the buffer append, no I/O.
+    public func send(_ samples: [Int16]) {
+        lock.lock()
+        totalSamples += UInt64(samples.count)
+        if let sink {
+            lock.unlock()
+            sink.enqueue(pcm: samples)
+            return
+        }
+        if holding {
+            held.append(samples)
+            heldSamples += UInt64(samples.count)
+            // Overflow drops the oldest chunk — and moves the front of the
+            // buffer, so the offset the next leg gets still describes the
+            // audio it will actually be fed.
+            while heldSamples > holdLimitSamples, let first = held.first {
+                held.removeFirst()
+                heldSamples -= UInt64(first.count)
+                heldStartSample += UInt64(first.count)
+            }
+        }
+        lock.unlock()
+    }
+
+    // MARK: leg lifecycle
+
+    /// Point the bridge at a leg with nothing held (the first connection).
+    public func attach<Leg: PcmSink>(_ leg: Leg) {
+        attach { _ in leg }
+    }
+
+    /// Create the next leg and hand it everything held during the gap.
+    ///
+    /// The closure receives the timestamp offset that leg must be configured
+    /// with — the position of the oldest held sample, or the live position
+    /// when nothing is held. Creating the client inside the closure is what
+    /// makes offset, flush, and swap one atomic step: a chunk arriving from
+    /// the audio thread mid-way can only land before the flush (held, and so
+    /// flushed in order) or after the swap (sent straight to the new leg).
+    /// Returning nil leaves the bridge holding.
+    @discardableResult
+    public func attach<Leg: PcmSink>(_ make: (UInt64) -> Leg?) -> Leg? {
+        lock.lock()
+        let offsetSamples = held.isEmpty ? totalSamples : heldStartSample
+        let offsetMs = offsetSamples * 1000 / sampleRate
+        guard let next = make(offsetMs) else {
+            lock.unlock()
+            return nil
+        }
+        let pending = held
+        held = []
+        heldSamples = 0
+        heldStartSample = totalSamples
+        holding = false
+        sink = next
+        lock.unlock()
+        // Outside the lock: `enqueue` is non-blocking, but the audio thread
+        // must never wait on a flush of up to 45 s of chunks.
+        for chunk in pending {
+            next.enqueue(pcm: chunk)
+        }
+        return next
+    }
+
+    /// The current leg is gone. Audio from here on is held until the next
+    /// `attach` — or dropped by `discard()` when reconnecting is given up on.
+    public func hold() {
+        lock.lock()
+        sink = nil
+        holding = true
+        heldStartSample = totalSamples - heldSamples
+        lock.unlock()
+    }
+
+    /// Stop holding and drop what is held: no leg is coming. The bridge stays
+    /// usable (and keeps counting) so the clock survives for a later attach.
+    public func discard() {
+        lock.lock()
+        sink = nil
+        holding = false
+        held = []
+        heldSamples = 0
+        heldStartSample = totalSamples
+        lock.unlock()
+    }
+
+    /// Forget everything, including the clock — a new recording.
+    public func reset() {
+        lock.lock()
+        sink = nil
+        holding = false
+        held = []
+        heldSamples = 0
+        totalSamples = 0
+        heldStartSample = 0
+        lock.unlock()
+    }
+
+    // MARK: observation
+
+    /// Position of the next sample to arrive, in milliseconds since `reset()`.
+    public var capturedMilliseconds: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return totalSamples * 1000 / sampleRate
+    }
+
+    /// How much audio is currently held for the next leg.
+    public var heldMilliseconds: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return heldSamples * 1000 / sampleRate
+    }
+
+    /// True while there is no leg and audio is being kept for the next one.
+    public var isHolding: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return holding
+    }
+}

--- a/ios/ParleyKit/Sources/ParleyKit/SttRelayClient.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/SttRelayClient.swift
@@ -5,7 +5,21 @@ public enum SttRelayEvent: Sendable {
     case segment(TranscriptSegment)
     /// Stream ended: normally (`finished`/server close after finalize) or not.
     case closed(reason: String)
-    case error(String)
+    /// An in-band error frame. `code` is the relay's when it sent one — 402
+    /// (out of quota) is the case worth telling apart, because redialling a
+    /// refused account only produces the same refusal on a slower clock.
+    case error(String, code: Int? = nil)
+}
+
+extension SttRelayEvent {
+    /// The relay says this account is out of transcription quota. Reconnecting
+    /// cannot fix it; the next handshake is refused the same way.
+    public static let quotaExceededCode = 402
+
+    public var isQuotaExceeded: Bool {
+        if case .error(_, Self.quotaExceededCode) = self { return true }
+        return false
+    }
 }
 
 /// WebSocket client for Parley's hosted STT relay
@@ -244,7 +258,7 @@ public actor SttRelayClient {
                     break
                 }
             } catch let err as SonioxStreamError {
-                onEvent(.error("relay error \(err.code): \(err.message)"))
+                onEvent(.error("relay error \(err.code): \(err.message)", code: err.code))
                 break
             } catch {
                 // Server closed the socket (normal after drain) or transport

--- a/ios/ParleyKit/Tests/ParleyKitTests/ReconnectPolicyTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/ReconnectPolicyTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import ParleyKit
+
+final class ReconnectPolicyTests: XCTestCase {
+    func testBackoffDoublesFromTheBaseAndCaps() {
+        let policy = ReconnectPolicy(maxAttempts: 8, base: .seconds(1), cap: .seconds(15))
+        let ladder = (1...8).map { policy.delay(forAttempt: $0) }
+
+        XCTAssertEqual(
+            ladder,
+            [
+                .seconds(1), .seconds(2), .seconds(4), .seconds(8),
+                .seconds(15), .seconds(15), .seconds(15), .seconds(15),
+            ])
+    }
+
+    func testTotalWaitCoversAFlakyStretchWithoutHammering() {
+        let policy = ReconnectPolicy()
+        let total = (1...policy.maxAttempts)
+            .map { policy.delay(forAttempt: $0).components.seconds }
+            .reduce(0, +)
+
+        // 1+2+4+8+15+15+15+15 — a minute and a quarter of trying, and never
+        // more than four dials in the first ten seconds.
+        XCTAssertEqual(total, 75)
+        XCTAssertLessThanOrEqual(
+            (1...3).map { policy.delay(forAttempt: $0).components.seconds }.reduce(0, +), 10)
+    }
+
+    func testGivesUpPastTheAttemptCeiling() {
+        let policy = ReconnectPolicy(maxAttempts: 3)
+
+        XCTAssertEqual(policy.decide(attempt: 1), .retry(after: .seconds(1)))
+        XCTAssertEqual(policy.decide(attempt: 3), .retry(after: .seconds(4)))
+        XCTAssertEqual(policy.decide(attempt: 4), .giveUp)
+        XCTAssertEqual(policy.decide(attempt: 99), .giveUp)
+    }
+
+    func testDictationRedialsFasterAndGivesUpSooner() {
+        let dictation = ReconnectPolicy.dictation
+        let meeting = ReconnectPolicy()
+
+        XCTAssertLessThan(dictation.delay(forAttempt: 1), meeting.delay(forAttempt: 1))
+        XCTAssertLessThan(dictation.maxAttempts, meeting.maxAttempts)
+        XCTAssertEqual(dictation.decide(attempt: dictation.maxAttempts + 1), .giveUp)
+        // The whole ladder fits inside a dictation session's two-minute cap.
+        let total = (1...dictation.maxAttempts)
+            .map { dictation.delay(forAttempt: $0) }
+            .reduce(Duration.zero, +)
+        XCTAssertLessThan(total, .seconds(30))
+    }
+
+    func testAttemptZeroIsNeverAskedToWaitNegatively() {
+        let policy = ReconnectPolicy()
+        XCTAssertEqual(policy.delay(forAttempt: 0), policy.base)
+        XCTAssertEqual(policy.decide(attempt: 0), .giveUp)
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/RelayAudioBridgeTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/RelayAudioBridgeTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// The contract a reconnect depends on: audio spoken while no socket exists is
+/// held, bounded, delivered in order to the next leg, and timestamped so it
+/// lands where it was actually said.
+final class RelayAudioBridgeTests: XCTestCase {
+    /// One second of audio at the pipeline's fixed 16 kHz.
+    private static let secondOfSamples = Int(SonioxProtocol.sampleRate)
+
+    private final class Recorder: PcmSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var chunks: [[Int16]] = []
+
+        func enqueue(pcm samples: [Int16]) {
+            lock.lock()
+            chunks.append(samples)
+            lock.unlock()
+        }
+
+        var received: [[Int16]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return chunks
+        }
+
+        var sampleCount: Int { received.reduce(0) { $0 + $1.count } }
+    }
+
+    /// A chunk whose every sample carries `marker`, so ordering is checkable.
+    private func chunk(_ marker: Int16, samples: Int = 1_600) -> [Int16] {
+        Array(repeating: marker, count: samples)
+    }
+
+    func testAttachedAudioGoesStraightToTheLeg() {
+        let bridge = RelayAudioBridge()
+        let leg = Recorder()
+        bridge.attach(leg)
+
+        bridge.send(chunk(1))
+        bridge.send(chunk(2))
+
+        XCTAssertEqual(leg.received.map { $0.first }, [1, 2])
+        XCTAssertFalse(bridge.isHolding)
+        XCTAssertEqual(bridge.heldMilliseconds, 0)
+    }
+
+    func testGapAudioIsHeldAndFlushedIntoTheNextLegInOrder() {
+        let bridge = RelayAudioBridge()
+        let first = Recorder()
+        bridge.attach(first)
+        bridge.send(chunk(1))
+
+        bridge.hold()
+        bridge.send(chunk(2))
+        bridge.send(chunk(3))
+        XCTAssertTrue(bridge.isHolding)
+        XCTAssertEqual(bridge.heldMilliseconds, 200, "two 100 ms chunks are waiting")
+
+        let second = Recorder()
+        bridge.attach { _ in second }
+        bridge.send(chunk(4))
+
+        XCTAssertEqual(first.received.map { $0.first }, [1], "the dead leg gets nothing more")
+        XCTAssertEqual(
+            second.received.map { $0.first }, [2, 3, 4],
+            "the gap arrives before the audio that followed it")
+        XCTAssertEqual(bridge.heldMilliseconds, 0)
+    }
+
+    func testTheNextLegIsOffsetToWhereTheHeldAudioWasSpoken() {
+        let bridge = RelayAudioBridge()
+        bridge.attach(Recorder())
+        // Ten seconds of meeting before the socket dies.
+        for _ in 0..<10 { bridge.send(chunk(1, samples: Self.secondOfSamples)) }
+
+        bridge.hold()
+        // Three seconds spoken into the gap.
+        for _ in 0..<3 { bridge.send(chunk(2, samples: Self.secondOfSamples)) }
+
+        var offset: UInt64?
+        bridge.attach { ms in
+            offset = ms
+            return Recorder()
+        }
+
+        XCTAssertEqual(
+            offset, 10_000,
+            "the leg's clock starts at the first sample it is fed, not at the reconnect")
+        XCTAssertEqual(bridge.capturedMilliseconds, 13_000)
+    }
+
+    func testOffsetWithNothingHeldIsTheLivePosition() {
+        let bridge = RelayAudioBridge()
+        bridge.attach(Recorder())
+        for _ in 0..<5 { bridge.send(chunk(1, samples: Self.secondOfSamples)) }
+        bridge.hold()
+
+        var offset: UInt64?
+        bridge.attach { ms in
+            offset = ms
+            return Recorder()
+        }
+        XCTAssertEqual(offset, 5_000)
+    }
+
+    func testHoldingIsBoundedAndDropsTheOldestAudio() {
+        let bridge = RelayAudioBridge(holdLimit: .seconds(3))
+        bridge.attach(Recorder())
+        bridge.hold()
+
+        // Six seconds into a three-second buffer.
+        for marker in 1...6 { bridge.send(chunk(Int16(marker), samples: Self.secondOfSamples)) }
+        XCTAssertEqual(bridge.heldMilliseconds, 3_000, "the hold never grows past its bound")
+
+        let leg = Recorder()
+        var offset: UInt64?
+        bridge.attach { ms in
+            offset = ms
+            return leg
+        }
+
+        XCTAssertEqual(
+            leg.received.map { $0.first }, [4, 5, 6], "the oldest seconds were dropped, not the newest")
+        XCTAssertEqual(
+            offset, 3_000,
+            "the offset follows the front of the buffer, so the surviving audio still lands where it was said"
+        )
+    }
+
+    func testDiscardDropsHeldAudioAndKeepsTheClock() {
+        let bridge = RelayAudioBridge()
+        bridge.attach(Recorder())
+        bridge.send(chunk(1, samples: Self.secondOfSamples))
+        bridge.hold()
+        bridge.send(chunk(2, samples: Self.secondOfSamples))
+
+        bridge.discard()
+        XCTAssertFalse(bridge.isHolding)
+        XCTAssertEqual(bridge.heldMilliseconds, 0)
+
+        // Audio after giving up is dropped on the floor rather than piling up.
+        bridge.send(chunk(3, samples: Self.secondOfSamples))
+        XCTAssertEqual(bridge.heldMilliseconds, 0)
+        XCTAssertEqual(bridge.capturedMilliseconds, 3_000)
+
+        let leg = Recorder()
+        var offset: UInt64?
+        bridge.attach { ms in
+            offset = ms
+            return leg
+        }
+        XCTAssertEqual(offset, 3_000, "a later leg still knows how far into the recording it is")
+        XCTAssertEqual(leg.sampleCount, 0)
+    }
+
+    func testAttachReturningNilLeavesTheBridgeHolding() {
+        let bridge = RelayAudioBridge()
+        bridge.hold()
+        bridge.send(chunk(1))
+
+        let leg: Recorder? = bridge.attach { _ -> Recorder? in nil }
+        XCTAssertNil(leg)
+        XCTAssertTrue(bridge.isHolding)
+        XCTAssertEqual(bridge.heldMilliseconds, 100, "nothing was flushed, so nothing was lost")
+    }
+
+    func testResetForgetsTheClock() {
+        let bridge = RelayAudioBridge()
+        bridge.attach(Recorder())
+        bridge.send(chunk(1, samples: Self.secondOfSamples))
+        bridge.reset()
+
+        XCTAssertEqual(bridge.capturedMilliseconds, 0)
+        XCTAssertFalse(bridge.isHolding)
+    }
+
+    /// A leg that dies while the microphone is mid-chunk must not lose or
+    /// reorder audio: everything sent lands somewhere, exactly once, in order.
+    func testConcurrentSendsAcrossAReconnectLoseNothing() {
+        let bridge = RelayAudioBridge()
+        let first = Recorder()
+        let second = Recorder()
+        bridge.attach(first)
+
+        let chunks = 200
+        let sender = DispatchQueue(label: "audio-thread")
+        let done = expectation(description: "audio sent")
+        sender.async {
+            for i in 0..<chunks {
+                bridge.send([Int16(i)])
+            }
+            done.fulfill()
+        }
+        // Swap the leg out and in from under the sender.
+        bridge.hold()
+        bridge.attach { _ in second }
+        wait(for: [done], timeout: 5)
+
+        let delivered = (first.received + second.received).map { $0[0] }
+        XCTAssertEqual(delivered.count, chunks, "every chunk reached a leg exactly once")
+        XCTAssertEqual(delivered, delivered.sorted(), "and none of them overtook another")
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/SttRelayEventTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/SttRelayEventTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// Which failures are worth redialling. Everything the relay can say is a
+/// reconnect except the refusal that would simply be repeated.
+final class SttRelayEventTests: XCTestCase {
+    func testQuotaRefusalIsNotWorthRedialling() {
+        let event = SttRelayEvent.error("relay error 402: out of quota", code: 402)
+        XCTAssertTrue(event.isQuotaExceeded)
+    }
+
+    func testOtherFailuresAreOrdinaryDrops() {
+        XCTAssertFalse(SttRelayEvent.error("relay error 500: upstream", code: 500).isQuotaExceeded)
+        XCTAssertFalse(SttRelayEvent.error("socket died").isQuotaExceeded)
+        XCTAssertFalse(SttRelayEvent.closed(reason: "close code=1006 ").isQuotaExceeded)
+    }
+
+    /// The parser's in-band error frame is where the code comes from, so the
+    /// two have to agree on the number.
+    func testStreamErrorCarriesTheCodeTheEventChecksFor() {
+        let parser = SonioxStreamParser { _ in }
+        XCTAssertThrowsError(
+            try parser.process(#"{"error_code":402,"error_message":"out of quota"}"#)
+        ) { error in
+            XCTAssertEqual(
+                (error as? SonioxStreamError)?.code, SttRelayEvent.quotaExceededCode)
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of #283 — the relay half, on iOS.

## What was actually broken

The report is "a phone call ends the recording", and reading the code it was three things. Only one of them still is.

**The relay never reconnected on the dictation path, and threw the gap away on the meeting path.** `DictationCoordinator` turned any `.closed` into `finishUp()` and any `.error` into `fail(message)` — with the raw wire string (`relay error 402: …`) shown to the user. `MeetingRecorder` did reconnect (that landed in #272) but dropped the sink the moment the socket died, so everything said during the backoff was gone from the live transcript, and the new leg's offset was `systemUptime - captureStartedAt` — "now" — which files a gap's worth of speech *after* the words that followed it.

**Can the relay resume a session? No.** One socket carries one Soniox session; there is no resume token in the protocol (`SonioxProtocol.swift` — config frame, keepalive, finalize, and that is the whole upstream vocabulary), and `SttRelayClient` is explicitly single-use. So a reconnect is necessarily a **fresh Soniox leg** whose token clock restarts at zero. That is exactly what `Options.idPrefix` and `Options.timeOffsetMs` were put there for; what was missing was something to hold the audio across the gap and a clock honest about where that audio belongs. This PR does not paper over the lack of resume — it builds on the per-leg offset the protocol already assumed.

**iOS audio interruptions: already fixed, left alone.** `AudioCapture` (#272) observes `interruptionNotification`, `routeChangeNotification`, `.AVAudioEngineConfigurationChange` and `mediaServicesWereResetNotification`, rebuilds the engine rather than leaving a tap on a dead node, deliberately ignores the absent `.shouldResume` (which is exactly the "other party hung up" case), and runs a two-second watchdog for what iOS announces to nobody. That covers the reported case. I did not touch it.

## What this PR adds

**`RelayAudioBridge` (ParleyKit).** The microphone's only counterparty. It forwards chunks to the current leg and *holds* them while there is none, bounded (45 s meetings, 20 s dictation) with drop-oldest, and on the next `attach` it hands the new leg both the held audio, in order, and the offset of its **first held sample**. Overflow advances that offset with the front of the buffer, so a leg is never told it is being fed audio it is not. `attach` takes a factory closure so the offset, flush and swap are one step the audio thread cannot land in the middle of.

**`ReconnectPolicy` (ParleyKit).** The 1, 2, 4, 8 … capped ladder and the attempt ceiling, in one place instead of a `pow()` inline per recorder. `.dictation` redials faster and gives up sooner — a two-minute session with someone standing there is not a meeting.

**`MeetingRecorder`** moves onto both, so the gap is kept instead of dropped and the offset comes from the bridge.

**`DictationCoordinator`** gets reconnect at all: a dropped socket redials with the microphone still open, each leg gets its own id prefix so leg 2's first sentence cannot overwrite leg 1's, the tentative tail is folded into the settled text rather than dying with the socket, and only an exhausted ladder ends the session — keeping every word the keyboard already typed into the user's document.

**Reconnecting no longer looks like failed**, in both languages:

| | reconnecting | live transcript over |
|---|---|---|
| meeting screen | amber spinner + "Transcription dropped — reconnecting…" / 「轉錄連線中斷，正在重新連線…」 | full-weight ink + icon, "…the recording is still running and will be transcribed after it syncs." |
| dictation screen | "Reconnecting…" / 「重新連線中…」 with "keep talking, what you say is kept" | error state, "Lost the connection. What you already said has been typed…" |
| keyboard | amber "Reconnecting… keep talking" / 「重新連線中…可以繼續說」 above the transcript, which stays put | red error caption |

The keyboard learns a `reconnecting` downlink state, so it stops going quiet mid-session. Red stays reserved for a session that actually ended; the meeting's "stopped" line is ink rather than red, because the *recording* is still running and colouring it like a failure would say the opposite of what the sentence says.

**One failure is deliberately not retried.** A 402 means the account is out of quota and the next handshake is refused identically, so `SttRelayEvent.error` now carries the relay's code and both paths say what happened instead of spending the whole ladder to arrive at "lost the connection".

## Verified

- `swift test --package-path ios/ParleyKit` — 37 tests, 16 new: hold/flush ordering, the bound and its drop-oldest, **timestamp continuity across a simulated reconnect leg** (10 s of meeting + 3 s into the gap ⇒ the new leg is offset to 10 000 ms, not 13 000), discard-keeps-the-clock, a concurrent-sender test that no chunk is lost or reordered while a leg is swapped underneath, the backoff ladder and ceiling, and the quota code the parser and the event have to agree on.
- `xcodebuild -project ios/App/Parley.xcodeproj -scheme Parley -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — clean (after `xcodegen generate`).
- `bunx tsc --noEmit` and `bunx vitest run` (231 tests) — clean. Untouched by this change; run because CLAUDE.md asks for it.
- Every new string has both `en` and `zh-Hant` entries in the app and keyboard catalogs.

## Not verified — needs a device

None of the below is reachable from a simulator or a unit test, and I have not run any of it. From the checklist in #283, for **iOS**:

- [ ] Incoming call, answered, then ended → recording continues, transcript continues, no gap beyond the call.
- [ ] Incoming call, declined → same.
- [ ] Wi-Fi → cellular handover mid-recording.
- [ ] Airplane mode for ~10 s mid-recording → reconnects, and the words spoken during the gap actually arrive (they are inside the 45 s hold, so they should — this is the specific claim most worth checking).
- [ ] Siri, an alarm, and another app opening a recording session.
- [ ] The relay restarted under a live session.
- [ ] The same six against **dictation**, where the ladder is shorter (0.5, 1, 2, 4 s) and the session is capped at two minutes — including that the keyboard shows "Reconnecting… keep talking" rather than going quiet, and that nothing is double-inserted across a leg change.
- [ ] A held gap longer than the bound (>45 s meeting / >20 s dictation) → the oldest audio is dropped and the surviving audio still lands at the right timestamp.

Two behaviours worth a specific eye on a device: the relay-side timestamps of a reconnected leg (the unit test proves the offset the client is *given*, not what the relay does with it), and whether a 402 arrives as an in-band error frame (handled) or as a socket close with code 1011 (falls through to the ordinary reconnect ladder, ending in the honest "live transcription stopped" line 75 s later).

## Not in this PR

Android — no audio focus handling at all, and `MeetingSession` throws the reconnect gap away exactly as iOS did. It is a separate PR by someone who can build it: there is no Android SDK on the machine this was written on and CI skips `android/**` on pull requests, so shipping unbuildable Kotlin here would have been worse than not shipping it. Filed with the full design and the device checklist as #284.

Closes nothing on its own — #283 stays open until #284 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
