### PR TITLE
[feature] a microphone window, so the keyboard's mic stops leaving the app you are typing in

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -42,7 +42,8 @@ hand-off, and the in-app dictation session are new.
 2. **App records.** `onOpenURL` routes to `DictationCoordinator`, which starts
    the mic + relay and mirrors the growing transcript into a *downlink* file,
    posting a Darwin notification on each update.
-3. **Return to the host app.** See the two regimes below.
+3. **Return to the host app** — or, far better, never leave it. See the
+   microphone window below.
 4. **Keyboard inserts.** On the Darwin note (and on every `viewWillAppear`, in
    case it was suspended through the notification), the keyboard reads the
    downlink and inserts whatever is new past its high-water mark
@@ -55,13 +56,20 @@ hand-off, and the in-app dictation session are new.
 
 ### App Group channel
 
-`DictationChannel` (in ParleyKit, so both targets share it) is two single-writer
-mailboxes plus two Darwin notifications, so the two processes never contend on a
-file:
+`DictationChannel` (in ParleyKit, so both targets share it) is four
+single-writer mailboxes, each with its own Darwin notification, so the two
+processes never contend on a file:
 
 - `dictation-down.json` — app → keyboard: `{session, committed, partial, state}`.
 - `dictation-up.json` — keyboard → app: `{session, hostBundleID, stopRequested,
   insertedCount}`.
+- `dictation-window.json` — app → keyboard: `{length, openedAt, expiresAt,
+  updatedAt}`, the microphone window and its heartbeat.
+- `dictation-window-control.json` — keyboard → app: `{closeRequestedAt}`, the
+  keyboard's "end the window now".
+
+The window pair is separate from the session pair because a window outlives any
+one dictation, and most of what it has to say happens when no session exists.
 
 The files are the source of truth; the Darwin notes are pure "go re-read"
 signals (they carry no payload). This is what makes the hand-off robust to the
@@ -70,36 +78,187 @@ missed is still in the downlink when it returns.
 
 App Group id: `group.com.pathors.parley.ios` (entitlement on both targets).
 
-## The "jump back to the previous app" problem
+## Not leaving in the first place — the microphone window
 
-Typeless's signature touch — tap the keyboard, it opens the app, and the app
-*automatically returns you to where you were* — was never a public API. It relied
-on the keyboard reading the host app's bundle id through private getters
-(`_hostBundleID`) and the app calling the private
-`LSApplicationWorkspace.openApplicationWithBundleID:`.
+This section used to be called "the jump back to the previous app problem", and
+it framed the whole thing as closed by Apple: the private auto-return died in
+iOS 26.4, so the answer was a swipe-back guide. That framing is what sent this
+feature down the wrong path, because **the competitors' trick is not returning
+faster. It is not leaving.**
 
-**Apple closed this in iOS 26.4.** The host-bundle-id getters now return nil, and
-the private launch lands on the Home Screen rather than the host app. Wispr Flow's
-own docs confirm the change: before 26.4 their keyboard "briefly opened the Flow
-app and returned you automatically"; now they instruct users to swipe right on
-the home indicator to go back.
+Wispr Flow sells the microphone as a *window of time* rather than a per-tap
+permission — their docs describe sessions as windows during which you let the
+app use the microphone. The first tap opens the app and starts the window; while
+it is open the app stays resident, and every later tap records with no app switch
+at all. Parley already had the shape of that path and almost never won it.
 
-Parley's decision (隱蔽 + 版本閘門) is to keep the good experience where it still
-works and degrade cleanly where it doesn't:
+### Why the old path lost
 
-- **iOS < 26.4** (`HostReturn.canReturn == true`): the app auto-returns to the
-  host app via the private launch. Every private symbol is assembled from string
-  fragments at runtime and reached through `responds(to:)`/`perform`, so no
-  literal private symbol sits in the binary (lowering the odds of a static-scan
-  2.5.1 flag) and a missing getter is a `nil`, never a crash.
-- **iOS 26.4+**: no private call is attempted. The dictation screen owns the
-  hand-off instead — it teaches the one gesture that replaces auto-return (swipe
-  right on the home bar) with a looping first-run guide, and reassures that
-  talking still works from the other app (the audio session keeps the mic alive
-  under `UIBackgroundModes: audio`). This matches shipped Wispr Flow behavior.
+`KeyboardViewController.startDictation` publishes the request to the App Group,
+waits `startAckWindow` (700 ms) for the app to answer, and only opens
+`parley://dictate` if nothing does. An app that is awake answers in
+milliseconds. The problem was how briefly the app stayed awake:
+`DictationCoordinator.beginLinger` is a `beginBackgroundTask`, and iOS grants one
+of those roughly **30 seconds**. Pause to think mid-sentence and the window is
+gone — so in practice every tap took the round trip.
 
-If Apple ships a public round-trip API (their open enhancement is FB22247647),
-only steps 1–3 change.
+There is also a second, harder reason, and it is the one that makes "keep the
+process awake longer" insufficient on its own: **iOS refuses to let a
+backgrounded process start recording.** Activating a record session from the
+background returns `AVAudioSessionErrorCodeCannotStartRecording` with
+`Client … is in the background and doesn't have the entitlement to start
+recording in the background` in the log. Apple has never published exactly how
+this interacts with `UIBackgroundModes: audio`, and we cannot settle it from a
+simulator. A resident process that still could not open the microphone would
+have had to come forward anyway.
+
+### What a window is
+
+The window sidesteps both. `MicWindowLength` (`ParleyKit/MicWindow.swift`) is a
+user setting — off / 5 minutes / 15 minutes / 1 hour — and while a window is open
+the app **does not close the microphone at the end of a dictation**. The audio
+session stays active, which is what keeps the process resident for minutes rather
+than seconds, and the next session does not *start* recording at all: it borrows
+a capture that has been running since the app was last in the foreground. The
+question of whether a background start is allowed never comes up, because there
+is never a background start.
+
+```
+tap 1   keyboard → parley://dictate → app comes forward → mic opens (foreground)
+        dictation → user swipes back → dictation ends
+        ─── window opens: capture keeps running, audio goes nowhere ───
+tap 2   keyboard → Darwin note → app (background, mic already open) attaches
+        the relay to the running capture.  No app switch.
+tap 3   …
+        ─── window expires: capture stops, indicator goes out ───
+tap 4   round trip again
+```
+
+`AudioCapture` is unchanged. `DictationCoordinator` simply stopped treating the
+microphone as a session's property: `releaseMicrophone()` at the end of a
+dictation either hands it to the window or closes it, and `launch()` reuses
+whatever is already running. While no dictation is attached, chunks go into
+`RelayAudioBridge` with no leg and no hold, which counts them and drops them —
+**an open window records nothing, because there is nowhere for the audio to go.**
+
+### What it costs, and where that is said
+
+The microphone is genuinely open for the whole window, so **iOS shows the orange
+recording indicator for the whole window**. That is the real price of this
+design, and it is not something to discover.
+
+- The Settings picker states it in the same breath as the benefit, before the
+  choice is made — see the footer under *Keeping the microphone ready*. It says
+  the indicator will be on, that Parley really is holding the microphone, and
+  that nothing is recorded, transcribed, or sent until the mic is tapped.
+- The **Record tab** grows a bar while a window is open. Someone who notices an
+  orange dot opens Parley and lands there; a record screen saying "not
+  recording" under a lit indicator would read as a lie.
+- The keyboard shows a **"Mic ready" chip** in the mode strip, in iOS's own
+  indicator orange rather than a Parley colour — two marks for the same fact
+  should look like the same fact.
+
+Every one of those three is also a way to end the window early.
+
+### A tap that stays and a tap that jumps must not look the same
+
+The chip is the positive signal, and it sits in the mode strip rather than on the
+voice pane: the strip already has an empty middle, the fact is true of the
+keyboard rather than of one pane, and the voice pane's heights are measured to
+the point where adding an element moves the record button. It is hidden during a
+session — the record button already says the microphone is live, and the chip is
+about the *next* tap.
+
+The negative signal cannot be the mere absence of the chip, so the idle slot
+gains a second line — *This tap opens Parley first* — but **only for someone who
+has turned a window on**. Without the setting, every tap has always opened
+Parley; saying so on every keyboard would be noise rather than information.
+
+### Bounded on purpose: there is no "until I turn it off"
+
+Wispr Flow offers a never-expires option. Parley does not, for two reasons that
+are really one:
+
+1. **It is a promise the platform will not let us keep.** A window is a live
+   recording session in a backgrounded app. iOS reclaims those under memory
+   pressure; another app taking the microphone ends ours; neither gives us a
+   chance to tell anyone. A window we close ourselves is one we can be right
+   about.
+2. **It is the one option with no natural end.** Every other choice eventually
+   turns the indicator off on its own, which makes a forgotten window
+   self-correcting. An unbounded one is a microphone left open for a day because
+   someone tapped a picker once.
+
+For the same reason the default is **off**. The setting existing is the point;
+an on-by-default open microphone is not.
+
+### The heartbeat, and why the keyboard does not trust the expiry
+
+The app writes `dictation-window.json`; the app can also be killed without ever
+writing again. The file left behind still says "open for another 50 minutes", and
+a keyboard that believed it would show a ready microphone that does not exist and
+then jump anyway.
+
+So the app re-stamps the file every `MicWindowState.heartbeat` (20 s) for as long
+as the window is really open, and a reader disbelieves a stamp older than
+`staleAfter` (55 s). One mechanism, two jobs: the same heartbeat is what ticks the
+chip's countdown without the extension running a timer of its own. Expiry is
+still punctual — the app's loop sleeps the *shorter* of a heartbeat and whatever
+is left, because five minutes has to mean five minutes.
+
+Ending early is a **timestamp, not a flag**: the keyboard writes
+`closeRequestedAt` and the app closes any window opened at or before it. Neither
+side ever has to clear anything, and a leftover request cannot refuse to let the
+next window open.
+
+### What ends a window
+
+Expiry, the user (from the keyboard, the Record tab, or Settings), a session
+failure of any kind, the microphone being interrupted or lost, and a meeting
+recording starting — there is one microphone, and `MeetingRecorder.start` takes
+it. Interruption is deliberately fatal to the window rather than something to
+wait out: **a window that cannot be honoured is worse than one that ended early,
+because the user can see the second and cannot see the first.**
+
+A background task is never held while a window is open. `beginBackgroundTask` is
+worth nothing next to an active audio session, and ending an assertion in the
+background is a documented way to get suspended anyway.
+
+### App Review
+
+The defence is consent that is visible and reversible, in that order: the user
+chose the length, the indicator says it is happening, three separate surfaces say
+what it means, and each of them ends it. The window is bounded in every case, it
+holds no audio, and nothing leaves the device until the mic is tapped. No private
+API is involved anywhere in it — audio session, App Group, Darwin notifications,
+`insertText`.
+
+### The jump that is left, and what is actually known about it
+
+There is still a first tap, and a tap after a window closes. Those still open
+Parley, and the dictation screen still teaches the swipe back (`SwipeBackGuide`).
+Two things are worth writing down rather than repeating:
+
+- **On iOS 26.4+ the host app cannot be detected at all.** The private
+  bundle-id path returns nil and `UIApplication.suspend()` lands on the Home
+  Screen because the app was launched by an extension. Apple's DTS has answered
+  that there is no public way to identify the host or to return to it
+  (FB22247647 remains open). The destination does not have to be *detected*
+  though — it can be *chosen*, which is how KeyboardKit 10.4 handles it, and is
+  tracked separately.
+- **Our own pre-26.4 auto-return has never fired on any iOS version.**
+  `KeyboardHost.bundleID(of:)` probes `_hostBundleID` and
+  `_hostApplicationBundleIdentifier` with `responds(to:)` **on the
+  `UIInputViewController` itself**. Both parts are wrong: the value lives on the
+  controller's `parent` (an `_UIViewServiceViewControllerOperator`), and
+  `_hostBundleID` is an **ivar with no getter**, so `responds(to:)` is
+  unconditionally false and only KVC's ivar fallback can reach it. So
+  `HostReturn.attempt` has never run, on 26.4 or before. Tracked separately; the
+  fix is small but it is a behaviour change nobody can verify without a device
+  below 26.4.
+
+Neither is why the reported bug happens, which is worth being clear about: the
+report is that dictation *leaves*, and leaving is what the window fixes.
 
 ## Action Button / Control Center trigger
 
@@ -287,9 +446,14 @@ more tap.
 - **Never trapping the user**: the exit is the system's own globe on the devices
   that draw one, and ours on the devices that don't — `needsInputModeSwitchKey`
   decides, in both panes. See the 注音 section above.
-- **2.5.1** (private APIs): the auto-return path is private and version-gated to
-  where it works; the rest of the flow (openURL, App Group, insertText, App
-  Intents) is entirely public.
+- **2.5.1** (private APIs): the only private code in the project is the
+  pre-26.4 auto-return, version-gated to where it once worked and — as the
+  microphone-window section records — never actually reached. Everything the
+  feature runs on is public: audio session, openURL, App Group, Darwin
+  notifications, insertText, App Intents.
+- **The microphone window** is the one part of this keyboard that holds a
+  system resource while the user is elsewhere. Its defence is consent that is
+  visible and reversible: see that section.
 - Memory: the keyboard process holds no audio, no model, and no transcript
   history — it only shuttles text — to stay under the tight jetsam limit
   keyboard extensions run against.

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -15,6 +15,23 @@ import UIKit
 /// One session at a time. A single coordinator is shared by both entry points —
 /// the keyboard's URL (`begin(session:)`) and the Action Button App Intent
 /// (`beginFromIntent()`) — so the two can never race two microphones open.
+///
+/// ## The microphone is not a session's
+///
+/// The interesting part of this object is what happens *between* dictations.
+/// When the user has chosen a microphone window (`MicWindowLength`), the end of
+/// a session does not close the microphone: the audio session stays active,
+/// which keeps this process resident for minutes instead of the ~30 seconds a
+/// background task buys, and the next session **borrows the running capture**
+/// rather than opening one. That is what lets a keyboard tap be served where
+/// the user already is instead of throwing them into Parley — and it is also
+/// the only way it can work at all, because iOS refuses to let a backgrounded
+/// process *start* recording. A window never starts; it continues.
+///
+/// The cost is that the orange microphone indicator is lit for the whole
+/// window, which is why the window is a setting, is bounded, is announced in
+/// three places, and can be ended from any of them. See
+/// `docs/design/ios-voice-keyboard.md`.
 @MainActor
 final class DictationCoordinator: ObservableObject {
     static let shared = DictationCoordinator()
@@ -37,8 +54,20 @@ final class DictationCoordinator: ObservableObject {
     /// that ended with users told to visit Settings for a permission they were
     /// never actually asked for.
     @Published private(set) var awaitingMicPermission = false
+    /// The microphone window the app is holding right now (see `MicWindow`).
+    /// Mirrored into the App Group so the keyboard can tell the user whether
+    /// the next tap will stay put.
+    @Published private(set) var window: MicWindowState
+    /// Why a window the user asked for could not be opened — a denied
+    /// microphone, or the audio session refusing. Shown in Settings, because a
+    /// picker that silently does nothing is worse than no picker.
+    @Published private(set) var windowProblem: String?
 
     private var session = ""
+    /// The microphone. Not a session's: once the user has chosen a window it
+    /// outlives the dictation that opened it, and the *next* dictation borrows
+    /// it rather than opening its own. That is the entire mechanism — see the
+    /// microphone-window section below.
     private var capture: AudioCapture?
     private var relay: SttRelayClient?
     /// The microphone's only counterparty. It forwards to the current relay
@@ -62,10 +91,31 @@ final class DictationCoordinator: ObservableObject {
     /// requests for the running session, and — the no-jump path — start
     /// requests from a keyboard while this process is awake in the background.
     private var requestObserver: DarwinObserver?
+    /// The keyboard asking for the microphone window to end now. Armed for the
+    /// process's whole life, like `requestObserver`.
+    private var windowControlObserver: DarwinObserver?
+    /// Heartbeat + expiry for the open window, in one loop (see `runWindow`).
+    private var windowTask: Task<Void, Never>?
+    /// A meeting recording has taken the microphone (see `yieldMicrophone`).
+    private var yieldedToMeeting = false
+    /// Whether the microphone's level is still worth reporting. Read on the
+    /// audio thread for every chunk, so it cannot be main-actor state: while a
+    /// window is open with no session, the microphone runs for up to an hour
+    /// with nothing on screen to show a level to, and hopping to the main actor
+    /// a dozen times a second to set a number nobody reads is exactly the kind
+    /// of background wakeup that shows up as battery.
+    private let reportsLevel = LevelGate()
     /// Keeps the process awake ~30 s after a session ends — and after any trip
     /// to the background (see `armLifecycleLinger`) — so the keyboard's next
     /// mic tap starts over the Darwin channel with no app switch. `.invalid`
-    /// when no window is open.
+    /// when no background task is held.
+    ///
+    /// This is the *fallback*, not the mechanism: `beginBackgroundTask` is
+    /// worth roughly 30 seconds, which is why the keyboard almost never won
+    /// the race. It is deliberately never used while a microphone window is
+    /// open — an active recording session is what keeps the process resident,
+    /// and mixing a background task into it risks the assertion's end
+    /// suspending an app the audio session was holding up.
     private var lingerTask: UIBackgroundTaskIdentifier = .invalid
     /// See `armLifecycleLinger`. Held for the process's whole life, like
     /// `requestObserver`.
@@ -86,9 +136,26 @@ final class DictationCoordinator: ObservableObject {
     /// at two minutes. `ReconnectPolicy.dictation` is that ladder.
     private static let reconnect = ReconnectPolicy.dictation
 
+    /// Where the chosen window length lives. `AppState` binds a picker to the
+    /// same key; the coordinator reads it directly because it has to know the
+    /// answer in the background, long after any view is gone.
+    nonisolated static let windowLengthKey = "micWindowLength"
+
+    var windowLength: MicWindowLength {
+        MicWindowLength(
+            rawValue: UserDefaults.standard.string(forKey: Self.windowLengthKey) ?? "") ?? .off
+    }
+
     private init() {
+        window = .closed(length: MicWindowLength(
+            rawValue: UserDefaults.standard.string(forKey: Self.windowLengthKey) ?? "") ?? .off)
         armRequestObserver()
+        armWindowControlObserver()
         armLifecycleLinger()
+        // Publish once at launch so a keyboard that comes up before anything
+        // else has happened already knows whether the feature is on — that is
+        // what it needs to say "this tap will open Parley" rather than nothing.
+        publishWindow()
     }
 
     // MARK: entry points
@@ -136,6 +203,8 @@ final class DictationCoordinator: ObservableObject {
 
     private func launch() async {
         endLinger()  // the live audio session keeps the process awake from here
+        reportsLevel.set(true)
+        yieldedToMeeting = false
         errorMessage = nil
         runs = []
         committed = ""
@@ -224,33 +293,35 @@ final class DictationCoordinator: ObservableObject {
         // through before their first word is captured. `AudioCapture.start()`
         // is `async` for the same reason: activating the audio session is slow
         // enough to be felt if it runs on the main actor.
-        let cap = AudioCapture(
-            onChunk: { [weak self, audio] samples, level in
-                audio.send(samples)
-                Task { @MainActor in self?.micLevel = level }
-            },
-            onStatus: { [weak self] status in
-                Task { @MainActor in self?.handle(capture: status) }
-            })
-        do {
-            try await cap.start()
-            capture = cap
-        } catch {
-            relay = nil
-            audio.discard()
-            client.cancel()
-            fail(String(localized: "Couldn't open the microphone."))
-            return
+        //
+        // **Or there is nothing to start.** With a microphone window open the
+        // capture is already running and this session simply borrows it. That
+        // is not merely faster: iOS refuses to *start* recording from a
+        // backgrounded process, so a session that had to open the microphone
+        // here would have to bring the app forward first — which is the app
+        // switch this whole feature exists to avoid.
+        if capture == nil {
+            let fresh = makeCapture()
+            do {
+                try await fresh.start()
+                capture = fresh
+            } catch {
+                relay = nil
+                audio.discard()
+                client.cancel()
+                fail(String(localized: "Couldn't open the microphone."))
+                return
+            }
         }
 
         do {
             try await client.start()
         } catch {
-            capture = nil
             relay = nil
             audio.discard()
             client.cancel()
-            await cap.stop()
+            // `fail` closes the microphone and any window with it — see there
+            // for why an error is not something to leave an open window behind.
             fail(String(localized: "Connection failed. Please try again."))
             return
         }
@@ -258,6 +329,26 @@ final class DictationCoordinator: ObservableObject {
         state = .listening
         publish()
         armCap()
+    }
+
+    /// The microphone, wired to the bridge once and for all.
+    ///
+    /// The same object serves every session for as long as it is running,
+    /// because what it is wired to never changes: `audio` is the coordinator's
+    /// one bridge, and while no session is attached to it the bridge counts
+    /// chunks and drops them. That is what makes holding the microphone open
+    /// between dictations safe — an open window records nothing, because there
+    /// is nowhere for the audio to go.
+    private func makeCapture() -> AudioCapture {
+        AudioCapture(
+            onChunk: { [weak self, audio, reportsLevel] samples, level in
+                audio.send(samples)
+                guard reportsLevel.isOpen else { return }
+                Task { @MainActor in self?.micLevel = level }
+            },
+            onStatus: { [weak self] status in
+                Task { @MainActor in self?.handle(capture: status) }
+            })
     }
 
     /// One relay leg. `feature: "voice_typing"` is the cloud's whitelisted tag
@@ -314,7 +405,9 @@ final class DictationCoordinator: ObservableObject {
     /// another app, tap the keyboard's mic — always found this process
     /// suspended and bounced the user through the app, even seconds after they
     /// had it open. Thirty seconds is the platform's ceiling for a background
-    /// task; past it the URL round trip is the only way to wake us.
+    /// task; past it the URL round trip is the only way to wake us — which is
+    /// the whole reason the microphone window exists, and why this linger is
+    /// now only what happens when no window is open.
     private func armLifecycleLinger() {
         let center = NotificationCenter.default
         lifecycleObservers = [
@@ -322,8 +415,10 @@ final class DictationCoordinator: ObservableObject {
                 forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main
             ) { [weak self] _ in
                 Task { @MainActor in
-                    // A live session's audio keeps the process awake already.
-                    guard let self, !self.active else { return }
+                    // A live session's audio keeps the process awake already,
+                    // and so does an open microphone window — `beginLinger`
+                    // declines in both cases; this is only about not asking.
+                    guard let self, !self.active, self.window.openedAt == nil else { return }
                     self.beginLinger()
                 }
             },
@@ -332,6 +427,21 @@ final class DictationCoordinator: ObservableObject {
             ) { [weak self] _ in
                 // Foreground needs no assertion; the next backgrounding re-arms.
                 Task { @MainActor in self?.endLinger() }
+            },
+            center.addObserver(
+                forName: UIApplication.willTerminateNotification, object: nil, queue: .main
+            ) { _ in
+                // The microphone goes with the process. Say so on the way out
+                // rather than leaving a file claiming an open window: the
+                // keyboard's staleness check would get there eventually, but
+                // the truth is available right now.
+                MainActor.assumeIsolated {
+                    DictationChannel.writeWindow(
+                        .closed(
+                            length: MicWindowLength(
+                                rawValue: UserDefaults.standard.string(
+                                    forKey: DictationCoordinator.windowLengthKey) ?? "") ?? .off))
+                }
             },
         ]
     }
@@ -348,7 +458,21 @@ final class DictationCoordinator: ObservableObject {
     /// The microphone's own state. `AudioCapture` recovers from interruptions
     /// and route changes on its own, so only the give-up case ends the session.
     private func handle(capture status: AudioCapture.Status) {
-        guard active else { return }
+        guard active else {
+            // No session: the microphone is only up because a window is
+            // holding it, and a window that cannot be honoured is worse than
+            // one that ended early — the user can see the second and cannot
+            // see the first. So anything other than "running" ends it, and the
+            // next tap goes back to the ordinary trip through Parley, which
+            // can open the microphone properly from the foreground.
+            switch status {
+            case .running, .resumed:
+                break
+            case .interrupted, .failed:
+                Task { await endWindow() }
+            }
+            return
+        }
         switch status {
         case .running, .resumed:
             break
@@ -523,19 +647,20 @@ final class DictationCoordinator: ObservableObject {
         reconnectTask = nil
         capTimer?.cancel()
         capTimer = nil
-        let cap = capture
-        capture = nil
-        await cap?.stop()
-        // Anything still held belongs to a leg that will never exist; the
+        // Cut the microphone off from the relay *before* draining rather than
+        // stopping it: with a window open the microphone keeps running, and
+        // what is said after ⏹ must not ride along in the finalize. Discarding
+        // also drops anything held for a leg that will never exist; the
         // finalize below drains what actually reached the relay.
         audio.discard()
+        reportsLevel.set(false)
         micLevel = 0
         state = .finishing
         publish()
         if let relay {
             await relay.finish()  // drain: the relay flushes the last utterance
         }
-        finishUp()
+        finishUp()  // which hands the microphone to the window, or closes it
     }
 
     private func finishUp() {
@@ -543,13 +668,18 @@ final class DictationCoordinator: ObservableObject {
         reconnectTask?.cancel()
         reconnectTask = nil
         audio.discard()
+        reportsLevel.set(false)
         state = .done
         // Fold the last partial into the committed text so nothing said right
         // before the endpoint is dropped from what the keyboard inserts.
         foldPartialIn()
         publish()
         active = false
-        beginLinger()
+        // Not `beginLinger()` any more: whether this leaves a ~30 s background
+        // task or an open microphone window is `releaseMicrophone`'s decision,
+        // and the two must never both be in flight. Reached from the relay
+        // signing off as well as from `stop`, hence the Task.
+        Task { await releaseMicrophone() }
     }
 
     private func fail(_ message: String) {
@@ -565,12 +695,219 @@ final class DictationCoordinator: ObservableObject {
         dying?.cancel()
         let cap = capture
         capture = nil
+        reportsLevel.set(false)
         // Detached because `fail` is the sync tail of half a dozen paths and
         // closing the audio session is slow; nothing after this depends on it.
         Task { await cap?.stop() }
+        // And the window goes with it. A window is the microphone the user
+        // agreed to leave open for a keyboard that works; after being told
+        // something went wrong, an indicator they now have no reason to expect
+        // is the worst of both — so an error always ends with the microphone
+        // visibly off.
+        closeWindowState()
         publish()
         active = false
         beginLinger()
+    }
+
+    // MARK: the microphone window
+
+    /// The end of a session: hand the microphone to the window the user chose,
+    /// or close it.
+    ///
+    /// This is the replacement for "stop the microphone, then hold a ~30 s
+    /// background task and hope the next tap lands inside it". A window keeps
+    /// the audio session live, and a live audio session — not a background
+    /// task — is what keeps the process resident for minutes rather than
+    /// seconds. Idempotent: both `stop` and the relay signing off reach it.
+    private func releaseMicrophone() async {
+        guard !active else { return }
+        if !yieldedToMeeting,
+            let opened = MicWindowState.opened(length: windowLength, at: Date()), capture != nil
+        {
+            openWindow(opened)
+            return
+        }
+        await closeMicrophone()
+        beginLinger()
+    }
+
+    /// A meeting is about to take the microphone. There is one microphone, so
+    /// give it up completely.
+    ///
+    /// The flag matters because the end of a dictation opens its window from a
+    /// detached task: without it, a meeting started in the beat between a
+    /// session finishing and that task running would find a second
+    /// `AudioCapture` opened underneath it, and the two would rebuild the audio
+    /// session out from under each other. Cleared by the next `launch`.
+    func yieldMicrophone() async {
+        yieldedToMeeting = true
+        closeWindowState()
+        guard !active else { return }
+        await closeMicrophone()
+    }
+
+    private func closeMicrophone() async {
+        let cap = capture
+        capture = nil
+        reportsLevel.set(false)
+        micLevel = 0
+        await cap?.stop()
+    }
+
+    /// Start (or restart) the window and the loop that heartbeats and expires
+    /// it. The microphone must already be running.
+    private func openWindow(_ opened: MicWindowState) {
+        // A background task and a window must never overlap: ending a
+        // background assertion in the background can suspend a process the
+        // audio session was keeping up.
+        endLinger()
+        windowProblem = nil
+        window = opened
+        publishWindow()
+        windowTask?.cancel()
+        windowTask = Task { [weak self] in await self?.runWindow() }
+    }
+
+    /// Heartbeat and expiry in one loop.
+    ///
+    /// The heartbeat is not decoration. The keyboard cannot tell an open window
+    /// from the file a killed process left behind except by how fresh the file
+    /// is, so a window that stops being re-stamped stops being believed within
+    /// `MicWindowState.staleAfter` — see `MicWindowState`. Sleeping the shorter
+    /// of a heartbeat and whatever is left is what keeps expiry punctual: a
+    /// window sold as five minutes has to end at five minutes, not at the next
+    /// heartbeat after it.
+    private func runWindow() async {
+        while !Task.isCancelled {
+            let left = window.remaining()
+            guard left > 0 else { break }
+            let nap = min(MicWindowState.heartbeat, left)
+            try? await Task.sleep(for: .seconds(nap))
+            guard !Task.isCancelled else { return }
+            guard window.openedAt != nil else { return }
+            if window.remaining() <= 0 { break }
+            publishWindow()
+        }
+        guard !Task.isCancelled else { return }
+        await endWindow()
+    }
+
+    /// End the window, closing the microphone unless a dictation is using it.
+    ///
+    /// Ending a window during a live session is not a stop: the user asked for
+    /// the microphone not to be *held afterwards*, and taking their sentence
+    /// away mid-word to honour that would be a strange reading of it. The
+    /// session finishes and `releaseMicrophone` then finds no window to open.
+    func endWindow() async {
+        guard window.openedAt != nil else { return }
+        windowTask?.cancel()
+        windowTask = nil
+        closeWindowState()
+        guard !active else { return }
+        await closeMicrophone()
+        beginLinger()
+    }
+
+    private func closeWindowState() {
+        windowTask?.cancel()
+        windowTask = nil
+        window = .closed(length: windowLength)
+        publishWindow()
+    }
+
+    /// The user chose a window length in Settings.
+    ///
+    /// Turning one on opens it immediately rather than at the end of the next
+    /// dictation. That is the point: the cost of this setting is a microphone
+    /// indicator, and the moment to show someone an indicator is the moment
+    /// they agree to it — with the row right there to end it again.
+    func setWindowLength(_ length: MicWindowLength) async {
+        UserDefaults.standard.set(length.rawValue, forKey: Self.windowLengthKey)
+        windowProblem = nil
+        guard length != .off else {
+            await endWindow()
+            window.length = .off
+            publishWindow()
+            return
+        }
+        // A running session will open the window itself when it ends.
+        guard !active else {
+            window.length = length
+            publishWindow()
+            return
+        }
+        await beginWindowFromForeground(length: length)
+    }
+
+    /// Open a window on demand, opening the microphone if it is not already.
+    ///
+    /// Foreground only, and not out of caution: iOS refuses to let a
+    /// backgrounded process *start* recording at all. A window can only ever be
+    /// born in the foreground — after that it survives backgrounding because
+    /// the session it is holding was activated while the app was up.
+    private func beginWindowFromForeground(length: MicWindowLength) async {
+        guard UIApplication.shared.applicationState == .active else {
+            window.length = length
+            publishWindow()
+            return
+        }
+        if capture == nil {
+            switch AudioCapture.permission {
+            case .granted:
+                break
+            case .denied:
+                windowProblem = String(
+                    localized: "Parley needs microphone access. Turn it on in Settings › Parley.")
+                window = .closed(length: length)
+                publishWindow()
+                return
+            default:
+                guard await AudioCapture.requestPermission() else {
+                    windowProblem = String(
+                        localized: "Microphone access wasn't granted, so there is no window to keep open.")
+                    window = .closed(length: length)
+                    publishWindow()
+                    return
+                }
+            }
+            let fresh = makeCapture()
+            do {
+                try await fresh.start()
+                capture = fresh
+            } catch {
+                windowProblem = String(localized: "Couldn't open the microphone.")
+                window = .closed(length: length)
+                publishWindow()
+                return
+            }
+        }
+        guard let opened = MicWindowState.opened(length: length, at: Date()) else { return }
+        openWindow(opened)
+    }
+
+    /// The keyboard's "end now". A timestamp rather than a flag, so neither
+    /// side has to clear anything and a stale request cannot refuse to let the
+    /// next window open — see `MicWindowState.closeApplies(requestedAt:)`.
+    private func armWindowControlObserver() {
+        windowControlObserver = DarwinObserver(DictationChannel.windowControlNote) {
+            [weak self] in
+            Task { @MainActor in
+                guard let self,
+                    self.window.closeApplies(
+                        requestedAt: DictationChannel.readWindowControl()?.closeRequestedAt)
+                else { return }
+                await self.endWindow()
+            }
+        }
+    }
+
+    /// Mirror the window into the App Group, re-stamping the local copy with
+    /// the same beat so the app's own reading of `isOpen` cannot go stale while
+    /// the app is very much alive.
+    private func publishWindow() {
+        window.updatedAt = Date()
+        DictationChannel.writeWindow(window)
     }
 
     // MARK: background linger
@@ -581,6 +918,10 @@ final class DictationCoordinator: ObservableObject {
     /// background-task time covers the common "stop, think, dictate again"
     /// beat with no app switch.
     private func beginLinger() {
+        // Never alongside a window. The window's audio session is what is
+        // holding the process up; a background assertion added on top buys
+        // nothing and its expiry is a documented way to get suspended anyway.
+        guard window.openedAt == nil else { return }
         endLinger()
         lingerTask = UIApplication.shared.beginBackgroundTask(withName: "dictation-relaunch") {
             [weak self] in self?.endLinger()
@@ -654,4 +995,29 @@ final class DictationCoordinator: ObservableObject {
             active = true
         }
     #endif
+}
+
+/// A boolean the audio thread may read on every chunk.
+///
+/// The microphone level is the one thing the capture callback reports that only
+/// matters while a screen is watching. With a microphone window open the
+/// callback runs a dozen times a second for up to an hour with nothing on
+/// screen at all, and each report is a hop to the main actor — a background
+/// wakeup a minute is a battery line item, not a rounding error. So the hop is
+/// gated by a flag cheap enough to read from the audio thread.
+private final class LevelGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var open = false
+
+    var isOpen: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return open
+    }
+
+    func set(_ value: Bool) {
+        lock.lock()
+        open = value
+        lock.unlock()
+    }
 }

--- a/ios/App/Parley/LiveView.swift
+++ b/ios/App/Parley/LiveView.swift
@@ -10,12 +10,20 @@ struct LiveView: View {
     /// "am I recording?" — see `MeetingRecorder` for why that cannot be a flag
     /// this view sets once the microphone is finally up.
     @StateObject private var recorder = MeetingRecorder()
+    /// Only for the microphone-window bar below. The keyboard's window is not
+    /// this screen's business, but the orange dot it lights is: someone who
+    /// notices that dot opens Parley and lands *here*, and a record screen that
+    /// says "not recording" while the indicator is on reads as a lie.
+    @ObservedObject private var dictation = DictationCoordinator.shared
     @State private var showRecordingConsent = false
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 transcript
+                if dictation.window.isOpen() && !recorder.isRecording {
+                    micWindowBar
+                }
                 Divider().overlay(Theme.border)
                 controls
             }
@@ -158,6 +166,43 @@ struct LiveView: View {
                 }
             }())
         .accessibilityElement(children: .combine)
+    }
+
+    /// What the orange dot means, and the way out of it. Shown only while a
+    /// window is actually open, and never during a meeting — a recording has
+    /// its own reason to hold the microphone, and two explanations for one
+    /// indicator is worse than none.
+    private var micWindowBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mic.fill")
+                .font(.parley.footnote)
+                .foregroundStyle(Theme.micWindow)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("The microphone is open for the keyboard")
+                    .font(.parley.caption.weight(.semibold))
+                    .foregroundStyle(Theme.foreground)
+                Text("Nothing is being recorded or transcribed.")
+                    .font(.parley.caption2)
+                    .foregroundStyle(Theme.mutedForeground)
+            }
+            Spacer(minLength: 8)
+            if let expiresAt = dictation.window.expiresAt {
+                Text(expiresAt, style: .timer)
+                    .font(.parley.caption2.monospacedDigit())
+                    .foregroundStyle(Theme.mutedForeground)
+            }
+            Button("End") {
+                Task { await dictation.endWindow() }
+            }
+            .font(.parley.caption.weight(.semibold))
+            .buttonStyle(.plain)
+            .foregroundStyle(Theme.primary)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(Theme.tintedSurface)
+        .accessibilityElement(children: .contain)
     }
 
     private var controls: some View {

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -106,6 +106,57 @@
         }
       }
     },
+    "1 hour": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 hour"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小時"
+          }
+        }
+      }
+    },
+    "15 minutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 minutes"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 分鐘"
+          }
+        }
+      }
+    },
+    "5 minutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 minutes"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 分鐘"
+          }
+        }
+      }
+    },
     "A pocket recorder for the meetings you have in person — live transcript while you talk, in the cloud by the time you stand up.": {
       "extractionState": "manual",
       "localizations": {
@@ -219,6 +270,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "管理員"
+          }
+        }
+      }
+    },
+    "After you dictate, Parley can hold the microphone open for a while, so the next tap on the keyboard's mic types where you already are instead of opening Parley.\n\niOS shows the orange microphone dot for the whole time, because Parley really is holding the microphone. It is not listening through it: nothing is recorded, transcribed, or sent until you tap the mic, and sound that arrives before then is thrown away as it comes in. The window ends on its own, and you can end it early here or from the keyboard.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After you dictate, Parley can hold the microphone open for a while, so the next tap on the keyboard's mic types where you already are instead of opening Parley.\n\niOS shows the orange microphone dot for the whole time, because Parley really is holding the microphone. It is not listening through it: nothing is recorded, transcribed, or sent until you tap the mic, and sound that arrives before then is thrown away as it comes in. The window ends on its own, and you can end it early here or from the keyboard."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聽寫結束後，Parley 可以先把麥克風留著一段時間。在這段時間內按鍵盤上的麥克風，就會直接在你正在打字的 App 裡開始聽寫，不會跳到 Parley。\n\n這段時間內 iOS 會一直顯示橘色的麥克風指示點，因為 Parley 確實佔用著麥克風。但它不會透過麥克風聽你說話：在你按下麥克風之前，不會錄音、不會轉錄、也不會送出任何東西，期間收到的聲音會邊收邊丟掉。時間到會自動結束，你也可以在這裡或在鍵盤上提前結束。"
           }
         }
       }
@@ -732,6 +800,23 @@
         }
       }
     },
+    "End": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結束"
+          }
+        }
+      }
+    },
     "End meeting": {
       "extractionState": "manual",
       "localizations": {
@@ -745,6 +830,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "結束會議"
+          }
+        }
+      }
+    },
+    "End now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End now"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即結束"
           }
         }
       }
@@ -863,6 +965,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "繼續說沒關係——麥克風還開著，這段話會先留著，等連線回來就送出。"
+          }
+        }
+      }
+    },
+    "Keep the microphone ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the microphone ready"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風待命時間"
+          }
+        }
+      }
+    },
+    "Keeping the microphone ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keeping the microphone ready"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓麥克風保持待命"
           }
         }
       }
@@ -1154,6 +1290,23 @@
         }
       }
     },
+    "Microphone access wasn't granted, so there is no window to keep open.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access wasn't granted, so there is no window to keep open."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有取得麥克風權限，因此無法讓麥克風保持待命。"
+          }
+        }
+      }
+    },
     "Microphone access wasn't granted. Tap the mic to try again.": {
       "extractionState": "manual",
       "localizations": {
@@ -1341,6 +1494,40 @@
         }
       }
     },
+    "Nothing is being recorded or transcribed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing is being recorded or transcribed."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前沒有在錄音，也沒有在轉錄。"
+          }
+        }
+      }
+    },
+    "Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        }
+      }
+    },
     "Only the uploader or an admin can delete this recording": {
       "extractionState": "manual",
       "localizations": {
@@ -1439,6 +1626,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Parley 桌面版"
+          }
+        }
+      }
+    },
+    "Parley needs microphone access. Turn it on in Settings › Parley.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley needs microphone access. Turn it on in Settings › Parley."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley 需要麥克風權限。請到「設定 › Parley」開啟。"
           }
         }
       }
@@ -2250,6 +2454,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "連線不穩，登入沒有完成。請確認網路後再試一次。"
+          }
+        }
+      }
+    },
+    "The microphone is open": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The microphone is open"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風開著"
+          }
+        }
+      }
+    },
+    "The microphone is open for the keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The microphone is open for the keyboard"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風正為鍵盤待命中"
           }
         }
       }

--- a/ios/App/Parley/MeetingRecorder.swift
+++ b/ios/App/Parley/MeetingRecorder.swift
@@ -109,6 +109,11 @@ final class MeetingRecorder: ObservableObject {
     /// guard that makes the double-tap harmless.
     func start(token: String?) async {
         guard phase == .idle else { return }
+        // The dictation keyboard may be holding the microphone open for its
+        // window. There is one microphone: take it before opening a meeting's
+        // own capture, rather than leaving two `AudioCapture`s to rebuild the
+        // audio session out from under each other.
+        await DictationCoordinator.shared.yieldMicrophone()
         phase = .starting
         status = String(localized: "Starting…")
         segments = []

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -7,6 +7,10 @@ import SwiftUI
 /// phone rides the hosted providers with the account token (design doc D6).
 struct SettingsView: View {
     @EnvironmentObject private var app: AppState
+    /// Only for the microphone-window rows: how long the keyboard's mic stays
+    /// ready is settings, but *whether it is open right now* is live state that
+    /// belongs to the thing holding it.
+    @ObservedObject private var dictation = DictationCoordinator.shared
     @State private var personalFolders: [CloudFolder] = []
     @State private var orgFolders: [String: [CloudFolder]] = [:]
     @State private var showDeleteConfirmation = false
@@ -33,6 +37,7 @@ struct SettingsView: View {
                     }
                     if app.hasAccount {
                         dictationSection.id(Self.keyboardSectionID)
+                        micWindowSection
                     }
                     appearanceSection
                     languageSection
@@ -445,6 +450,78 @@ struct SettingsView: View {
             sectionHeader("Voice keyboard")
         }
         .listRowBackground(Theme.tintedSurface)
+    }
+
+    // MARK: the microphone window
+
+    /// The setting the whole of #286 is about, and the one place its cost is
+    /// stated. Everything here is written to be read *before* agreeing rather
+    /// than explained afterwards: an orange microphone indicator nobody expects
+    /// is worse than the app switch this replaces.
+    private var micWindowSection: some View {
+        Section {
+            if dictation.window.isOpen() {
+                openWindowRow
+            }
+            Picker("Keep the microphone ready", selection: micWindowBinding) {
+                ForEach(MicWindowLength.allCases) { length in
+                    Text(Self.micWindowLabel(length)).tag(length)
+                }
+            }
+            if let problem = dictation.windowProblem {
+                Label(problem, systemImage: "exclamationmark.triangle")
+                    .font(.parley.caption)
+                    .foregroundStyle(Theme.warning)
+            }
+        } header: {
+            sectionHeader("Keeping the microphone ready")
+        } footer: {
+            sectionFooter("After you dictate, Parley can hold the microphone open for a while, so the next tap on the keyboard's mic types where you already are instead of opening Parley.\n\niOS shows the orange microphone dot for the whole time, because Parley really is holding the microphone. It is not listening through it: nothing is recorded, transcribed, or sent until you tap the mic, and sound that arrives before then is thrown away as it comes in. The window ends on its own, and you can end it early here or from the keyboard.")
+        }
+        .listRowBackground(Theme.tintedSurface)
+    }
+
+    /// What is true right now, with the way out next to it. The countdown is a
+    /// system timer rather than a string this view refreshes: it is the cheap
+    /// way to be accurate to the second, and being accurate about when an open
+    /// microphone closes is the point.
+    @ViewBuilder
+    private var openWindowRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mic.fill")
+                .font(.parley.footnote)
+                .foregroundStyle(Theme.micWindow)
+            Text("The microphone is open")
+                .font(.parley.subheadlineEmphasized)
+            Spacer(minLength: 8)
+            if let expiresAt = dictation.window.expiresAt {
+                Text(expiresAt, style: .timer)
+                    .font(.parley.caption.monospacedDigit())
+                    .foregroundStyle(Theme.mutedForeground)
+            }
+        }
+        .padding(.vertical, 2)
+        Button("End now") {
+            Task { await dictation.endWindow() }
+        }
+    }
+
+    private var micWindowBinding: Binding<MicWindowLength> {
+        Binding(
+            get: { dictation.window.length },
+            set: { length in Task { await dictation.setWindowLength(length) } })
+    }
+
+    /// Spelled out rather than "5 min": this picker is the moment someone
+    /// decides how long to leave a microphone open, and an abbreviation is a
+    /// worse thing to skim.
+    private static func micWindowLabel(_ length: MicWindowLength) -> LocalizedStringKey {
+        switch length {
+        case .off: return "Off"
+        case .fiveMinutes: return "5 minutes"
+        case .fifteenMinutes: return "15 minutes"
+        case .oneHour: return "1 hour"
+        }
     }
 
     private func dictationStep(number: Int, title: LocalizedStringKey, detail: LocalizedStringKey)

--- a/ios/App/Parley/Theme.swift
+++ b/ios/App/Parley/Theme.swift
@@ -23,6 +23,13 @@ enum Theme {
     static let success = adaptive(ParleyDesignTokens.Light.success, ParleyDesignTokens.Dark.success)
     static let radius = ParleyDesignTokens.radius
 
+    /// The microphone window (see `MicWindow`). Deliberately **iOS's own orange
+    /// privacy indicator** rather than a Parley token: while a window is open
+    /// the system is showing that exact dot in the status bar, and the app's
+    /// mark for the same fact should be recognisably the same mark. Fixed in
+    /// both appearances, because the system's is.
+    static let micWindow = Color(red: 0.99, green: 0.62, blue: 0.05)
+
     /// The pale blue section fill the landing site uses behind grouped
     /// content. Reach for this instead of `muted` when the intent is "this is a
     /// section", not "this text is secondary".

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -98,6 +98,10 @@ struct KeyboardRootView: View {
                 .font(.footnote.weight(.bold))
                 .foregroundStyle(KBTheme.wordmark(dark))
             Spacer(minLength: 8)
+            if showsWindowChip {
+                windowChip
+                Spacer(minLength: 8)
+            }
             Text(bridge.mode == .voice ? "Voice" : "Keyboard")
                 .font(.caption.weight(.medium))
                 .foregroundStyle(KBTheme.inkSoft(dark))
@@ -110,6 +114,55 @@ struct KeyboardRootView: View {
         }
         .frame(height: KBMetrics.strip)
         .padding(.horizontal, 12)
+    }
+
+    // MARK: the microphone window
+
+    /// Whether the next tap on the mic will stay in this app.
+    ///
+    /// The chip lives in the strip rather than on the voice pane for three
+    /// reasons: the strip already has the empty middle it needs, the fact is
+    /// true of the keyboard rather than of one pane, and the voice pane is
+    /// measured to the point where adding anything to it moves the record
+    /// button.
+    ///
+    /// Hidden during a session. The record button already says the microphone
+    /// is live, and a second element saying so is exactly the redundancy this
+    /// pane was rebuilt to remove — the chip is about the *next* tap, and
+    /// during a session there is no next tap to describe.
+    private var showsWindowChip: Bool {
+        bridge.hasFullAccess && !bridge.listening && bridge.windowIsOpen
+    }
+
+    /// Tapping it ends the window. That is the whole control: there is nothing
+    /// else a keyboard could usefully do to one, and a chip that says the
+    /// microphone is open without a way to close it is a notice rather than a
+    /// control.
+    private var windowChip: some View {
+        Button(action: { bridge.endWindow() }) {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(KBTheme.micWindow)
+                    .frame(width: 6, height: 6)
+                Text("Mic ready")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(KBTheme.ink(dark))
+                if let minutes = bridge.windowMinutesLeft {
+                    Text(verbatim: "\(minutes)m")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(KBTheme.inkSoft(dark))
+                }
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(KBTheme.inkSoft(dark))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(KBTheme.control(dark)))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text("The microphone is ready. Tap to close it."))
     }
 
     private func dot(_ mode: KeyboardMode, label: Text) -> some View {
@@ -301,11 +354,7 @@ struct KeyboardRootView: View {
             } else if bridge.listening || !bridge.tail.isEmpty {
                 liveText
             } else {
-                centered {
-                    Text("Tap to speak")
-                        .font(.subheadline)
-                        .foregroundStyle(KBTheme.inkSoft(dark))
-                }
+                idleText
             }
         }
         .frame(height: KBMetrics.textHeight)
@@ -333,6 +382,29 @@ struct KeyboardRootView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Idle, and — for someone who has turned the microphone window on — what
+    /// this particular tap is going to do.
+    ///
+    /// The second line only appears while the feature is *on but closed*.
+    /// Without a window every tap opens Parley, always has, and saying so on a
+    /// keyboard someone is about to type on is noise. With one, it is the
+    /// difference the setting exists to make, and it must not be legible only
+    /// as the absence of a chip.
+    private var idleText: some View {
+        centered {
+            VStack(spacing: 3) {
+                Text("Tap to speak")
+                    .font(.subheadline)
+                    .foregroundStyle(KBTheme.inkSoft(dark))
+                if bridge.windowIsChosen && !bridge.windowIsOpen {
+                    Text("This tap opens Parley first")
+                        .font(.caption2)
+                        .foregroundStyle(KBTheme.inkSoft(dark).opacity(0.8))
+                }
+            }
+        }
     }
 
     private var liveText: some View {

--- a/ios/Keyboard/KeyboardTheme.swift
+++ b/ios/Keyboard/KeyboardTheme.swift
@@ -22,6 +22,13 @@ enum KBTheme {
     /// The relay dropped and the app is redialling. Amber on purpose: red is
     /// reserved for a session that actually ended, and a reconnect has not.
     static let reconnecting = Color(red: 0.85, green: 0.55, blue: 0.09)
+    /// The microphone window is open. This is **iOS's own orange privacy
+    /// indicator**, not a Parley colour: the system is showing that exact dot
+    /// in the status bar for the same reason, and the two marks meaning the
+    /// same thing should look like the same thing. Close to `reconnecting`, but
+    /// never on screen at the same time — one is about the socket during a
+    /// session, the other about the microphone between them.
+    static let micWindow = Color(red: 0.99, green: 0.62, blue: 0.05)
 
     /// Pathors' two brand blues, mirroring the tokens on the landing site
     /// (`#1469D4` deep and `#2DB6F3` sky). They are used sparingly and only

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -17,6 +17,10 @@ import UIKit
 final class KeyboardViewController: UIInputViewController {
     private let bridge = KeyboardBridge()
     private var down: DarwinObserver?
+    /// The app announcing that the microphone window opened, closed, or ticked.
+    /// It is what lets a tap that will stay put look different from a tap that
+    /// will jump — see `MicWindowState`.
+    private var windowNote: DarwinObserver?
 
     /// The keyboard's view of the current session. It mints the id, so it owns
     /// the truth about which downlink is "ours"; a downlink for any other
@@ -91,6 +95,12 @@ final class KeyboardViewController: UIInputViewController {
             down = DarwinObserver(DictationChannel.downNote) { [weak self] in
                 DispatchQueue.main.async { self?.drainDownlink() }
             }
+            // The app heartbeats an open window, so this note is also what
+            // ticks the chip's countdown down — the extension runs no timer of
+            // its own for it.
+            windowNote = DarwinObserver(DictationChannel.windowNote) { [weak self] in
+                DispatchQueue.main.async { self?.readWindow() }
+            }
         }
     }
 
@@ -107,6 +117,7 @@ final class KeyboardViewController: UIInputViewController {
         if !bridge.listening { bridge.tail = "" }
         refreshAppearance()
         refreshReturnKey()
+        readWindow()
         drainDownlink()
     }
 
@@ -209,6 +220,44 @@ final class KeyboardViewController: UIInputViewController {
             guard let self, self.session == target else { return }
             completion(DictationChannel.startURL(session: target))
         }
+    }
+
+    // MARK: the microphone window (called from SwiftUI)
+
+    /// Read what the app says about the microphone window.
+    ///
+    /// The keyboard reads it and never writes it, and it deliberately trusts
+    /// `isOpen()` rather than the expiry alone: the app can be killed without
+    /// ever writing again, and a chip promising a microphone that no longer
+    /// exists would be worse than no chip at all.
+    private func readWindow() {
+        guard hasFullAccess else {
+            bridge.windowIsOpen = false
+            bridge.windowIsChosen = false
+            return
+        }
+        let window = DictationChannel.readWindow()
+        bridge.windowIsChosen = (window?.length ?? .off) != .off
+        bridge.windowIsOpen = window?.isOpen() ?? false
+        // Rounded up, so "1m" never means "already gone": the number is there
+        // to say roughly how much room is left, and rounding down would let the
+        // chip read 0.
+        bridge.windowMinutesLeft = bridge.windowIsOpen
+            ? max(1, Int(((window?.remaining() ?? 0) / 60).rounded(.up)))
+            : nil
+    }
+
+    /// The keyboard's half of "end it early". A timestamp rather than a flag,
+    /// so nothing has to be cleared afterwards and a leftover request cannot
+    /// stop the next window from opening.
+    func endMicWindow() {
+        guard hasFullAccess else { return }
+        DictationChannel.writeWindowControl(.init(closeRequestedAt: Date()))
+        // Optimistic, and corrected by the app's next note either way: the app
+        // may be suspended, in which case the window died with it and the chip
+        // was already wrong.
+        bridge.windowIsOpen = false
+        bridge.windowMinutesLeft = nil
     }
 
     /// Ask the app to stop and flush the tail. The app is running during
@@ -410,6 +459,18 @@ final class KeyboardBridge: ObservableObject {
     /// connection), shown in the caption slot until the next start.
     @Published var errorText: String?
 
+    /// The microphone window is open: the next tap will be served where the
+    /// user already is, with no trip through Parley.
+    @Published var windowIsOpen = false
+    /// The user has chosen a window length at all. Distinct from
+    /// `windowIsOpen`, and the distinction is the whole point: someone who has
+    /// not turned the feature on is told nothing, while someone who has needs
+    /// to know that *this* tap falls outside it.
+    @Published var windowIsChosen = false
+    /// Roughly how long the open window has left, in whole minutes. Refreshed
+    /// by the app's heartbeat rather than by a timer in this process.
+    @Published var windowMinutesLeft: Int?
+
     /// Which pane is showing. Changing it also has to change the keyboard's
     /// height, which only the controller can do — hence `setMode` rather than a
     /// plain assignment.
@@ -470,6 +531,9 @@ final class KeyboardBridge: ObservableObject {
     }
     /// Older-iOS fallback when `openURL` reports the app didn't open.
     func fallbackOpen(_ url: URL) { controller?.openContainerApp(url) }
+    /// Close the microphone window from here rather than making the user go
+    /// and find the app.
+    func endWindow() { controller?.endMicWindow() }
     func stop() { controller?.stopDictation() }
     func backspace() { controller?.deleteBackward() }
     func type(_ text: String) { controller?.insert(text) }

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -136,6 +136,23 @@
         }
       }
     },
+    "Mic ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mic ready"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風待命"
+          }
+        }
+      }
+    },
     "Next": {
       "extractionState": "manual",
       "localizations": {
@@ -310,6 +327,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "點一下開始說話"
+          }
+        }
+      }
+    },
+    "The microphone is ready. Tap to close it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The microphone is ready. Tap to close it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風待命中，點一下即可關閉。"
+          }
+        }
+      }
+    },
+    "This tap opens Parley first": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This tap opens Parley first"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這次會先開啟 Parley"
           }
         }
       }

--- a/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
@@ -5,10 +5,17 @@ import Foundation
 /// iOS 8, Full Access included), so dictation runs in the app and the transcript
 /// is handed back through the App Group container.
 ///
-/// Two single-writer mailboxes plus two Darwin notifications, so the two
-/// processes never contend on the same file:
+/// Four single-writer mailboxes, each with its own Darwin notification, so the
+/// two processes never contend on the same file:
 ///   - `downlink` (app → keyboard): the growing transcript + session state.
 ///   - `uplink`   (keyboard → app): the session request, host bundle id, stop.
+///   - `window`   (app → keyboard): the microphone window — whether the next
+///     tap will be served where the user is, or has to open Parley.
+///   - `window control` (keyboard → app): end the window now.
+///
+/// The window pair is separate from the session pair on purpose: a window
+/// outlives any one dictation and most of what it has to say happens when no
+/// session exists at all.
 ///
 /// Darwin notifications carry no payload — they are pure "go re-read" signals.
 /// The files are the source of truth, which is what makes this robust to the
@@ -26,6 +33,12 @@ public enum DictationChannel {
     /// so a Darwin note reaches it; starting instead goes through the URL so it
     /// can launch a suspended app).
     public static let upNote = "com.pathors.parley.dictation.up"
+    /// app → keyboard: the microphone window opened, closed, or ticked. Its own
+    /// note rather than `downNote` because the window outlives sessions — most
+    /// of what it announces happens when there is no downlink to speak of.
+    public static let windowNote = "com.pathors.parley.dictation.window"
+    /// keyboard → app: end the microphone window now.
+    public static let windowControlNote = "com.pathors.parley.dictation.window-control"
 
     /// The URL the keyboard opens to start a session. The app routes this in
     /// `onOpenURL`. The session id round-trips so a stale downlink from a prior
@@ -126,8 +139,37 @@ public enum DictationChannel {
         read("dictation-up.json")
     }
 
+    // MARK: microphone window (app writes state, keyboard writes control)
+
+    /// Publish the window the app is actually holding. Stamped on every write:
+    /// the stamp is what lets the keyboard tell an open window from the file a
+    /// killed process left behind (see `MicWindowState`).
+    public static func writeWindow(_ value: MicWindowState) {
+        var stamped = value
+        stamped.updatedAt = Date()
+        write(stamped, to: "dictation-window.json")
+        post(windowNote)
+    }
+
+    public static func readWindow() -> MicWindowState? {
+        read("dictation-window.json")
+    }
+
+    /// The keyboard asking for the window to end now.
+    public static func writeWindowControl(_ value: MicWindowControl) {
+        write(value, to: "dictation-window-control.json")
+        post(windowControlNote)
+    }
+
+    public static func readWindowControl() -> MicWindowControl? {
+        read("dictation-window-control.json")
+    }
+
     public static func clear() {
-        for name in ["dictation-down.json", "dictation-up.json"] {
+        for name in [
+            "dictation-down.json", "dictation-up.json",
+            "dictation-window.json", "dictation-window-control.json",
+        ] {
             if let url = container?.appendingPathComponent(name) {
                 try? FileManager.default.removeItem(at: url)
             }

--- a/ios/ParleyKit/Sources/ParleyKit/MicWindow.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/MicWindow.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// How long Parley may hold the microphone open after a dictation, so the next
+/// tap on the keyboard's mic never has to leave the app being typed into.
+///
+/// This is **not** a limit on one dictation (that is the coordinator's 120 s
+/// `maxSeconds`) and it is not the relay's reconnect ladder. It is the window
+/// during which the *process* stays resident with a live audio session, which
+/// is the only thing that makes a keyboard tap a no-op instead of an app
+/// switch. See `docs/design/ios-voice-keyboard.md`.
+///
+/// ## Why there is no "until I turn it off"
+///
+/// The category's reference implementation (Wispr Flow) offers one. Parley
+/// deliberately does not, for two reasons that are really the same reason:
+///
+/// 1. **It is a promise the platform will not let us keep.** A window is a live
+///    recording session in a backgrounded app; iOS reclaims those under memory
+///    pressure, another app taking the microphone ends ours, and neither event
+///    gives us a chance to tell anyone. A bounded window that we close
+///    ourselves is something we can be right about. "Until I turn it off"
+///    would be a setting that is silently wrong most of the time it is on.
+/// 2. **It is the one option with no natural end.** Every other choice
+///    eventually turns the microphone indicator off on its own, which is what
+///    makes a forgotten window self-correcting. An unbounded one is a
+///    microphone left open for a day because someone tapped a picker once.
+///
+/// One hour is kept because it is bounded, self-terminating, and matches a
+/// stretch of writing; the copy next to it says plainly what it costs.
+public enum MicWindowLength: String, Codable, CaseIterable, Sendable, Identifiable {
+    /// No window. The microphone closes with the dictation, exactly as it did
+    /// before this setting existed, and every keyboard tap opens Parley.
+    case off
+    case fiveMinutes
+    case fifteenMinutes
+    case oneHour
+
+    public var id: String { rawValue }
+
+    /// `nil` for `.off` — there is no window to give a length to.
+    public var seconds: TimeInterval? {
+        switch self {
+        case .off: return nil
+        case .fiveMinutes: return 5 * 60
+        case .fifteenMinutes: return 15 * 60
+        case .oneHour: return 60 * 60
+        }
+    }
+}
+
+/// What the app publishes about the microphone window, and the only thing the
+/// keyboard knows about it.
+///
+/// The keyboard has to answer one question before the user taps: *will this tap
+/// stay put, or will it throw me into Parley?* That is `isOpen(at:)`, and it
+/// deliberately takes two things into account rather than one.
+///
+/// ## Why an expiry is not enough on its own
+///
+/// The app writes this file; the app can also be killed without ever writing
+/// again — jetsam, a crash, the user swiping it out of the app switcher. The
+/// file left behind still says "open until 14:35", and a keyboard that believed
+/// it would show a ready microphone that does not exist and then jump anyway.
+///
+/// So the app re-stamps the file every `heartbeat` seconds for as long as the
+/// window is really open, and a reader treats a stamp older than `staleAfter`
+/// as a window that ended when the process did. One mechanism, two jobs: the
+/// same heartbeat is what refreshes the countdown on the keyboard without the
+/// extension having to run a timer of its own.
+public struct MicWindowState: Codable, Sendable, Equatable {
+    /// The user's setting, mirrored here so the keyboard can tell "the feature
+    /// is off" (say nothing) from "it is on but the window has closed" (say the
+    /// next tap will open Parley). The keyboard has no access to the app's
+    /// `UserDefaults`, only to this container.
+    public var length: MicWindowLength
+    /// When this window was opened. `nil` when no window is open. It is also
+    /// what makes closing idempotent: a close requested before this window
+    /// began is a request for a window that is already over.
+    public var openedAt: Date?
+    /// When the app will close it. `nil` when no window is open.
+    public var expiresAt: Date?
+    /// Last heartbeat. Optional so a file written before this field existed
+    /// still decodes — and a decoded `nil` reads as "not open", which is the
+    /// safe answer.
+    public var updatedAt: Date?
+
+    /// How often the app re-stamps an open window.
+    public static let heartbeat: TimeInterval = 20
+    /// How old a stamp may be before a reader stops believing the window.
+    /// Comfortably more than two heartbeats, so an app that is merely busy is
+    /// never mistaken for an app that is gone.
+    public static let staleAfter: TimeInterval = 55
+
+    public init(
+        length: MicWindowLength = .off, openedAt: Date? = nil,
+        expiresAt: Date? = nil, updatedAt: Date? = nil
+    ) {
+        self.length = length
+        self.openedAt = openedAt
+        self.expiresAt = expiresAt
+        self.updatedAt = updatedAt
+    }
+
+    /// No window, remembering only what the user has chosen.
+    public static func closed(length: MicWindowLength) -> MicWindowState {
+        MicWindowState(length: length)
+    }
+
+    /// A window running from `now` for `length`. `nil` for `.off`, which has no
+    /// window to open.
+    public static func opened(length: MicWindowLength, at now: Date) -> MicWindowState? {
+        guard let seconds = length.seconds else { return nil }
+        return MicWindowState(
+            length: length, openedAt: now, expiresAt: now.addingTimeInterval(seconds),
+            updatedAt: now)
+    }
+
+    /// The microphone is open right now — so a keyboard tap will be served
+    /// where the user already is.
+    public func isOpen(at now: Date = Date()) -> Bool {
+        guard let expiresAt, let updatedAt, openedAt != nil else { return false }
+        return now < expiresAt && now.timeIntervalSince(updatedAt) < Self.staleAfter
+    }
+
+    /// Seconds left, floored at zero. Meaningless unless `isOpen(at:)`.
+    public func remaining(at now: Date = Date()) -> TimeInterval {
+        guard let expiresAt else { return 0 }
+        return max(0, expiresAt.timeIntervalSince(now))
+    }
+
+    /// Whether a close asked for at `requestedAt` applies to this window.
+    ///
+    /// The keyboard's "end now" writes a timestamp rather than a flag, so the
+    /// app can act on it without either side having to clear anything: a
+    /// request is for whatever window was open when it was made, and a window
+    /// opened afterwards is simply a different window. That makes a stale
+    /// control file harmless instead of a microphone that refuses to open.
+    public func closeApplies(requestedAt: Date?) -> Bool {
+        guard let requestedAt, let openedAt else { return false }
+        return requestedAt >= openedAt
+    }
+}
+
+/// The keyboard's one request about the window: end it now.
+///
+/// Deliberately not a field on `Uplink`. The uplink is scoped to a dictation
+/// session — it carries the session id and the insertion high-water mark — and
+/// the window outlives sessions, is closed while none is running, and must not
+/// be able to disturb the one place in this system where an off-by-one costs
+/// the user duplicated text.
+public struct MicWindowControl: Codable, Sendable, Equatable {
+    public var closeRequestedAt: Date
+
+    public init(closeRequestedAt: Date) {
+        self.closeRequestedAt = closeRequestedAt
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/MicWindowTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/MicWindowTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// The microphone window's state machine — the part of the feature that can be
+/// reasoned about without a phone. What it cannot prove is that iOS keeps the
+/// process resident for the window's length; that is on the device checklist.
+final class MicWindowTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: lengths
+
+    func testOffHasNoDuration() {
+        XCTAssertNil(MicWindowLength.off.seconds)
+        XCTAssertNil(MicWindowState.opened(length: .off, at: t0))
+    }
+
+    func testEveryOtherLengthIsBounded() {
+        // The point of the enum: there is no unbounded case. If one is ever
+        // added, this test is the place that argues about it.
+        for length in MicWindowLength.allCases where length != .off {
+            guard let seconds = length.seconds else {
+                return XCTFail("\(length) has no duration")
+            }
+            XCTAssertGreaterThan(seconds, 0)
+            XCTAssertLessThanOrEqual(seconds, 3600)
+        }
+    }
+
+    // MARK: open / expiry
+
+    func testAWindowIsOpenUntilItExpires() {
+        guard let window = MicWindowState.opened(length: .fiveMinutes, at: t0) else {
+            return XCTFail("no window")
+        }
+        XCTAssertTrue(window.isOpen(at: t0))
+        XCTAssertTrue(window.isOpen(at: t0.addingTimeInterval(10)))
+        XCTAssertEqual(window.remaining(at: t0.addingTimeInterval(60)), 240)
+    }
+
+    func testAnExpiredWindowIsClosedEvenWithAFreshStamp() {
+        // Expiry wins over the heartbeat: a process that is alive and stamping
+        // must still stop claiming a window whose time is up.
+        let expired = MicWindowState(
+            length: .fiveMinutes, openedAt: t0, expiresAt: t0.addingTimeInterval(300),
+            updatedAt: t0.addingTimeInterval(301))
+        XCTAssertFalse(expired.isOpen(at: t0.addingTimeInterval(301)))
+        XCTAssertEqual(expired.remaining(at: t0.addingTimeInterval(400)), 0)
+    }
+
+    func testAStaleStampClosesTheWindowLongBeforeItExpires() {
+        // The jetsam case: the file says "open for another 50 minutes" and the
+        // process that wrote it is gone. Believing the expiry alone would show
+        // a ready microphone that does not exist.
+        guard let window = MicWindowState.opened(length: .oneHour, at: t0) else {
+            return XCTFail("no window")
+        }
+        let afterOneHeartbeat = t0.addingTimeInterval(MicWindowState.heartbeat)
+        XCTAssertTrue(window.isOpen(at: afterOneHeartbeat))
+        XCTAssertFalse(window.isOpen(at: t0.addingTimeInterval(MicWindowState.staleAfter)))
+    }
+
+    func testStalenessToleratesTwoMissedHeartbeats() {
+        // A busy app must not read as a dead one.
+        XCTAssertGreaterThan(MicWindowState.staleAfter, MicWindowState.heartbeat * 2)
+    }
+
+    func testAClosedWindowRemembersTheSetting() {
+        let closed = MicWindowState.closed(length: .fifteenMinutes)
+        XCTAssertFalse(closed.isOpen(at: t0))
+        // Which is what lets the keyboard say "this tap opens Parley" instead
+        // of saying nothing at all.
+        XCTAssertEqual(closed.length, .fifteenMinutes)
+    }
+
+    func testAFileWrittenBeforeTheStampExistedReadsAsClosed() {
+        let unstamped = MicWindowState(
+            length: .oneHour, openedAt: t0, expiresAt: t0.addingTimeInterval(3600),
+            updatedAt: nil)
+        XCTAssertFalse(unstamped.isOpen(at: t0))
+    }
+
+    // MARK: ending early
+
+    func testACloseRequestAppliesToTheWindowThatWasOpen() {
+        guard let window = MicWindowState.opened(length: .fiveMinutes, at: t0) else {
+            return XCTFail("no window")
+        }
+        XCTAssertTrue(window.closeApplies(requestedAt: t0.addingTimeInterval(30)))
+        XCTAssertTrue(window.closeApplies(requestedAt: t0))
+    }
+
+    func testACloseRequestFromBeforeTheWindowIsIgnored() {
+        // The control file is never cleared by either side, so yesterday's
+        // "end now" is still sitting there. It must not refuse to let a new
+        // window open — a stale request is a request about a window that is
+        // already over.
+        guard let window = MicWindowState.opened(length: .fiveMinutes, at: t0) else {
+            return XCTFail("no window")
+        }
+        XCTAssertFalse(window.closeApplies(requestedAt: t0.addingTimeInterval(-1)))
+    }
+
+    func testNoWindowMeansNothingToClose() {
+        XCTAssertFalse(MicWindowState.closed(length: .oneHour).closeApplies(requestedAt: t0))
+        XCTAssertFalse(MicWindowState.closed(length: .oneHour).closeApplies(requestedAt: nil))
+    }
+
+    // MARK: wire format
+
+    func testStateSurvivesTheAppGroupRoundTrip() throws {
+        guard let window = MicWindowState.opened(length: .fifteenMinutes, at: t0) else {
+            return XCTFail("no window")
+        }
+        let data = try JSONEncoder().encode(window)
+        let back = try JSONDecoder().decode(MicWindowState.self, from: data)
+        XCTAssertEqual(back, window)
+        XCTAssertTrue(back.isOpen(at: t0))
+    }
+
+    func testAnUnknownLengthDoesNotDecode() throws {
+        // Both processes ship together, so a length one side has never heard of
+        // means a mismatched install. Failing to decode leaves the reader with
+        // nil — no window — which is the safe reading.
+        let json = Data(#"{"length":"twoDays"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(MicWindowState.self, from: json))
+    }
+
+    func testControlSurvivesTheAppGroupRoundTrip() throws {
+        let control = MicWindowControl(closeRequestedAt: t0)
+        let back = try JSONDecoder().decode(
+            MicWindowControl.self, from: JSONEncoder().encode(control))
+        XCTAssertEqual(back, control)
+    }
+}


### PR DESCRIPTION
Part 1 of #286. **Stacked on #285** (`fix/relay-reconnect`) — it rewrites half of `DictationCoordinator` and touches every file this does, so this branches off it rather than duplicating it. Review the second commit; the base retargets to `main` when #285 merges.

Parts 2 and 3 are #288 and #287 — see *Not in this PR* below, where part 3 has turned into an answer rather than a question.

## What was actually wrong

The report is that tapping the mic throws you into Parley and leaves you there. `docs/design/ios-voice-keyboard.md` framed that as closed by Apple in 26.4 and stopped there, which is what sent this down the wrong path. **The competitors' trick is not returning faster. It is not leaving.**

Parley already had the no-jump path: `KeyboardViewController.startDictation` publishes the request to the App Group and waits 700 ms for the app to answer before opening the URL. It almost never won, because the only thing keeping the app awake was `beginLinger` — a `beginBackgroundTask`, worth roughly 30 seconds. Pause to think mid-sentence and it was gone.

There is a second reason, and it is why "stay awake longer" would not have been enough on its own: **iOS refuses to let a backgrounded process start recording** (`AVAudioSessionErrorCodeCannotStartRecording`, `Client … is in the background and doesn't have the entitlement to start recording in the background`). Apple has never published how that interacts with `UIBackgroundModes: audio` and it is not settleable from a simulator. A resident app that still could not open the microphone would have had to come forward anyway.

## The window

The microphone stops being a session's property. With a window chosen — **off / 5 / 15 / 60 minutes, default off** — the end of a dictation does not close it:

```
tap 1   keyboard → parley://dictate → app forward → mic opens (foreground)
        dictation → user swipes back → dictation ends
        ─── window opens: capture keeps running, audio goes nowhere ───
tap 2   keyboard → Darwin note → app (background, mic already open)
        attaches the relay to the running capture.  No app switch.
        ─── window expires: capture stops, indicator goes out ───
tap 4   round trip again
```

The active audio session is what keeps the process resident for minutes rather than seconds, and the next session **borrows** the running capture — so the background-start question never comes up, because there is never a background start. While no session is attached, chunks go into the existing `RelayAudioBridge` with no leg: it counts them and drops them. **An open window records nothing, because there is nowhere for the audio to go.**

`AudioCapture` is untouched.

## The cost, and where it is said

The microphone is genuinely open for the whole window, so **the orange indicator is lit for the whole window**. That is most of this diff:

| | says what is happening | ends it |
|---|---|---|
| **Settings** footer, before the choice | the indicator will be on, Parley really is holding the microphone, nothing is recorded/transcribed/sent until you tap the mic, sound before that is thrown away as it arrives | picker → Off, or **End now** on the live row with a countdown |
| **Record tab** bar, while open — where someone who notices the dot lands | "The microphone is open for the keyboard / Nothing is being recorded or transcribed." | **End** |
| **Keyboard** strip chip | ● **Mic ready · 4m** | tap the chip |

The chip's dot is **iOS's own indicator orange**, not a Parley colour: two marks for the same fact should look like the same fact.

## A tap that stays and a tap that jumps do not look the same

The chip is the positive signal. It sits in the mode strip because the strip already has the empty middle it needs, the fact is true of the keyboard rather than of one pane, and the voice pane's heights are measured to the point where adding an element moves the record button. It is hidden during a session — the record button already says the microphone is live, and the chip is about the *next* tap.

The negative signal is not the mere absence of a chip: the idle slot gains a second line, **"This tap opens Parley first"**, shown **only to someone who has turned a window on**. Without the setting every tap has always opened Parley, and saying so on every keyboard would be noise.

## There is no "until I turn it off"

Wispr Flow offers one. This does not, for two reasons that are one:

1. **It is a promise the platform will not let us keep.** A window is a live recording session in a backgrounded app. iOS reclaims those under memory pressure, another app taking the microphone ends ours, and neither gives us a chance to tell anyone. A window we close ourselves is one we can be right about.
2. **It is the one option with no natural end.** Every other choice eventually turns the indicator off by itself, which makes a forgotten window self-correcting. An unbounded one is a microphone left open for a day because someone tapped a picker once.

Same reason the default is off. The setting existing is the point; the default being aggressive is not.

## Honesty mechanics

- **Heartbeat.** The app re-stamps the window file every 20 s; a reader disbelieves a stamp older than 55 s. Otherwise a killed app's leftover file would promise a microphone that no longer exists — and then jump anyway. The same heartbeat ticks the chip's countdown, so the extension runs **no timer**. Expiry stays punctual: the app's loop sleeps the *shorter* of a heartbeat and whatever is left, because five minutes has to mean five minutes.
- **Ending early is a timestamp, not a flag.** The keyboard writes `closeRequestedAt`; the app closes any window opened at or before it. Neither side clears anything, and a stale request cannot refuse to let the next window open.
- **A window ends** on expiry, on the user asking (three places), on any session failure, on the microphone being interrupted or lost, and when a meeting recording takes it. Interruption is deliberately fatal rather than something to wait out: **a window that cannot be honoured is worse than one that ended early, because the user can see the second and cannot see the first.**
- **No background task alongside a window** — `beginBackgroundTask` is worth nothing next to an active audio session, and ending an assertion in the background is a documented way to get suspended.
- **One microphone.** `MeetingRecorder.start` takes it via `yieldMicrophone()`, with a flag so the detached task that opens a window at the end of a dictation cannot open one underneath a meeting that started in the same beat.
- **Battery.** The level callback no longer hops to the main actor when nothing is watching (`LevelGate`); an open window would otherwise have done that a dozen times a second for up to an hour.

## App Review

Consent that is visible and reversible, in that order: the user chose the length, the indicator says it is happening, three surfaces say what it means, each of them ends it, every window is bounded, no audio is held, nothing leaves the device until the mic is tapped. No private API anywhere in it — audio session, App Group, Darwin notifications, `insertText`.

## Verified

- `swift test --package-path ios/ParleyKit` — **51 tests, 14 new**, covering what is reachable without a phone: the window state machine, expiry beating a fresh stamp, a stale stamp closing a window long before its expiry (the jetsam case), staleness tolerating two missed heartbeats, a close request applying to the window that was open and a stale one being ignored, the App Group wire format round-tripping, a pre-`updatedAt` file reading as closed, and that no length is unbounded.
- `xcodegen generate` then `xcodebuild … -scheme Parley` and `… -scheme ParleyKeyboard` (`generic/platform=iOS Simulator`, `CODE_SIGNING_ALLOWED=NO`) — both clean, no new warnings.
- `bunx tsc --noEmit` and `bunx vitest run` (231 tests) — clean. Untouched by this change; run because CLAUDE.md asks.
- Every new string has both `en` and `zh-Hant` in the app and keyboard catalogs (14 + 3); checked programmatically across both files.

## Not verified — needs a device

**None of the behaviour this PR exists for is reachable from a simulator or a unit test, and I have not run any of it.** The state machine being right is not evidence that iOS keeps the process resident, and that is the load-bearing assumption. From the checklist in #286:

- [ ] **The whole point.** Window open → tap the mic in Messages, Mail, LINE → **no app switch**, words land at the cursor. Repeat after a two-minute pause, which is where the old 30 s linger died.
- [ ] Does the process actually survive a whole window? Check 5 minutes first, then 1 hour — a window that iOS quietly kills at minute 12 is a setting that lies, and the honest fix would be to drop the longer options.
- [ ] Window closed → the first tap jumps, as before, and the idle slot says it will.
- [ ] Expiry mid-use: the chip disappears, the indicator goes out, the next tap jumps.
- [ ] Ending early from all three places, including from the keyboard while the app is suspended (which is the case the timestamp protocol exists for).
- [ ] The orange indicator matches what the app said would happen, and goes out when the window does.
- [ ] Another app taking the audio session during an open window → the window ends rather than lingering un-honourable.
- [ ] A phone call, Siri, an alarm during an open window.
- [ ] A meeting recording started while a window is open → the meeting gets the microphone, the window is gone, one indicator.
- [ ] Battery over a real 1-hour window.
- [ ] The keyboard's chip after the app is force-quit from the app switcher: it should go within ~55 s, and the next tap should jump.
- [ ] Whether a session started inside a window is transcribed identically — this is the path where the relay attaches to a capture that has been running for a while, and the bridge's clock resets in `launch()`.

Two specific things I would watch hardest: whether the first chunk after attaching to a long-running capture arrives clean, and whether iOS ever refuses `setActive` on the *first* window opened from Settings on a device where the mic permission was only just granted.

## Not in this PR

- **#288 — part 2**, the return path for the taps that do still jump. The window removes most of them, not all.
- **#287 — part 3**, which turned out to be an answer rather than a question: `KeyboardHost.bundleID(of:)` probes `_hostBundleID` and `_hostApplicationBundleIdentifier` with `responds(to:)` **on the `UIInputViewController` itself**, and both halves are wrong. The value lives on the controller's `parent` (an `_UIViewServiceViewControllerOperator`), and `_hostBundleID` is an **ivar with no getter**, so `responds(to:)` is unconditionally false and only KVC's ivar fallback can reach it. **`HostReturn.attempt` has never run on any iOS version**, which is exactly what the issue suspected. The fix is small and is written out in #287; it was kept out of here because it turns on a path that has never executed in production and cannot be verified without a device below 26.4.

The design doc's "The jump back to the previous app problem" section — the framing that caused this — is rewritten around the window, including both findings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
