### PR TITLE
[refactor] sweep 144 open SonarQube issues across TS, Rust, Kotlin, and web

### DIFF
--- a/android/app/src/main/kotlin/com/pathors/parley/audio/OggOpusEncoder.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/audio/OggOpusEncoder.kt
@@ -322,7 +322,8 @@ class OggOpusEncoder private constructor(
     private fun captureCsd(buffer: ByteBuffer) {
         if (capturedCsd.size < 3) {
             val copy = ByteArray(bufferInfo.size)
-            buffer.get(copy)
+            // Bulk read: `ByteBuffer.get(ByteArray)` reads as an indexed accessor in Kotlin.
+            buffer[copy]
             capturedCsd.add(copy)
         }
     }

--- a/android/app/src/main/kotlin/com/pathors/parley/ui/AccountSheet.kt
+++ b/android/app/src/main/kotlin/com/pathors/parley/ui/AccountSheet.kt
@@ -1,5 +1,6 @@
 package com.pathors.parley.ui
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -57,26 +58,7 @@ fun AccountSheet(viewModel: HomeViewModel, onDismiss: () -> Unit) {
                 style = MaterialTheme.typography.titleLarge,
             )
 
-            when {
-                account.loading -> Text(
-                    text = stringResource(R.string.account_loading),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                account.failed -> Text(
-                    text = stringResource(R.string.account_load_failed),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-
-                else -> {
-                    account.user?.let { user ->
-                        Text(text = user.email, style = MaterialTheme.typography.bodyLarge)
-                    }
-                    account.quota?.let { quota -> QuotaLines(quota) }
-                }
-            }
+            AccountIdentity(account)
 
             HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
@@ -92,44 +74,13 @@ fun AccountSheet(viewModel: HomeViewModel, onDismiss: () -> Unit) {
                 )
             }
 
-            // Same condition as iOS: shown once `me()` has confirmed who is
-            // signed in. While the account is merely unreachable there is no
-            // point offering a call that cannot reach the server either.
-            if (account.user != null) {
-                TextButton(
-                    onClick = {
-                        viewModel.clearDeleteAccountError()
-                        confirmingDelete = true
-                    },
-                    enabled = !account.deleting,
-                ) {
-                    Text(
-                        text = stringResource(
-                            if (account.deleting) {
-                                R.string.account_delete_in_progress
-                            } else {
-                                R.string.account_delete
-                            }
-                        ),
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                }
-
-                account.deleteError?.let { error ->
-                    Text(
-                        text = stringResource(
-                            when (error) {
-                                DeleteAccountError.OWNS_ORGANIZATIONS ->
-                                    R.string.account_delete_error_owns_organizations
-
-                                DeleteAccountError.FAILED -> R.string.account_delete_error_failed
-                            }
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
+            DeleteAccountSection(
+                account = account,
+                onArm = {
+                    viewModel.clearDeleteAccountError()
+                    confirmingDelete = true
+                },
+            )
         }
     }
 
@@ -142,6 +93,73 @@ fun AccountSheet(viewModel: HomeViewModel, onDismiss: () -> Unit) {
             onDismiss = { confirmingDelete = false },
         )
     }
+}
+
+/**
+ * Who is signed in and what the plan has left — or why neither is known yet.
+ */
+@Composable
+private fun AccountIdentity(account: HomeViewModel.AccountState) {
+    when {
+        account.loading -> Text(
+            text = stringResource(R.string.account_loading),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        account.failed -> Text(
+            text = stringResource(R.string.account_load_failed),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+
+        else -> {
+            account.user?.let { user ->
+                Text(text = user.email, style = MaterialTheme.typography.bodyLarge)
+            }
+            account.quota?.let { quota -> QuotaLines(quota) }
+        }
+    }
+}
+
+/**
+ * The first step of deletion: a destructive button that only arms the
+ * confirmation dialog, plus whatever the last attempt failed with.
+ *
+ * Same condition as iOS: shown once `me()` has confirmed who is signed in.
+ * While the account is merely unreachable there is no point offering a call
+ * that cannot reach the server either.
+ */
+@Composable
+private fun DeleteAccountSection(account: HomeViewModel.AccountState, onArm: () -> Unit) {
+    if (account.user == null) return
+
+    TextButton(onClick = onArm, enabled = !account.deleting) {
+        Text(
+            text = stringResource(
+                if (account.deleting) {
+                    R.string.account_delete_in_progress
+                } else {
+                    R.string.account_delete
+                }
+            ),
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+
+    account.deleteError?.let { error ->
+        Text(
+            text = stringResource(deleteErrorMessage(error)),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@StringRes
+private fun deleteErrorMessage(error: DeleteAccountError): Int = when (error) {
+    DeleteAccountError.OWNS_ORGANIZATIONS -> R.string.account_delete_error_owns_organizations
+    DeleteAccountError.FAILED -> R.string.account_delete_error_failed
 }
 
 /**

--- a/android/parleykit/src/test/kotlin/com/pathors/parley/kit/SegmentBuilderTest.kt
+++ b/android/parleykit/src/test/kotlin/com/pathors/parley/kit/SegmentBuilderTest.kt
@@ -6,6 +6,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+/** The one id that never moves, whichever leg or run produced the tail. */
+private const val TAIL_ID = "mix-tail"
+
 /**
  * Semantics ported from `src-tauri/src/transcription/common.rs::SegmentBuilder`
  * (via `SegmentBuilderTests.swift`). These tests are the contract: if they
@@ -101,9 +104,9 @@ class SegmentBuilderTest {
         builder.emitTail("", speaker = 2, startMs = 300)
 
         assertEquals(2, emitted.size)
-        assertEquals("mix-tail", emitted[0].id)
+        assertEquals(TAIL_ID, emitted[0].id)
         assertFalse(emitted[0].isFinal)
-        assertEquals("mix-tail", emitted[1].id)
+        assertEquals(TAIL_ID, emitted[1].id)
         assertEquals("empty tail clears the UI row", "", emitted[1].text)
     }
 
@@ -139,7 +142,7 @@ class SegmentBuilderTest {
         // The tail id is the one thing that stays put: every `-tail` check in
         // the app and the cloud depends on this exact shape, and only one tail
         // is ever on screen.
-        assertEquals("mix-tail", second[1].id)
+        assertEquals(TAIL_ID, second[1].id)
         assertEquals(60_900L, second[1].startMs)
     }
 }

--- a/docs/design/ios-app-store-readiness.html
+++ b/docs/design/ios-app-store-readiness.html
@@ -18,14 +18,24 @@
       --red: #df5963;
       --amber: #c77c21;
       --green: #16836d;
+      /* Chip tints: opaque so contrast is predictable, and per-theme so the
+         label stays readable in both light and dark. All pairs clear WCAG AA. */
+      --chip-teal-bg: #e2f7f5;
+      --chip-teal-ink: #0f5b62;
+      --chip-red-bg: #fbe6e8;
+      --chip-red-ink: #983340;
+      --chip-amber-bg: #f7ecd9;
+      --chip-amber-ink: #7d4b0c;
+      --chip-green-bg: #dff0ec;
+      --chip-green-ink: #0d5d4c;
       --font-body: -apple-system, BlinkMacSystemFont, "PingFang TC", "Noto Sans TC", sans-serif;
       --font-data: ui-monospace, "SFMono-Regular", Menlo, monospace;
     }
     @media (prefers-color-scheme: dark) {
-      :root { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; }
+      :root { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; --chip-teal-bg: #123037; --chip-teal-ink: #7fe3dc; --chip-red-bg: #3a2228; --chip-red-ink: #f0a3a9; --chip-amber-bg: #332714; --chip-amber-ink: #e5b061; --chip-green-bg: #123028; --chip-green-ink: #6fd6b7; }
     }
-    :root[data-theme="light"] { --paper: #f5f7fb; --panel: #ffffff; --line: #dbe1ec; --muted: #667085; --ink: #11151e; --ink-soft: #202735; }
-    :root[data-theme="dark"] { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; }
+    :root[data-theme="light"] { --paper: #f5f7fb; --panel: #ffffff; --line: #dbe1ec; --muted: #667085; --ink: #11151e; --ink-soft: #202735; --chip-teal-bg: #e2f7f5; --chip-teal-ink: #0f5b62; --chip-red-bg: #fbe6e8; --chip-red-ink: #983340; --chip-amber-bg: #f7ecd9; --chip-amber-ink: #7d4b0c; --chip-green-bg: #dff0ec; --chip-green-ink: #0d5d4c; }
+    :root[data-theme="dark"] { --paper: #0d1118; --panel: #151b25; --line: #283141; --muted: #a8b1c1; --ink: #f5f7fb; --ink-soft: #e5eaf2; --chip-teal-bg: #123037; --chip-teal-ink: #7fe3dc; --chip-red-bg: #3a2228; --chip-red-ink: #f0a3a9; --chip-amber-bg: #332714; --chip-amber-ink: #e5b061; --chip-green-bg: #123028; --chip-green-ink: #6fd6b7; }
     * { box-sizing: border-box; }
     body { margin: 0; background: var(--paper); color: var(--ink); font: 15px/1.55 var(--font-body); }
     .shell { width: min(1100px, calc(100% - 40px)); margin: 0 auto; padding: 28px 0 72px; }
@@ -54,8 +64,8 @@
     .option.recommended { border-color: #48b5e3; box-shadow: inset 0 3px 0 var(--teal); }
     .option h3 { margin-top: 10px; font-size: 19px; letter-spacing: -.025em; }
     .option p { margin-top: 8px; color: var(--muted); }
-    .tag { align-self: flex-start; padding: 4px 8px; border-radius: 999px; color: #176d75; background: #57dbd21f; font: 700 10px/1 var(--font-data); letter-spacing: .08em; text-transform: uppercase; }
-    .tag.neutral { color: var(--muted); background: var(--paper); } .tag.risk { color: #9d3a46; background: #df59631f; }
+    .tag { align-self: flex-start; padding: 4px 8px; border-radius: 999px; color: var(--chip-teal-ink); background: var(--chip-teal-bg); font: 700 10px/1 var(--font-data); letter-spacing: .08em; text-transform: uppercase; }
+    .tag.neutral { color: var(--muted); background: var(--paper); } .tag.risk { color: var(--chip-red-ink); background: var(--chip-red-bg); }
     .option .effort { margin-top: auto; padding-top: 16px; font: 11px/1.4 var(--font-data); color: var(--muted); }
     .preview { height: 82px; margin: 16px 0 2px; overflow: hidden; border: 1px solid #ffffff16; border-radius: 10px; background: #121720; position: relative; }
     .preview.night::before { content: ""; position: absolute; inset: 18px 18px auto; height: 5px; border-radius: 999px; background: linear-gradient(90deg, var(--teal), var(--blue), var(--indigo)); box-shadow: 0 18px 0 #ffffff1c, 0 36px 0 #ffffff12; }
@@ -70,7 +80,7 @@
     td:nth-child(2) { width: 190px; font-weight: 650; }
     td:last-child { color: var(--muted); }
     .status { display: inline-block; padding: 4px 7px; border-radius: 5px; font: 700 10px/1 var(--font-data); letter-spacing: .05em; }
-    .status.block { background: #df59631f; color: #b33c4c; } .status.watch { background: #c77c211f; color: #a35e0e; } .status.ok { background: #16836d1f; color: #10705b; }
+    .status.block { background: var(--chip-red-bg); color: var(--chip-red-ink); } .status.watch { background: var(--chip-amber-bg); color: var(--chip-amber-ink); } .status.ok { background: var(--chip-green-bg); color: var(--chip-green-ink); }
     .flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
     .flow > div { min-height: 100px; padding: 14px; border-top: 2px solid var(--line); background: var(--panel); }
     .flow > div:first-child { border-color: var(--teal); } .flow > div:nth-child(2) { border-color: var(--blue); } .flow > div:nth-child(3) { border-color: var(--indigo); } .flow > div:last-child { border-color: var(--green); }

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -23,6 +23,90 @@ const MAX_BACKLOG: usize = TARGET_SAMPLE_RATE as usize * 2; // 2 seconds
 /// meeting transcribes nothing.
 const STALL: Duration = Duration::from_millis(600);
 
+/// One input stream's pending samples plus the liveness bookkeeping the mixer
+/// needs about it: whether the producer is still open and when it last handed
+/// over a chunk.
+struct Side {
+    buf: VecDeque<i16>,
+    open: bool,
+    last: Instant,
+}
+
+impl Side {
+    fn new() -> Self {
+        Self {
+            buf: VecDeque::new(),
+            open: true,
+            last: Instant::now(),
+        }
+    }
+
+    /// Absorb one `recv` result: buffer the chunk, or mark the side closed.
+    fn accept(&mut self, chunk: Option<Vec<i16>>) {
+        match chunk {
+            Some(c) => {
+                self.buf.extend(c);
+                self.last = Instant::now();
+            }
+            None => self.open = false,
+        }
+    }
+
+    /// Open but silent for [STALL] — it must stop gating the other side.
+    fn is_stalled(&self) -> bool {
+        self.last.elapsed() >= STALL
+    }
+
+    /// Whether this side's pending samples may be forwarded unmixed: the
+    /// counterpart has permanently ended (nothing left to mix with), or — while
+    /// both are still open — it has stalled and must not dam this one.
+    fn may_bypass(&self, other: &Side) -> bool {
+        !other.open || (self.open && other.is_stalled())
+    }
+
+    fn take_all(&mut self) -> Vec<i16> {
+        self.buf.drain(..).collect()
+    }
+
+    /// Drift guard: only trim a side that is still producing. A closed side's
+    /// residual is real captured audio — leave it for the bypass flush rather
+    /// than dropping it.
+    fn trim_backlog(&mut self) {
+        if self.open && self.buf.len() > MAX_BACKLOG {
+            self.buf.drain(..self.buf.len() - MAX_BACKLOG);
+        }
+    }
+}
+
+/// Sum the overlapping prefix of both sides, consuming it. `None` when the two
+/// don't currently overlap, so there is nothing to mix.
+fn mix_prefix(a: &mut Side, b: &mut Side) -> Option<Vec<i16>> {
+    let n = a.buf.len().min(b.buf.len());
+    if n == 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        let s = a.buf.pop_front().unwrap() as i32 + b.buf.pop_front().unwrap() as i32;
+        out.push(s.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
+    }
+    Some(out)
+}
+
+/// Audio that has to skip mixing this round: the flowing side's buffer once its
+/// counterpart ended or stalled. When the stalled side wakes, min-prefix mixing
+/// resumes (the streams re-align within MAX_BACKLOG). At most one side can hold
+/// samples here — [`mix_prefix`] just drained the overlap.
+fn bypass(a: &mut Side, b: &mut Side) -> Option<Vec<i16>> {
+    if !a.buf.is_empty() && a.may_bypass(b) {
+        Some(a.take_all())
+    } else if !b.buf.is_empty() && b.may_bypass(a) {
+        Some(b.take_all())
+    } else {
+        None
+    }
+}
+
 /// Sum `rx_a` and `rx_b` sample-by-sample into `tx_out` until both close.
 /// Mixes where both sides have data; a side that ends (or stalls — see [STALL])
 /// stops gating the other, whose audio then passes through untouched. The mixed
@@ -37,12 +121,8 @@ pub async fn mix_streams(
     tx_out: UnboundedSender<Vec<i16>>,
 ) {
     let mut meter = LevelMeter::new(app, "me", LEVEL_EVENT);
-    let mut a: VecDeque<i16> = VecDeque::new();
-    let mut b: VecDeque<i16> = VecDeque::new();
-    let mut a_open = true;
-    let mut b_open = true;
-    let mut last_a = Instant::now();
-    let mut last_b = Instant::now();
+    let mut a = Side::new();
+    let mut b = Side::new();
     // Wakes the loop so a stall is detected even when the stalled side never
     // delivers another chunk (recv alone would park us until the OTHER side's
     // next chunk, which is fine while it flows — the tick covers full silence).
@@ -57,77 +137,25 @@ pub async fn mix_streams(
         tx_out.send(out).is_ok()
     };
 
-    while a_open || b_open {
+    while a.open || b.open {
         tokio::select! {
-            chunk = rx_a.recv(), if a_open => match chunk {
-                Some(c) => {
-                    a.extend(c);
-                    last_a = Instant::now();
-                }
-                None => a_open = false,
-            },
-            chunk = rx_b.recv(), if b_open => match chunk {
-                Some(c) => {
-                    b.extend(c);
-                    last_b = Instant::now();
-                }
-                None => b_open = false,
-            },
+            chunk = rx_a.recv(), if a.open => a.accept(chunk),
+            chunk = rx_b.recv(), if b.open => b.accept(chunk),
             _ = tick.tick() => {}
         }
 
-        // Mix the overlapping prefix of both buffers.
-        let n = a.len().min(b.len());
-        if n > 0 {
-            let mut out = Vec::with_capacity(n);
-            for _ in 0..n {
-                let s = a.pop_front().unwrap() as i32 + b.pop_front().unwrap() as i32;
-                out.push(s.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
+        if let Some(out) = mix_prefix(&mut a, &mut b) {
+            if !emit(out) {
+                return;
             }
+        }
+        if let Some(out) = bypass(&mut a, &mut b) {
             if !emit(out) {
                 return;
             }
         }
 
-        // Stall guard: an open-but-silent side must not dam the flowing one.
-        // Pass the flowing side straight through; when the stalled side wakes,
-        // min-prefix mixing resumes (the streams re-align within MAX_BACKLOG).
-        if a_open && b_open {
-            if !a.is_empty() && b.is_empty() && last_b.elapsed() >= STALL {
-                let out: Vec<i16> = a.drain(..).collect();
-                if !emit(out) {
-                    return;
-                }
-            } else if !b.is_empty() && a.is_empty() && last_a.elapsed() >= STALL {
-                let out: Vec<i16> = b.drain(..).collect();
-                if !emit(out) {
-                    return;
-                }
-            }
-        }
-
-        // When one side has permanently ended, flush the other directly.
-        if !a_open && !b.is_empty() {
-            let out: Vec<i16> = b.drain(..).collect();
-            if !emit(out) {
-                return;
-            }
-        }
-        if !b_open && !a.is_empty() {
-            let out: Vec<i16> = a.drain(..).collect();
-            if !emit(out) {
-                return;
-            }
-        }
-
-        // Drift guard: only trim a side that is still producing. A closed
-        // side's residual is real captured audio — leave it for the flush
-        // above rather than dropping it.
-        if a_open && a.len() > MAX_BACKLOG {
-            a.drain(..a.len() - MAX_BACKLOG);
-        }
-        if b_open && b.len() > MAX_BACKLOG {
-            b.drain(..b.len() - MAX_BACKLOG);
-        }
+        a.trim_backlog();
+        b.trim_backlog();
     }
 }

--- a/src-tauri/src/audio/prosody.rs
+++ b/src-tauri/src/audio/prosody.rs
@@ -741,7 +741,18 @@ fn yin_f0(frame: &[f32], sample_rate: f32) -> Option<f32> {
         return None;
     }
 
-    // Difference function d(tau) over the integration window w.
+    let cmnd = cumulative_mean_normalized_difference(frame, w, tau_max);
+    let best_tau = first_dip_below_threshold(&cmnd, tau_min, tau_max)?;
+    let refined = parabolic_refine(&cmnd, best_tau, tau_min, tau_max);
+
+    let f0 = sample_rate / refined;
+    (F0_MIN_HZ..=F0_MAX_HZ).contains(&f0).then_some(f0)
+}
+
+/// YIN steps 1–2: the squared-difference function d(tau) over the integration
+/// window `w`, then its cumulative-mean normalization d'(tau). Index 0 is 1.0 so
+/// the zero lag never wins the threshold search.
+fn cumulative_mean_normalized_difference(frame: &[f32], w: usize, tau_max: usize) -> Vec<f32> {
     let mut d = vec![0.0f32; tau_max + 1];
     for (tau, slot) in d.iter_mut().enumerate().take(tau_max + 1).skip(1) {
         let mut sum = 0.0f32;
@@ -752,7 +763,6 @@ fn yin_f0(frame: &[f32], sample_rate: f32) -> Option<f32> {
         *slot = sum;
     }
 
-    // Cumulative mean normalized difference d'(tau).
     let mut cmnd = vec![1.0f32; tau_max + 1];
     let mut running = 0.0f32;
     for tau in 1..=tau_max {
@@ -763,39 +773,41 @@ fn yin_f0(frame: &[f32], sample_rate: f32) -> Option<f32> {
             1.0
         };
     }
+    cmnd
+}
 
-    // First lag below the threshold, then descend to its local minimum.
+/// YIN step 3: the first lag below the absolute threshold, descended to its
+/// local minimum. `None` when the frame is aperiodic (nothing ever dips).
+fn first_dip_below_threshold(cmnd: &[f32], tau_min: usize, tau_max: usize) -> Option<usize> {
     let mut tau = tau_min;
-    let best_tau = loop {
-        if tau > tau_max {
-            return None;
-        }
+    while tau <= tau_max {
         if cmnd[tau] < YIN_THRESHOLD {
             while tau < tau_max && cmnd[tau + 1] < cmnd[tau] {
                 tau += 1;
             }
-            break tau;
+            return Some(tau);
         }
         tau += 1;
-    };
+    }
+    None
+}
 
-    // Parabolic interpolation around best_tau for sub-sample precision.
-    let refined = if best_tau > tau_min && best_tau < tau_max {
-        let s0 = cmnd[best_tau - 1];
-        let s1 = cmnd[best_tau];
-        let s2 = cmnd[best_tau + 1];
-        let denom = 2.0 * (2.0 * s1 - s2 - s0);
-        if denom.abs() > f32::EPSILON {
-            best_tau as f32 + (s2 - s0) / denom
-        } else {
-            best_tau as f32
-        }
+/// YIN step 4: parabolic interpolation around `best_tau` for sub-sample
+/// precision. Falls back to the integer lag at the edges of the search range or
+/// when the parabola is degenerate.
+fn parabolic_refine(cmnd: &[f32], best_tau: usize, tau_min: usize, tau_max: usize) -> f32 {
+    if best_tau <= tau_min || best_tau >= tau_max {
+        return best_tau as f32;
+    }
+    let s0 = cmnd[best_tau - 1];
+    let s1 = cmnd[best_tau];
+    let s2 = cmnd[best_tau + 1];
+    let denom = 2.0 * (2.0 * s1 - s2 - s0);
+    if denom.abs() > f32::EPSILON {
+        best_tau as f32 + (s2 - s0) / denom
     } else {
         best_tau as f32
-    };
-
-    let f0 = sample_rate / refined;
-    (F0_MIN_HZ..=F0_MAX_HZ).contains(&f0).then_some(f0)
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -31,7 +31,7 @@ use tauri::{AppHandle, Emitter};
 
 use anyhow::{anyhow, Result};
 use core_foundation::array::CFArray;
-use core_foundation::base::TCFType;
+use core_foundation::base::{CFType, TCFType};
 use core_foundation::boolean::CFBoolean;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
@@ -176,40 +176,7 @@ fn run(tx: UnboundedSender<Vec<i16>>, running: Arc<AtomicBool>, app: &AppHandle)
         let uid = tap_uuid_string(desc);
 
         // 3. Wrap the tap in a private aggregate device we can run an IOProc on.
-        let sub_tap = CFDictionary::from_CFType_pairs(&[
-            (
-                CFString::new("uid").as_CFType(),
-                CFString::new(&uid).as_CFType(),
-            ),
-            (
-                CFString::new("drift").as_CFType(),
-                CFBoolean::true_value().as_CFType(),
-            ),
-        ]);
-        let tap_list = CFArray::from_CFTypes(&[sub_tap]);
-        let agg_desc = CFDictionary::from_CFType_pairs(&[
-            (
-                CFString::new("name").as_CFType(),
-                CFString::new("Parley System Tap").as_CFType(),
-            ),
-            (
-                CFString::new("uid").as_CFType(),
-                CFString::new(&format!("com.pathors.parley.agg.{uid}")).as_CFType(),
-            ),
-            (
-                CFString::new("private").as_CFType(),
-                CFBoolean::true_value().as_CFType(),
-            ),
-            (
-                CFString::new("stacked").as_CFType(),
-                CFBoolean::false_value().as_CFType(),
-            ),
-            (CFString::new("taps").as_CFType(), tap_list.as_CFType()),
-            (
-                CFString::new("tapautostart").as_CFType(),
-                CFBoolean::true_value().as_CFType(),
-            ),
-        ]);
+        let agg_desc = aggregate_description(&uid);
 
         let mut agg_id: AudioObjectID = 0;
         let status = AudioHardwareCreateAggregateDevice(
@@ -227,16 +194,13 @@ fn run(tx: UnboundedSender<Vec<i16>>, running: Arc<AtomicBool>, app: &AppHandle)
         // 4. Read the tap's audio format to configure the resampler. Failing to
         // read it is the "created but unauthorized" signature — keep going (the
         // watchdog below reports if no frames ever arrive), but say why.
-        let in_rate = match tap_sample_rate(tap_id) {
-            Some(r) => r,
-            None => {
-                log::warn!(
-                    "[system] tap exposes no stream format — System Audio Recording permission \
-                     likely missing; assuming 48 kHz"
-                );
-                48_000.0
-            }
-        };
+        let in_rate = tap_sample_rate(tap_id).unwrap_or_else(|| {
+            log::warn!(
+                "[system] tap exposes no stream format — System Audio Recording permission \
+                 likely missing; assuming 48 kHz"
+            );
+            48_000.0
+        });
         log::info!("[system] tap @ {in_rate} Hz → {TARGET_SAMPLE_RATE} Hz mono");
 
         // 5. Install + start the IOProc.
@@ -272,29 +236,9 @@ fn run(tx: UnboundedSender<Vec<i16>>, running: Arc<AtomicBool>, app: &AppHandle)
         std::thread::spawn(kick_system_output);
 
         // 6. Hold the device open until the meeting stops, then tear everything
-        // down. Watchdog: an unauthorized tap "starts" fine but its IOProc never
-        // fires — detect that (zero frames a few seconds in) and tell the UI, so
-        // a permission problem doesn't just look like a silent remote party.
-        let started_at = Instant::now();
-        let mut checked = false;
-        while running.load(Ordering::Relaxed) {
-            std::thread::sleep(Duration::from_millis(100));
-            if !checked && started_at.elapsed() >= Duration::from_secs(3) {
-                checked = true;
-                if frames.load(Ordering::Relaxed) == 0 {
-                    log::warn!(
-                        "[system] tap delivered no frames in 3s — grant \"System Audio \
-                         Recording\" (Settings → Permissions) and restart the meeting"
-                    );
-                    let _ = app.emit(
-                        "meeting://warning",
-                        serde_json::json!({ "code": "system-audio-silent" }),
-                    );
-                } else {
-                    crate::permissions::note_system_audio_granted();
-                }
-            }
-        }
+        // down.
+        hold_until_stopped(&running, &frames, app);
+
         AudioDeviceStop(agg_id, proc_id);
         AudioDeviceDestroyIOProcID(agg_id, proc_id);
         AudioHardwareDestroyAggregateDevice(agg_id);
@@ -303,6 +247,79 @@ fn run(tx: UnboundedSender<Vec<i16>>, running: Arc<AtomicBool>, app: &AppHandle)
         let _: () = msg_send![desc, release];
     }
     Ok(())
+}
+
+/// Describe the private aggregate device that wraps the process tap `uid`, in
+/// the CFDictionary shape `AudioHardwareCreateAggregateDevice` expects.
+fn aggregate_description(uid: &str) -> CFDictionary<CFType, CFType> {
+    let sub_tap = CFDictionary::from_CFType_pairs(&[
+        (
+            CFString::new("uid").as_CFType(),
+            CFString::new(uid).as_CFType(),
+        ),
+        (
+            CFString::new("drift").as_CFType(),
+            CFBoolean::true_value().as_CFType(),
+        ),
+    ]);
+    let tap_list = CFArray::from_CFTypes(&[sub_tap]);
+    CFDictionary::from_CFType_pairs(&[
+        (
+            CFString::new("name").as_CFType(),
+            CFString::new("Parley System Tap").as_CFType(),
+        ),
+        (
+            CFString::new("uid").as_CFType(),
+            CFString::new(&format!("com.pathors.parley.agg.{uid}")).as_CFType(),
+        ),
+        (
+            CFString::new("private").as_CFType(),
+            CFBoolean::true_value().as_CFType(),
+        ),
+        (
+            CFString::new("stacked").as_CFType(),
+            CFBoolean::false_value().as_CFType(),
+        ),
+        (CFString::new("taps").as_CFType(), tap_list.as_CFType()),
+        (
+            CFString::new("tapautostart").as_CFType(),
+            CFBoolean::true_value().as_CFType(),
+        ),
+    ])
+}
+
+/// Park until the meeting stops, running the delivery watchdog once on the way:
+/// an unauthorized tap "starts" fine but its IOProc never fires — detect that
+/// (zero frames a few seconds in) and tell the UI, so a permission problem
+/// doesn't just look like a silent remote party.
+fn hold_until_stopped(running: &AtomicBool, frames: &AtomicU64, app: &AppHandle) {
+    let started_at = Instant::now();
+    let mut checked = false;
+    while running.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(100));
+        if checked || started_at.elapsed() < Duration::from_secs(3) {
+            continue;
+        }
+        checked = true;
+        report_tap_delivery(frames.load(Ordering::Relaxed), app);
+    }
+}
+
+/// Turn the watchdog's frame count into either a permission warning for the UI
+/// or a note that the System Audio Recording grant is confirmed working.
+fn report_tap_delivery(frames: u64, app: &AppHandle) {
+    if frames > 0 {
+        crate::permissions::note_system_audio_granted();
+        return;
+    }
+    log::warn!(
+        "[system] tap delivered no frames in 3s — grant \"System Audio \
+         Recording\" (Settings → Permissions) and restart the meeting"
+    );
+    let _ = app.emit(
+        "meeting://warning",
+        serde_json::json!({ "code": "system-audio-silent" }),
+    );
 }
 
 /// Realtime callback: downmix the tapped interleaved float frames to mono,

--- a/src-tauri/src/ax_observe.rs
+++ b/src-tauri/src/ax_observe.rs
@@ -210,6 +210,30 @@ mod imp {
         })
     }
 
+    /// One tick's reading of the watched field, or `None` when polling must
+    /// stop: a newer paste superseded us, focus left the element, or the value
+    /// became unreadable (element went away, stopped being a string, grew past
+    /// the cap).
+    fn read_tick(element: &OwnedElement, generation: u64) -> Option<String> {
+        // A newer paste owns the field now — stop without a word.
+        if GENERATION.load(Ordering::SeqCst) != generation {
+            return None;
+        }
+        // Focus must still be on the very element we pasted into. Comparing
+        // the AX refs (rather than, say, the app) is what keeps us from
+        // reporting on a different field that happens to look edited.
+        let still_focused = unsafe {
+            match copy_focused_element() {
+                Some(current) => CFEqual(current.0, element.0),
+                None => false,
+            }
+        };
+        if !still_focused {
+            return None;
+        }
+        unsafe { copy_value_string(element.0) }
+    }
+
     fn poll(
         app: AppHandle,
         element: OwnedElement,
@@ -225,25 +249,7 @@ mod imp {
 
         for _ in 0..ticks {
             std::thread::sleep(POLL_INTERVAL);
-            // A newer paste owns the field now — stop without a word.
-            if GENERATION.load(Ordering::SeqCst) != generation {
-                return;
-            }
-            // Focus must still be on the very element we pasted into. Comparing
-            // the AX refs (rather than, say, the app) is what keeps us from
-            // reporting on a different field that happens to look edited.
-            let still_focused = unsafe {
-                match copy_focused_element() {
-                    Some(current) => CFEqual(current.0, element.0),
-                    None => false,
-                }
-            };
-            if !still_focused {
-                return;
-            }
-            let Some(current) = (unsafe { copy_value_string(element.0) }) else {
-                // Unreadable now (element went away, value stopped being a
-                // string, grew past the cap) — give up silently.
+            let Some(current) = read_tick(&element, generation) else {
                 return;
             };
 
@@ -253,45 +259,42 @@ mod imp {
                 stable_ticks = 0;
                 continue;
             }
-            match &candidate {
-                Some(previous) if *previous == current => {
-                    stable_ticks += 1;
-                    if stable_ticks >= SETTLED_TICKS {
-                        // The baseline is snapshotted right after the ⌘V is
-                        // POSTED, not after the target app has PROCESSED it. If
-                        // the app was slow, the paste itself shows up here as
-                        // "the field changed" — adopt it as the real baseline
-                        // and keep watching for the actual correction instead
-                        // of spending our one event on it.
-                        if is_paste_landing(&baseline, &current, &inserted_text) {
-                            baseline = current;
-                            candidate = None;
-                            stable_ticks = 0;
-                            continue;
-                        }
-                        log::info!(
-                            "ax_observe: correction candidate (baseline {} chars, current {} chars)",
-                            baseline.chars().count(),
-                            current.chars().count()
-                        );
-                        let _ = app.emit(
-                            CORRECTION_CANDIDATE_EVENT,
-                            json!({
-                                "baseline": baseline,
-                                "current": current,
-                                "insertedText": inserted_text,
-                            }),
-                        );
-                        return;
-                    }
-                }
-                // First sighting of this value (or it changed again): restart
-                // the settle count with this reading as tick one.
-                _ => {
-                    candidate = Some(current);
-                    stable_ticks = 1;
-                }
+            // First sighting of this value (or it changed again): restart the
+            // settle count with this reading as tick one.
+            if candidate.as_deref() != Some(current.as_str()) {
+                candidate = Some(current);
+                stable_ticks = 1;
+                continue;
             }
+            stable_ticks += 1;
+            if stable_ticks < SETTLED_TICKS {
+                continue;
+            }
+            // The baseline is snapshotted right after the ⌘V is POSTED, not
+            // after the target app has PROCESSED it. If the app was slow, the
+            // paste itself shows up here as "the field changed" — adopt it as
+            // the real baseline and keep watching for the actual correction
+            // instead of spending our one event on it.
+            if is_paste_landing(&baseline, &current, &inserted_text) {
+                baseline = current;
+                candidate = None;
+                stable_ticks = 0;
+                continue;
+            }
+            log::info!(
+                "ax_observe: correction candidate (baseline {} chars, current {} chars)",
+                baseline.chars().count(),
+                current.chars().count()
+            );
+            let _ = app.emit(
+                CORRECTION_CANDIDATE_EVENT,
+                json!({
+                    "baseline": baseline,
+                    "current": current,
+                    "insertedText": inserted_text,
+                }),
+            );
+            return;
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -657,7 +657,7 @@ fn urldecode(s: &str) -> String {
 /// registration, unlike a custom-scheme deep link). Gives up after 5 minutes.
 #[tauri::command]
 pub fn start_oauth_loopback(app: AppHandle) -> Result<u16, String> {
-    use std::io::{Read, Write};
+    use std::io::Read;
     use std::net::TcpListener;
 
     let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| e.to_string())?;
@@ -671,34 +671,9 @@ pub fn start_oauth_loopback(app: AppHandle) -> Result<u16, String> {
                 Ok((mut stream, _)) => {
                     let mut buf = [0u8; 4096];
                     let n = stream.read(&mut buf).unwrap_or(0);
-                    let req = String::from_utf8_lossy(&buf[..n]);
-                    // Request line: "GET /cb?token=… HTTP/1.1"
-                    let path = req
-                        .lines()
-                        .next()
-                        .and_then(|l| l.split_whitespace().nth(1))
-                        .unwrap_or("");
-                    let query = path.split_once('?').map_or("", |(_, q)| q);
-                    let (mut token, mut error) = (None::<String>, None::<String>);
-                    for pair in query.split('&') {
-                        let mut kv = pair.splitn(2, '=');
-                        match (kv.next(), kv.next()) {
-                            (Some("token"), Some(v)) => token = Some(urldecode(v)),
-                            (Some("error"), Some(v)) => error = Some(urldecode(v)),
-                            _ => {}
-                        }
-                    }
-                    let body = "<!doctype html><meta charset=utf-8><title>Parley</title>\
-<body style=\"font-family:system-ui;padding:3rem;text-align:center;color:#333\">\
-<h2>Parley</h2><p>登入完成，可以關閉這個分頁回到 Parley。</p>\
-<p>You're signed in — close this tab and return to Parley.</p></body>";
-                    let resp = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-                    let _ = stream.write_all(resp.as_bytes());
-                    let _ = stream.flush();
+                    let (token, error) =
+                        parse_loopback_callback(&String::from_utf8_lossy(&buf[..n]));
+                    write_close_tab_page(&mut stream);
                     let _ = app.emit(
                         "auth://callback",
                         serde_json::json!({ "token": token, "error": error }),
@@ -719,6 +694,44 @@ pub fn start_oauth_loopback(app: AppHandle) -> Result<u16, String> {
     });
 
     Ok(port)
+}
+
+/// Pull `token` / `error` out of the loopback request's query string.
+fn parse_loopback_callback(req: &str) -> (Option<String>, Option<String>) {
+    // Request line: "GET /cb?token=… HTTP/1.1"
+    let path = req
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .unwrap_or("");
+    let query = path.split_once('?').map_or("", |(_, q)| q);
+    let (mut token, mut error) = (None::<String>, None::<String>);
+    for pair in query.split('&') {
+        let mut kv = pair.splitn(2, '=');
+        match (kv.next(), kv.next()) {
+            (Some("token"), Some(v)) => token = Some(urldecode(v)),
+            (Some("error"), Some(v)) => error = Some(urldecode(v)),
+            _ => {}
+        }
+    }
+    (token, error)
+}
+
+/// Serve the bilingual "you can close this tab" page and flush it.
+fn write_close_tab_page(stream: &mut std::net::TcpStream) {
+    use std::io::Write;
+
+    let body = "<!doctype html><meta charset=utf-8><title>Parley</title>\
+<body style=\"font-family:system-ui;padding:3rem;text-align:center;color:#333\">\
+<h2>Parley</h2><p>登入完成，可以關閉這個分頁回到 Parley。</p>\
+<p>You're signed in — close this tab and return to Parley.</p></body>";
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(resp.as_bytes());
+    let _ = stream.flush();
 }
 
 /// Tee the mic ("me") PCM through a [`ProsodyAnalyzer`](crate::audio::prosody::ProsodyAnalyzer)

--- a/src-tauri/src/diarize.rs
+++ b/src-tauri/src/diarize.rs
@@ -276,15 +276,61 @@ fn run_pipeline(
         bail!("decoded audio was empty");
     }
 
-    // Embedding is embarrassingly parallel — each slice is independent. ONNX
-    // Runtime's `Session::run` takes `&mut self`, so instead of sharing one
-    // session we give each worker thread its OWN single-threaded session and feed
-    // them from a shared ROLLING WORK QUEUE: a worker claims the next unclaimed
-    // segment (one atomic fetch_add) the instant it's free, so a slow long segment
-    // never makes the others idle — no batch barrier, naturally load-balanced.
-    // W workers running 1-intra-thread sessions ≈ W cores busy, no oversubscription.
-    // Capped to bound memory (each session holds the ~27 MB model) and skipped for
-    // small jobs where the spin-up isn't worth it.
+    let n = spans.len();
+    let (embedded, matrix) = embed_all_segments(&app, &model, &audio, &spans)?;
+
+    emit("clustering", 0, 0);
+    let labels = cluster_embeddings(&matrix, num_speakers);
+    let k_final = labels.iter().copied().max().map(|m| m + 1).unwrap_or(1);
+    let centroids = compute_centroids(&matrix, &labels, k_final);
+    log::info!("diarize: {} segments → {} speakers", matrix.len(), k_final);
+
+    // (label, confidence) per segment; embedded ones first.
+    let mut assigned: Vec<Option<(usize, f32)>> = vec![None; n];
+    for (j, &i) in embedded.iter().enumerate() {
+        let conf = margin_confidence(&matrix[j], &centroids, labels[j]);
+        assigned[i] = Some((labels[j], conf));
+    }
+
+    // Short/failed slices inherit the temporally nearest embedded speaker:
+    // carry the last seen label forward, then back-fill any leading gap.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by_key(|&i| spans[i].start_ms);
+    carry_labels(&mut assigned, order.iter().copied());
+    carry_labels(&mut assigned, order.iter().rev().copied());
+
+    Ok(spans
+        .into_iter()
+        .enumerate()
+        .map(|(i, sp)| {
+            let (lab, conf) = assigned[i].unwrap_or((0, 0.0));
+            SegSpeaker {
+                id: sp.id,
+                speaker: lab + 1, // 1-based, matches the LLM re-attribution path
+                confidence: conf,
+            }
+        })
+        .collect())
+}
+
+/// Embed every long-enough slice in parallel. Returns the indices that produced
+/// an embedding and the matching embedding matrix (same order).
+///
+/// Embedding is embarrassingly parallel — each slice is independent. ONNX
+/// Runtime's `Session::run` takes `&mut self`, so instead of sharing one
+/// session we give each worker thread its OWN single-threaded session and feed
+/// them from a shared ROLLING WORK QUEUE: a worker claims the next unclaimed
+/// segment (one atomic fetch_add) the instant it's free, so a slow long segment
+/// never makes the others idle — no batch barrier, naturally load-balanced.
+/// W workers running 1-intra-thread sessions ≈ W cores busy, no oversubscription.
+/// Capped to bound memory (each session holds the ~27 MB model) and skipped for
+/// small jobs where the spin-up isn't worth it.
+fn embed_all_segments(
+    app: &AppHandle,
+    model: &Path,
+    audio: &[f32],
+    spans: &[SegSpan],
+) -> Result<(Vec<usize>, Vec<Vec<f32>>)> {
     let n = spans.len();
     let step = (n / 100).max(1); // throttle to ~100 progress events total
     let cores = std::thread::available_parallelism()
@@ -305,42 +351,8 @@ fn run_pipeline(
         let handles: Vec<_> = (0..workers)
             .map(|_| {
                 let (spans, audio, model, next, processed, app) =
-                    (&spans, &audio, &model, &next, &processed, &app);
-                scope.spawn(move || -> Result<Vec<IndexedEmbedding>> {
-                    let mut session = build_session(model)?;
-                    let mut out: Vec<IndexedEmbedding> = Vec::new();
-                    loop {
-                        // Claim the next segment; stop when the queue is drained.
-                        let i = next.fetch_add(1, Ordering::Relaxed);
-                        if i >= spans.len() {
-                            break;
-                        }
-                        let sp = &spans[i];
-                        let start = (sp.start_ms as usize) * SAMPLES_PER_MS;
-                        let end = ((sp.end_ms as usize) * SAMPLES_PER_MS).min(audio.len());
-                        if end > start && end - start >= MIN_SLICE_SAMPLES {
-                            match embed_segment(&mut session, &audio[start..end]) {
-                                Ok(v) => out.push((i, v)),
-                                Err(e) => {
-                                    log::warn!("diarize: embed failed for segment {i}: {e:#}")
-                                }
-                            }
-                        }
-                        // else: too short / out of range — filled from a neighbour later.
-                        let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
-                        if done % step == 0 || done == n {
-                            let _ = app.emit(
-                                "diarize://progress",
-                                Progress {
-                                    stage: "embedding",
-                                    received: done as u64,
-                                    total: n as u64,
-                                },
-                            );
-                        }
-                    }
-                    Ok(out)
-                })
+                    (spans, audio, model, &next, &processed, app);
+                scope.spawn(move || embed_worker(app, model, audio, spans, next, processed, step))
             })
             .collect();
         handles
@@ -381,45 +393,84 @@ fn run_pipeline(
         .iter()
         .map(|&i| embeds[i].take().unwrap())
         .collect();
+    Ok((embedded, matrix))
+}
 
-    // Cluster. NME spectral clustering is the primary method (auto-picks the
-    // affinity pruning AND, when unknown, the speaker count via the eigengap).
-    // It needs enough segments to be stable, so small/huge jobs fall back to the
-    // simpler methods: spherical k-means (known count) / agglomerative (auto).
-    emit("clustering", 0, 0);
+/// One embedding worker: claim slices off the shared cursor until the queue is
+/// drained, embedding each and reporting progress.
+fn embed_worker(
+    app: &AppHandle,
+    model: &Path,
+    audio: &[f32],
+    spans: &[SegSpan],
+    next: &AtomicUsize,
+    processed: &AtomicUsize,
+    step: usize,
+) -> Result<Vec<IndexedEmbedding>> {
+    let n = spans.len();
+    let mut session = build_session(model)?;
+    let mut out: Vec<IndexedEmbedding> = Vec::new();
+    loop {
+        // Claim the next segment; stop when the queue is drained.
+        let i = next.fetch_add(1, Ordering::Relaxed);
+        if i >= spans.len() {
+            break;
+        }
+        let sp = &spans[i];
+        let start = (sp.start_ms as usize) * SAMPLES_PER_MS;
+        let end = ((sp.end_ms as usize) * SAMPLES_PER_MS).min(audio.len());
+        if end > start && end - start >= MIN_SLICE_SAMPLES {
+            match embed_segment(&mut session, &audio[start..end]) {
+                Ok(v) => out.push((i, v)),
+                Err(e) => log::warn!("diarize: embed failed for segment {i}: {e:#}"),
+            }
+        }
+        // else: too short / out of range — filled from a neighbour later.
+        let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
+        if done % step == 0 || done == n {
+            let _ = app.emit(
+                "diarize://progress",
+                Progress {
+                    stage: "embedding",
+                    received: done as u64,
+                    total: n as u64,
+                },
+            );
+        }
+    }
+    Ok(out)
+}
+
+/// Pick a clustering method and run it. NME spectral clustering is the primary
+/// method (auto-picks the affinity pruning AND, when unknown, the speaker count
+/// via the eigengap). It needs enough segments to be stable, so small/huge jobs
+/// fall back to the simpler methods: spherical k-means (known count) /
+/// agglomerative (auto).
+fn cluster_embeddings(matrix: &[Vec<f32>], num_speakers: Option<usize>) -> Vec<usize> {
     let len = matrix.len();
     let use_nme = (NME_MIN_SEGMENTS..=NME_MAX_SEGMENTS).contains(&len);
-    let labels = match num_speakers.filter(|&k| k >= 1) {
+    match num_speakers.filter(|&k| k >= 1) {
         Some(k) => {
             let k = k.min(len);
             if k <= 1 {
                 vec![0usize; len]
             } else if use_nme {
-                nme_spectral(&matrix, Some(k))
+                nme_spectral(matrix, Some(k))
             } else {
-                spherical_kmeans(&matrix, k)
+                spherical_kmeans(matrix, k)
             }
         }
-        None if use_nme => nme_spectral(&matrix, None),
-        None => agglomerative(&matrix),
-    };
-    let k_final = labels.iter().copied().max().map(|m| m + 1).unwrap_or(1);
-    let centroids = compute_centroids(&matrix, &labels, k_final);
-    log::info!("diarize: {} segments → {} speakers", matrix.len(), k_final);
-
-    // (label, confidence) per segment; embedded ones first.
-    let mut assigned: Vec<Option<(usize, f32)>> = vec![None; n];
-    for (j, &i) in embedded.iter().enumerate() {
-        let conf = margin_confidence(&matrix[j], &centroids, labels[j]);
-        assigned[i] = Some((labels[j], conf));
+        None if use_nme => nme_spectral(matrix, None),
+        None => agglomerative(matrix),
     }
+}
 
-    // Short/failed slices inherit the temporally nearest embedded speaker:
-    // carry the last seen label forward, then back-fill any leading gap.
-    let mut order: Vec<usize> = (0..n).collect();
-    order.sort_by_key(|&i| spans[i].start_ms);
+/// Fill unassigned slots with the label of the nearest already-assigned segment
+/// seen while walking `order` (run forwards, then backwards, to cover both
+/// sides). Inherited assignments carry zero confidence.
+fn carry_labels(assigned: &mut [Option<(usize, f32)>], order: impl Iterator<Item = usize>) {
     let mut carry: Option<usize> = None;
-    for &i in &order {
+    for i in order {
         match assigned[i] {
             Some((lab, _)) => carry = Some(lab),
             None => {
@@ -429,30 +480,6 @@ fn run_pipeline(
             }
         }
     }
-    let mut back: Option<usize> = None;
-    for &i in order.iter().rev() {
-        match assigned[i] {
-            Some((lab, _)) => back = Some(lab),
-            None => {
-                if let Some(lab) = back {
-                    assigned[i] = Some((lab, 0.0));
-                }
-            }
-        }
-    }
-
-    Ok(spans
-        .into_iter()
-        .enumerate()
-        .map(|(i, sp)| {
-            let (lab, conf) = assigned[i].unwrap_or((0, 0.0));
-            SegSpeaker {
-                id: sp.id,
-                speaker: lab + 1, // 1-based, matches the LLM re-attribution path
-                confidence: conf,
-            }
-        })
-        .collect())
 }
 
 /// Build a single-threaded ONNX session for the speaker model. One per worker
@@ -586,8 +613,31 @@ fn margin_confidence(point: &[f32], centroids: &[Vec<f32>], own: usize) -> f32 {
 /// cluster label in [0, k) per row. `k` is assumed ≥ 2 and ≤ matrix.len().
 fn spherical_kmeans(matrix: &[Vec<f32>], k: usize) -> Vec<usize> {
     let n = matrix.len();
-    // Farthest-first seeding: start at 0, then repeatedly take the point least
-    // similar to all chosen centroids. Deterministic (no RNG → reproducible).
+    let mut centroids = farthest_first_cosine(matrix, k);
+    let mut labels = vec![0usize; n];
+    for _ in 0..KMEANS_ITERS {
+        let mut changed = false;
+        for (i, v) in matrix.iter().enumerate() {
+            let lab = (0..k)
+                .max_by(|&a, &b| dot(v, &centroids[a]).total_cmp(&dot(v, &centroids[b])))
+                .unwrap_or(0);
+            if lab != labels[i] {
+                changed = true;
+                labels[i] = lab;
+            }
+        }
+        refresh_centroids_cosine(matrix, &mut labels, &mut centroids);
+        if !changed {
+            break;
+        }
+    }
+    labels
+}
+
+/// Farthest-first seeding under cosine similarity: start at 0, then repeatedly
+/// take the point least similar to all chosen centroids. Deterministic (no RNG
+/// → reproducible).
+fn farthest_first_cosine(matrix: &[Vec<f32>], k: usize) -> Vec<Vec<f32>> {
     let mut centroids: Vec<Vec<f32>> = vec![matrix[0].clone()];
     while centroids.len() < k {
         let mut best_i = 0;
@@ -602,48 +652,34 @@ fn spherical_kmeans(matrix: &[Vec<f32>], k: usize) -> Vec<usize> {
         }
         centroids.push(matrix[best_i].clone());
     }
+    centroids
+}
 
-    let mut labels = vec![0usize; n];
-    for _ in 0..KMEANS_ITERS {
-        let mut changed = false;
-        for (i, v) in matrix.iter().enumerate() {
-            let lab = (0..k)
-                .max_by(|&a, &b| dot(v, &centroids[a]).total_cmp(&dot(v, &centroids[b])))
-                .unwrap_or(0);
-            if lab != labels[i] {
-                changed = true;
-                labels[i] = lab;
+/// Recompute cosine centroids; re-seed any emptied cluster with the worst-fitting
+/// point overall (lowest similarity to its own current centroid) and steal it, so
+/// k clusters stay populated.
+fn refresh_centroids_cosine(matrix: &[Vec<f32>], labels: &mut [usize], centroids: &mut [Vec<f32>]) {
+    let n = matrix.len();
+    for c in 0..centroids.len() {
+        let members: Vec<&Vec<f32>> = matrix
+            .iter()
+            .zip(labels.iter())
+            .filter(|(_, &l)| l == c)
+            .map(|(v, _)| v)
+            .collect();
+        if members.is_empty() {
+            drop(members);
+            if let Some(worst) = (0..n).min_by(|&a, &b| {
+                dot(&matrix[a], &centroids[labels[a]])
+                    .total_cmp(&dot(&matrix[b], &centroids[labels[b]]))
+            }) {
+                labels[worst] = c;
+                centroids[c] = matrix[worst].clone();
             }
-        }
-        // Recompute centroids; re-seed any emptied cluster with the point
-        // farthest from its current centroid so k clusters stay populated.
-        for c in 0..k {
-            let members: Vec<&Vec<f32>> = matrix
-                .iter()
-                .zip(&labels)
-                .filter(|(_, &l)| l == c)
-                .map(|(v, _)| v)
-                .collect();
-            if members.is_empty() {
-                // Reseed an emptied cluster with the worst-fitting point overall
-                // (lowest similarity to its own current centroid) and steal it.
-                drop(members);
-                if let Some(worst) = (0..n).min_by(|&a, &b| {
-                    dot(&matrix[a], &centroids[labels[a]])
-                        .total_cmp(&dot(&matrix[b], &centroids[labels[b]]))
-                }) {
-                    labels[worst] = c;
-                    centroids[c] = matrix[worst].clone();
-                }
-            } else {
-                centroids[c] = normalized_mean(&members);
-            }
-        }
-        if !changed {
-            break;
+        } else {
+            centroids[c] = normalized_mean(&members);
         }
     }
-    labels
 }
 
 /// Agglomerative average-linkage clustering on cosine similarity. Merges the most
@@ -656,54 +692,19 @@ fn agglomerative(matrix: &[Vec<f32>]) -> Vec<usize> {
         return vec![0];
     }
 
-    // Pairwise item similarities.
-    let mut sim = vec![vec![0f32; n]; n];
-    for i in 0..n {
-        for j in (i + 1)..n {
-            let s = dot(&matrix[i], &matrix[j]);
-            sim[i][j] = s;
-            sim[j][i] = s;
-        }
-    }
-
     // Active clusters as member-index lists, plus cross-cluster similarity SUMS
     // (average linkage = sum / (|A|*|B|)). `members[c]` empty ⇒ cluster merged away.
     let mut members: Vec<Vec<usize>> = (0..n).map(|i| vec![i]).collect();
-    let mut sumsim = sim.clone(); // sumsim[a][b] starts as the single-pair sim
+    let mut sumsim = pairwise_similarity(matrix); // sumsim[a][b] starts as the single-pair sim
     let mut active: Vec<usize> = (0..n).collect();
 
     while active.len() > 1 {
-        // Best mergeable pair by average linkage.
-        let (mut ba, mut bb, mut best) = (0usize, 0usize, f32::MIN);
-        for ia in 0..active.len() {
-            for ib in (ia + 1)..active.len() {
-                let a = active[ia];
-                let b = active[ib];
-                let avg = sumsim[a][b] / (members[a].len() * members[b].len()) as f32;
-                if avg > best {
-                    best = avg;
-                    ba = a;
-                    bb = b;
-                }
-            }
-        }
-
+        let (ba, bb, best) = best_linkage_pair(&active, &members, &sumsim);
         let must_reduce = active.len() > KMAX;
         if !must_reduce && best < MERGE_THRESHOLD {
             break;
         }
-
-        // Merge bb into ba: combine members and fold similarity sums.
-        let moved = std::mem::take(&mut members[bb]);
-        members[ba].extend(moved);
-        for &c in &active {
-            if c != ba && c != bb {
-                let s = sumsim[ba][c] + sumsim[bb][c];
-                sumsim[ba][c] = s;
-                sumsim[c][ba] = s;
-            }
-        }
-        active.retain(|&c| c != bb);
+        merge_clusters(ba, bb, &mut active, &mut members, &mut sumsim);
     }
 
     // Densify: active cluster id → 0..k.
@@ -714,6 +715,63 @@ fn agglomerative(matrix: &[Vec<f32>]) -> Vec<usize> {
         }
     }
     labels
+}
+
+/// Symmetric N×N pairwise cosine similarity, diagonal 0.
+fn pairwise_similarity(matrix: &[Vec<f32>]) -> Vec<Vec<f32>> {
+    let n = matrix.len();
+    let mut sim = vec![vec![0f32; n]; n];
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let s = dot(&matrix[i], &matrix[j]);
+            sim[i][j] = s;
+            sim[j][i] = s;
+        }
+    }
+    sim
+}
+
+/// The most similar pair of active clusters by average linkage, as
+/// `(a, b, similarity)`.
+fn best_linkage_pair(
+    active: &[usize],
+    members: &[Vec<usize>],
+    sumsim: &[Vec<f32>],
+) -> (usize, usize, f32) {
+    let (mut ba, mut bb, mut best) = (0usize, 0usize, f32::MIN);
+    for ia in 0..active.len() {
+        for ib in (ia + 1)..active.len() {
+            let a = active[ia];
+            let b = active[ib];
+            let avg = sumsim[a][b] / (members[a].len() * members[b].len()) as f32;
+            if avg > best {
+                best = avg;
+                ba = a;
+                bb = b;
+            }
+        }
+    }
+    (ba, bb, best)
+}
+
+/// Merge `bb` into `ba`: combine members, fold similarity sums, drop `bb`.
+fn merge_clusters(
+    ba: usize,
+    bb: usize,
+    active: &mut Vec<usize>,
+    members: &mut [Vec<usize>],
+    sumsim: &mut [Vec<f32>],
+) {
+    let moved = std::mem::take(&mut members[bb]);
+    members[ba].extend(moved);
+    for &c in active.iter() {
+        if c != ba && c != bb {
+            let s = sumsim[ba][c] + sumsim[bb][c];
+            sumsim[ba][c] = s;
+            sumsim[c][ba] = s;
+        }
+    }
+    active.retain(|&c| c != bb);
 }
 
 // ---------------------------------------------------------------------------
@@ -735,49 +793,9 @@ fn nme_spectral(matrix: &[Vec<f32>], known_k: Option<usize>) -> Vec<usize> {
     let aff = cosine_affinity(matrix);
     let max_k = KMAX.min(n - 1).max(1);
 
-    // Search the neighbour count p: keep the p whose pruned affinity yields the
-    // cleanest spectrum, scored r(p) = p / g(p) with g the normalized max eigengap.
-    // Each p is an independent eigendecomposition → workers pull from a shared
-    // rolling queue (claim next p when free), same load-balanced pattern as the
-    // embedding loop — no fixed chunk that could leave a worker idle.
     let p_max = (n / 4).clamp(2, n - 1);
     let cands = p_candidates(p_max, NME_MAX_P_CANDIDATES);
-    let workers = num_workers(cands.len());
-    let cursor = AtomicUsize::new(0);
-
-    let scored: Vec<(usize, f32, usize)> = std::thread::scope(|scope| {
-        let (aff, cands, cursor) = (&aff, &cands, &cursor);
-        let handles: Vec<_> = (0..workers)
-            .map(|_| {
-                scope.spawn(move || {
-                    let mut local: Vec<(usize, f32, usize)> = Vec::new();
-                    loop {
-                        let idx = cursor.fetch_add(1, Ordering::Relaxed);
-                        if idx >= cands.len() {
-                            break;
-                        }
-                        let p = cands[idx];
-                        let lap = pruned_laplacian(aff, p);
-                        let mut evals: Vec<f64> =
-                            lap.symmetric_eigenvalues().iter().copied().collect();
-                        evals.sort_by(|a, b| a.total_cmp(b));
-                        let (g, k_est) = nme_and_count(&evals, max_k);
-                        let r = if g > 0.0 {
-                            p as f32 / g as f32
-                        } else {
-                            f32::INFINITY
-                        };
-                        local.push((p, r, k_est));
-                    }
-                    local
-                })
-            })
-            .collect();
-        handles
-            .into_iter()
-            .flat_map(|h| h.join().unwrap_or_default())
-            .collect()
-    });
+    let scored = score_p_candidates(&aff, &cands, max_k);
 
     let (best_p, _, k_est) = scored
         .into_iter()
@@ -795,6 +813,56 @@ fn nme_spectral(matrix: &[Vec<f32>], known_k: Option<usize>) -> Vec<usize> {
     let se = SymmetricEigen::new(lap);
     let spec = spectral_embedding(&se, k);
     kmeans_euclidean(&spec, k)
+}
+
+/// Search the neighbour count p: score each candidate p by r(p) = p / g(p), with
+/// g the normalized max eigengap of the pruned affinity's spectrum (lower r =
+/// cleaner spectrum). Returns `(p, r, estimated speaker count)` per candidate.
+///
+/// Each p is an independent eigendecomposition → workers pull from a shared
+/// rolling queue (claim next p when free), same load-balanced pattern as the
+/// embedding loop — no fixed chunk that could leave a worker idle.
+fn score_p_candidates(aff: &[Vec<f32>], cands: &[usize], max_k: usize) -> Vec<(usize, f32, usize)> {
+    let workers = num_workers(cands.len());
+    let cursor = AtomicUsize::new(0);
+    std::thread::scope(|scope| {
+        let cursor = &cursor;
+        let handles: Vec<_> = (0..workers)
+            .map(|_| scope.spawn(move || score_p_worker(aff, cands, cursor, max_k)))
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap_or_default())
+            .collect()
+    })
+}
+
+/// One p-search worker: claim candidates off the shared cursor until drained.
+fn score_p_worker(
+    aff: &[Vec<f32>],
+    cands: &[usize],
+    cursor: &AtomicUsize,
+    max_k: usize,
+) -> Vec<(usize, f32, usize)> {
+    let mut local: Vec<(usize, f32, usize)> = Vec::new();
+    loop {
+        let idx = cursor.fetch_add(1, Ordering::Relaxed);
+        if idx >= cands.len() {
+            break;
+        }
+        let p = cands[idx];
+        let lap = pruned_laplacian(aff, p);
+        let mut evals: Vec<f64> = lap.symmetric_eigenvalues().iter().copied().collect();
+        evals.sort_by(|a, b| a.total_cmp(b));
+        let (g, k_est) = nme_and_count(&evals, max_k);
+        let r = if g > 0.0 {
+            p as f32 / g as f32
+        } else {
+            f32::INFINITY
+        };
+        local.push((p, r, k_est));
+    }
+    local
 }
 
 /// N×N cosine affinity (embeddings are L2-normalized, so this is a dot product),
@@ -904,7 +972,30 @@ fn spectral_embedding(se: &SymmetricEigen<f64, nalgebra::Dyn>, k: usize) -> Vec<
 fn kmeans_euclidean(points: &[Vec<f32>], k: usize) -> Vec<usize> {
     let n = points.len();
     let dim = points.first().map(|p| p.len()).unwrap_or(0);
+    let mut centroids = farthest_first_euclidean(points, k);
+    let mut labels = vec![0usize; n];
+    for _ in 0..KMEANS_ITERS {
+        let mut changed = false;
+        for (i, pt) in points.iter().enumerate() {
+            let lab = (0..k)
+                .min_by(|&a, &b| sqdist(pt, &centroids[a]).total_cmp(&sqdist(pt, &centroids[b])))
+                .unwrap_or(0);
+            if lab != labels[i] {
+                changed = true;
+                labels[i] = lab;
+            }
+        }
+        refresh_centroids_euclidean(points, &mut labels, &mut centroids, dim);
+        if !changed {
+            break;
+        }
+    }
+    labels
+}
 
+/// Farthest-first seeding under squared Euclidean distance: start at 0, then
+/// repeatedly take the point farthest from every chosen centroid.
+fn farthest_first_euclidean(points: &[Vec<f32>], k: usize) -> Vec<Vec<f32>> {
     let mut centroids: Vec<Vec<f32>> = vec![points[0].clone()];
     while centroids.len() < k {
         let mut best_i = 0;
@@ -921,53 +1012,52 @@ fn kmeans_euclidean(points: &[Vec<f32>], k: usize) -> Vec<usize> {
         }
         centroids.push(points[best_i].clone());
     }
+    centroids
+}
 
-    let mut labels = vec![0usize; n];
-    for _ in 0..KMEANS_ITERS {
-        let mut changed = false;
-        for (i, pt) in points.iter().enumerate() {
-            let lab = (0..k)
-                .min_by(|&a, &b| sqdist(pt, &centroids[a]).total_cmp(&sqdist(pt, &centroids[b])))
-                .unwrap_or(0);
-            if lab != labels[i] {
-                changed = true;
-                labels[i] = lab;
+/// Recompute Euclidean centroids as member means; an emptied cluster steals the
+/// worst-fitting point (farthest from its own current centroid) instead.
+fn refresh_centroids_euclidean(
+    points: &[Vec<f32>],
+    labels: &mut [usize],
+    centroids: &mut [Vec<f32>],
+    dim: usize,
+) {
+    let n = points.len();
+    for c in 0..centroids.len() {
+        let members: Vec<&Vec<f32>> = points
+            .iter()
+            .zip(labels.iter())
+            .filter(|(_, &l)| l == c)
+            .map(|(p, _)| p)
+            .collect();
+        if members.is_empty() {
+            drop(members);
+            if let Some(worst) = (0..n).max_by(|&a, &b| {
+                sqdist(&points[a], &centroids[labels[a]])
+                    .total_cmp(&sqdist(&points[b], &centroids[labels[b]]))
+            }) {
+                labels[worst] = c;
+                centroids[c] = points[worst].clone();
             }
-        }
-        for c in 0..k {
-            let members: Vec<&Vec<f32>> = points
-                .iter()
-                .zip(&labels)
-                .filter(|(_, &l)| l == c)
-                .map(|(p, _)| p)
-                .collect();
-            if members.is_empty() {
-                drop(members);
-                if let Some(worst) = (0..n).max_by(|&a, &b| {
-                    sqdist(&points[a], &centroids[labels[a]])
-                        .total_cmp(&sqdist(&points[b], &centroids[labels[b]]))
-                }) {
-                    labels[worst] = c;
-                    centroids[c] = points[worst].clone();
-                }
-            } else {
-                let mut mean = vec![0f32; dim];
-                for m in &members {
-                    for (a, x) in mean.iter_mut().zip(m.iter()) {
-                        *a += x;
-                    }
-                }
-                for a in &mut mean {
-                    *a /= members.len() as f32;
-                }
-                centroids[c] = mean;
-            }
-        }
-        if !changed {
-            break;
+        } else {
+            centroids[c] = mean_point(&members, dim);
         }
     }
-    labels
+}
+
+/// Arithmetic mean of `members` in `dim` dimensions.
+fn mean_point(members: &[&Vec<f32>], dim: usize) -> Vec<f32> {
+    let mut mean = vec![0f32; dim];
+    for m in members {
+        for (a, x) in mean.iter_mut().zip(m.iter()) {
+            *a += x;
+        }
+    }
+    for a in &mut mean {
+        *a /= members.len() as f32;
+    }
+    mean
 }
 
 fn sqdist(a: &[f32], b: &[f32]) -> f32 {

--- a/src-tauri/src/diarize.rs
+++ b/src-tauri/src/diarize.rs
@@ -427,7 +427,7 @@ fn embed_worker(
         }
         // else: too short / out of range — filled from a neighbour later.
         let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
-        if done % step == 0 || done == n {
+        if done.is_multiple_of(step) || done == n {
             let _ = app.emit(
                 "diarize://progress",
                 Progress {

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1542,13 +1542,11 @@ fn focused_content(state: &HttpState) -> Value {
         s.get("findings").cloned().unwrap_or_else(|| json!([])),
     );
     // Every analysis artifact the app has for the loaded content.
-    for key in ["brief", "actionItems", "deliveryAssessment"] {
-        if let Some(v) = s.get(key) {
-            if !v.is_null() {
-                out.insert(key.into(), v.clone());
-            }
-        }
-    }
+    copy_missing_keys(
+        &mut out,
+        &s,
+        &["brief", "actionItems", "deliveryAssessment"],
+    );
     if focus == "live-meeting" || focus == "live-post-meeting" {
         out.insert(
             "todos".into(),
@@ -1560,36 +1558,55 @@ fn focused_content(state: &HttpState) -> Value {
         );
     }
     if focus == "replay" {
-        if let Some(id) = ctx
-            .pointer("/replay/savedHistoryId")
-            .and_then(Value::as_str)
-        {
-            // Backfill from disk anything the snapshot didn't carry (e.g. a
-            // snapshot written by an older app version).
-            if let Ok(meta) = read_meta(&state.history_dir, id) {
-                for key in ["title", "brief", "actionItems", "deliveryAssessment"] {
-                    if out.contains_key(key) {
-                        continue;
-                    }
-                    if let Some(v) = meta.get(key) {
-                        if !v.is_null() {
-                            out.insert(key.into(), v.clone());
-                        }
-                    }
-                }
-            }
-        } else {
-            out.insert(
-                "note".into(),
-                json!(
-                    "This recording is not in the local library (an unsaved upload or an \
-                       org recording viewed read-only), so saved extras like action items \
-                       are unavailable here."
-                ),
-            );
-        }
+        add_replay_extras(&mut out, &ctx, &state.history_dir);
     }
     Value::Object(out)
+}
+
+/// Copy each non-null `keys` entry from `src` into `out`, leaving whatever `out`
+/// already carries untouched.
+fn copy_missing_keys(out: &mut serde_json::Map<String, Value>, src: &Value, keys: &[&str]) {
+    for key in keys {
+        if out.contains_key(*key) {
+            continue;
+        }
+        if let Some(v) = src.get(*key) {
+            if !v.is_null() {
+                out.insert((*key).to_string(), v.clone());
+            }
+        }
+    }
+}
+
+/// For a replay, backfill from `meta.json` anything the snapshot didn't carry
+/// (e.g. a snapshot written by an older app version). A recording that isn't in
+/// the local library gets a note saying so instead.
+fn add_replay_extras(
+    out: &mut serde_json::Map<String, Value>,
+    ctx: &Value,
+    history_dir: &std::path::Path,
+) {
+    let Some(id) = ctx
+        .pointer("/replay/savedHistoryId")
+        .and_then(Value::as_str)
+    else {
+        out.insert(
+            "note".into(),
+            json!(
+                "This recording is not in the local library (an unsaved upload or an \
+                       org recording viewed read-only), so saved extras like action items \
+                       are unavailable here."
+            ),
+        );
+        return;
+    };
+    if let Ok(meta) = read_meta(history_dir, id) {
+        copy_missing_keys(
+            out,
+            &meta,
+            &["title", "brief", "actionItems", "deliveryAssessment"],
+        );
+    }
 }
 
 // ── Local recording store (read-only; mirrors the history.rs layout) ─────────
@@ -1620,41 +1637,53 @@ fn list_recordings(history_dir: &std::path::Path, args: &Value) -> anyhow::Resul
     let since = args.get("since").and_then(Value::as_i64).unwrap_or(0);
     let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(50) as usize;
 
-    let mut items: Vec<Value> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(history_dir) {
-        for entry in entries.flatten() {
-            let Ok(raw) = std::fs::read_to_string(entry.path().join("summary.json")) else {
-                continue;
-            };
-            let Ok(v) = serde_json::from_str::<Value>(&raw) else {
-                continue;
-            };
-            if let Some(folder) = folder {
-                if v.get("folderId").and_then(Value::as_str) != Some(folder) {
-                    continue;
-                }
-            }
-            if since > 0 && v.get("createdAt").and_then(Value::as_i64).unwrap_or(0) < since {
-                continue;
-            }
-            if !query.is_empty() {
-                let title = v.get("title").and_then(Value::as_str).unwrap_or("");
-                let snippet = v.get("snippet").and_then(Value::as_str).unwrap_or("");
-                if !title.to_lowercase().contains(&query)
-                    && !snippet.to_lowercase().contains(&query)
-                {
-                    continue;
-                }
-            }
-            items.push(v);
-        }
-    }
+    let mut items: Vec<Value> = read_entry_files(history_dir, "summary.json")
+        .filter(|v| in_scope(v, folder, since) && summary_matches_query(v, &query))
+        .collect();
     items.sort_by_key(|v| {
         std::cmp::Reverse(v.get("createdAt").and_then(Value::as_i64).unwrap_or(0))
     });
     let total = items.len();
     items.truncate(limit);
     Ok(json!({ "recordings": items, "total": total, "returned": items.len() }))
+}
+
+/// Every entry's `file` (`summary.json` / `meta.json`) in the store, as JSON.
+/// Entries that can't be read or parsed are skipped — a half-written recording
+/// shouldn't fail the whole listing. Lazy: one entry is held at a time, so a
+/// large library's `meta.json` files never all sit in memory at once.
+fn read_entry_files<'a>(
+    history_dir: &std::path::Path,
+    file: &'a str,
+) -> impl Iterator<Item = Value> + 'a {
+    std::fs::read_dir(history_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(move |entry| std::fs::read_to_string(entry.path().join(file)).ok())
+        .filter_map(|raw| serde_json::from_str::<Value>(&raw).ok())
+}
+
+/// Folder + `since` scoping, shared by the listing and the search.
+fn in_scope(v: &Value, folder: Option<&str>, since: i64) -> bool {
+    if let Some(folder) = folder {
+        if v.get("folderId").and_then(Value::as_str) != Some(folder) {
+            return false;
+        }
+    }
+    since <= 0 || v.get("createdAt").and_then(Value::as_i64).unwrap_or(0) >= since
+}
+
+/// The listing's shallow text filter: title or first-line snippet only (the deep
+/// search is `search_meetings`). An empty query matches everything. `query` is
+/// already lowercased.
+fn summary_matches_query(v: &Value, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let title = v.get("title").and_then(Value::as_str).unwrap_or("");
+    let snippet = v.get("snippet").and_then(Value::as_str).unwrap_or("");
+    title.to_lowercase().contains(query) || snippet.to_lowercase().contains(query)
 }
 
 /// Where a search hit landed. Ordered by how much a reader trusts it: a line
@@ -1723,100 +1752,18 @@ fn search_meetings(history_dir: &std::path::Path, args: &Value) -> anyhow::Resul
 
     let mut results: Vec<Value> = Vec::new();
     let mut scanned = 0usize;
-    if let Ok(entries) = std::fs::read_dir(history_dir) {
-        for entry in entries.flatten() {
-            let Ok(raw) = std::fs::read_to_string(entry.path().join("meta.json")) else {
-                continue;
-            };
-            let Ok(meta) = serde_json::from_str::<Value>(&raw) else {
-                continue;
-            };
-            if let Some(folder) = folder {
-                if meta.get("folderId").and_then(Value::as_str) != Some(folder) {
-                    continue;
-                }
-            }
-            if since > 0 && meta.get("createdAt").and_then(Value::as_i64).unwrap_or(0) < since {
-                continue;
-            }
-            scanned += 1;
-            let mut hits: Vec<Value> = Vec::new();
-
-            // What was said. Segment-level so each hit carries a seek target.
-            if let Some(segs) = meta.get("segments").and_then(Value::as_array) {
-                for s in segs {
-                    let text = s.get("text").and_then(Value::as_str).unwrap_or("");
-                    if let Some(at) = find_ci(text, &query) {
-                        hits.push(hit(
-                            "transcript",
-                            text,
-                            at,
-                            qlen,
-                            s.get("startMs").and_then(Value::as_i64),
-                        ));
-                    }
-                }
-            }
-            // What the analysis concluded.
-            for (field, text) in [
-                ("brief", meta.get("brief").and_then(Value::as_str)),
-                (
-                    "context",
-                    meta.get("meetingContext").and_then(Value::as_str),
-                ),
-            ] {
-                if let Some(text) = text {
-                    if let Some(at) = find_ci(text, &query) {
-                        hits.push(hit(field, text, at, qlen, None));
-                    }
-                }
-            }
-            for (field, key, parts) in [
-                ("finding", "findings", ["title", "detail"]),
-                ("actionItem", "actionItems", ["text", "rationale"]),
-            ] {
-                for item in meta
-                    .get(key)
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten()
-                {
-                    let text = parts
-                        .iter()
-                        .filter_map(|p| item.get(*p).and_then(Value::as_str))
-                        .collect::<Vec<_>>()
-                        .join(" — ");
-                    if let Some(at) = find_ci(&text, &query) {
-                        hits.push(hit(
-                            field,
-                            &text,
-                            at,
-                            qlen,
-                            item.get("atMs").and_then(Value::as_i64),
-                        ));
-                    }
-                }
-            }
-            if hits.is_empty() {
-                continue;
-            }
-            let total = hits.len();
-            // Most-trusted field first, then chronological within a field.
-            hits.sort_by_key(|h| {
-                let f = h.get("field").and_then(Value::as_str).unwrap_or("");
-                let rank = SEARCH_FIELDS.iter().position(|x| *x == f).unwrap_or(9);
-                (rank, h.get("atMs").and_then(Value::as_i64).unwrap_or(0))
-            });
-            hits.truncate(per_recording);
-            results.push(json!({
-                "id": meta.get("id").cloned().unwrap_or(Value::Null),
-                "title": meta.get("title").cloned().unwrap_or(Value::Null),
-                "createdAt": meta.get("createdAt").cloned().unwrap_or(Value::Null),
-                "folderId": meta.get("folderId").cloned().unwrap_or(Value::Null),
-                "hitCount": total,
-                "hits": hits,
-            }));
+    for meta in read_entry_files(history_dir, "meta.json") {
+        if !in_scope(&meta, folder, since) {
+            continue;
         }
+        scanned += 1;
+        let mut hits = segment_hits(&meta, &query, qlen);
+        hits.extend(summary_field_hits(&meta, &query, qlen));
+        hits.extend(list_field_hits(&meta, &query, qlen));
+        if hits.is_empty() {
+            continue;
+        }
+        results.push(recording_hits(&meta, hits, per_recording));
     }
     // Recordings with the most to say about the query first; ties break newest.
     results.sort_by_key(|r| {
@@ -1834,6 +1781,97 @@ fn search_meetings(history_dir: &std::path::Path, args: &Value) -> anyhow::Resul
         "returned": results.len(),
         "recordings": results,
     }))
+}
+
+/// What was said. Segment-level so each hit carries a seek target.
+fn segment_hits(meta: &Value, query: &str, qlen: usize) -> Vec<Value> {
+    let Some(segs) = meta.get("segments").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    segs.iter()
+        .filter_map(|s| {
+            let text = s.get("text").and_then(Value::as_str).unwrap_or("");
+            let at = find_ci(text, query)?;
+            Some(hit(
+                "transcript",
+                text,
+                at,
+                qlen,
+                s.get("startMs").and_then(Value::as_i64),
+            ))
+        })
+        .collect()
+}
+
+/// What the analysis concluded, in the single-string fields.
+fn summary_field_hits(meta: &Value, query: &str, qlen: usize) -> Vec<Value> {
+    [
+        ("brief", meta.get("brief").and_then(Value::as_str)),
+        (
+            "context",
+            meta.get("meetingContext").and_then(Value::as_str),
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(field, text)| {
+        let text = text?;
+        let at = find_ci(text, query)?;
+        Some(hit(field, text, at, qlen, None))
+    })
+    .collect()
+}
+
+/// What the analysis concluded, in the list fields (findings, action items).
+/// Each item's parts are joined so a query spanning title and detail still hits.
+fn list_field_hits(meta: &Value, query: &str, qlen: usize) -> Vec<Value> {
+    let mut hits: Vec<Value> = Vec::new();
+    for (field, key, parts) in [
+        ("finding", "findings", ["title", "detail"]),
+        ("actionItem", "actionItems", ["text", "rationale"]),
+    ] {
+        for item in meta
+            .get(key)
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let text = parts
+                .iter()
+                .filter_map(|p| item.get(*p).and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(" — ");
+            if let Some(at) = find_ci(&text, query) {
+                hits.push(hit(
+                    field,
+                    &text,
+                    at,
+                    qlen,
+                    item.get("atMs").and_then(Value::as_i64),
+                ));
+            }
+        }
+    }
+    hits
+}
+
+/// One recording's search result: its identity plus the best `per_recording`
+/// hits, most-trusted field first and chronological within a field.
+fn recording_hits(meta: &Value, mut hits: Vec<Value>, per_recording: usize) -> Value {
+    let total = hits.len();
+    hits.sort_by_key(|h| {
+        let f = h.get("field").and_then(Value::as_str).unwrap_or("");
+        let rank = SEARCH_FIELDS.iter().position(|x| *x == f).unwrap_or(9);
+        (rank, h.get("atMs").and_then(Value::as_i64).unwrap_or(0))
+    });
+    hits.truncate(per_recording);
+    json!({
+        "id": meta.get("id").cloned().unwrap_or(Value::Null),
+        "title": meta.get("title").cloned().unwrap_or(Value::Null),
+        "createdAt": meta.get("createdAt").cloned().unwrap_or(Value::Null),
+        "folderId": meta.get("folderId").cloned().unwrap_or(Value::Null),
+        "hitCount": total,
+        "hits": hits,
+    })
 }
 
 /// Read one recording in full: curated meta fields + the transcript rebuilt as
@@ -1900,35 +1938,29 @@ fn transcript_text(meta: &Value, names: &Value) -> String {
             let total = start / 1000;
             let source = s.get("source").and_then(Value::as_str).unwrap_or("me");
             let speaker = s.get("speaker").and_then(Value::as_i64).unwrap_or(0);
-            let key = format!("{source}-{speaker}");
-            let label = match names.get(&key).and_then(Value::as_str) {
-                Some(custom) => custom.to_string(),
-                None => {
-                    let display = if speaker == 0 { 1 } else { speaker };
-                    match source {
-                        "mix" => format!("Speaker {display}"),
-                        "me" => {
-                            if display <= 1 {
-                                "You".to_string()
-                            } else {
-                                format!("Speaker {display}")
-                            }
-                        }
-                        _ => {
-                            if speaker > 0 {
-                                format!("Remote {speaker}")
-                            } else {
-                                "Them".to_string()
-                            }
-                        }
-                    }
-                }
-            };
+            let label = speaker_label(names, source, speaker);
             let text = s.get("text").and_then(Value::as_str).unwrap_or("").trim();
             format!("[{}:{:02}] [{label}] {text}", total / 60, total % 60)
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// One segment's speaker label: the user's own name for that voice when there is
+/// one, otherwise the same default the frontend's speakerLabel derives (store.ts).
+fn speaker_label(names: &Value, source: &str, speaker: i64) -> String {
+    let key = format!("{source}-{speaker}");
+    if let Some(custom) = names.get(&key).and_then(Value::as_str) {
+        return custom.to_string();
+    }
+    let display = if speaker == 0 { 1 } else { speaker };
+    match source {
+        "mix" => format!("Speaker {display}"),
+        "me" if display <= 1 => "You".to_string(),
+        "me" => format!("Speaker {display}"),
+        _ if speaker > 0 => format!("Remote {speaker}"),
+        _ => "Them".to_string(),
+    }
 }
 
 // ── RPC bridge: enqueue a command, wait for the frontend's result ─────────────

--- a/src-tauri/src/transcription/assemblyai.rs
+++ b/src-tauri/src/transcription/assemblyai.rs
@@ -5,25 +5,21 @@
 //! emitted under speaker 0 (a single speaker in the UI).
 
 use anyhow::{anyhow, Result};
-use futures_util::stream::SplitStream;
-use futures_util::{SinkExt, StreamExt};
+use futures_util::StreamExt;
 use serde::Deserialize;
 use tauri::AppHandle;
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, urlencode, LevelMeter, SegmentBuilder,
     TranscribeConfig, LEVEL_EVENT, TRANSCRIPT_EVENT,
 };
+use super::ws::{self, Next, OnClose, Pump, WsRead};
 use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const AAI_BASE: &str = "wss://streaming.assemblyai.com/v3/ws";
-
-type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// Universal-Streaming's custom-vocabulary query param, ready to append to the
 /// v3 websocket URL. The wire shape is `keyterms_prompt=<JSON array of terms>`,
@@ -67,33 +63,6 @@ struct AaiMessage {
     error: Option<String>,
 }
 
-/// What the read loop should do with one incoming websocket frame.
-enum Frame {
-    /// A JSON payload to parse.
-    Payload(String),
-    /// Nothing of interest — keep reading.
-    Skip,
-    /// The stream ended; stop reading.
-    Stop,
-}
-
-/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
-fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
-    match msg {
-        Ok(Message::Text(t)) => Frame::Payload(t.to_string()),
-        Ok(Message::Binary(b)) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
-        Ok(Message::Close(frame)) => {
-            eprintln!("[assemblyai:{source}] closed by server: {frame:?}");
-            Frame::Stop
-        }
-        Ok(_) => Frame::Skip,
-        Err(e) => {
-            eprintln!("[assemblyai:{source}] read error: {e}");
-            Frame::Stop
-        }
-    }
-}
-
 /// Turn one "Turn" message into either a committed segment (settled and
 /// punctuated) or the tentative tail for the in-progress turn.
 fn apply_turn(builder: &mut SegmentBuilder, m: &AaiMessage) {
@@ -118,24 +87,14 @@ fn apply_turn(builder: &mut SegmentBuilder, m: &AaiMessage) {
 
 /// Parse server frames into transcript segments until the socket ends or an
 /// in-band error arrives.
-async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+async fn read_transcripts(app: AppHandle, source: &'static str, read: WsRead) -> Result<()> {
     let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
-    let mut msg_count: u64 = 0;
-    while let Some(msg) = read.next().await {
-        let payload = match classify(msg, source) {
-            Frame::Payload(p) => p,
-            Frame::Skip => continue,
-            Frame::Stop => break,
-        };
-        msg_count += 1;
-        if msg_count <= 3 {
-            eprintln!("[assemblyai:{source}] RX raw#{msg_count}: {payload}");
-        }
-        let m: AaiMessage = match serde_json::from_str(&payload) {
+    ws::read_frames("assemblyai", source, read, OnClose::Stop, |payload| {
+        let m: AaiMessage = match serde_json::from_str(payload) {
             Ok(m) => m,
             Err(e) => {
                 eprintln!("[assemblyai:{source}] parse error: {e}");
-                continue;
+                return Ok(Next::Continue);
             }
         };
         if let Some(err) = m.error {
@@ -144,19 +103,20 @@ async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead
             eprintln!("[assemblyai:{source}] error: {err}");
             return Err(anyhow!("server error: {err}"));
         }
-        if m.msg_type != "Turn" {
-            continue; // Begin / Termination / etc.
+        // Everything that isn't a Turn (Begin, Termination, …) is ignored.
+        if m.msg_type == "Turn" {
+            apply_turn(&mut builder, &m);
         }
-        apply_turn(&mut builder, &m);
-    }
-    Ok(())
+        Ok(Next::Continue)
+    })
+    .await
 }
 
 pub async fn run_session(
     app: AppHandle,
     config: TranscribeConfig,
     source: &'static str,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
 ) -> Result<()> {
     let url = format!(
         "{AAI_BASE}?sample_rate={}&encoding=pcm_s16le&format_turns=true{}",
@@ -165,29 +125,18 @@ pub async fn run_session(
     );
     // AssemblyAI takes the API key directly in the Authorization header.
     let ws = connect_with_headers(&url, &[("Authorization", config.api_key.clone())]).await?;
-    let (mut write, read) = ws.split();
+    let (write, read) = ws.split();
     eprintln!("[assemblyai:{source}] connected (diarization unsupported → speaker 0)");
 
-    let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
-    // Resolves with whether the input drained (normal stop) or a send failed
-    // (dead socket) — drive_session reports the latter as a failure.
-    let forward = async move {
-        let drained = loop {
-            let Some(chunk) = pcm_rx.recv().await else {
-                break true;
-            };
-            meter.push(&chunk);
-            let bytes = pcm_to_le_bytes(&chunk);
-            if write.send(Message::Binary(bytes)).await.is_err() {
-                break false;
-            }
-        };
-        let _ = write
-            .send(Message::Text("{\"type\":\"Terminate\"}".to_string()))
-            .await;
-        let _ = write.close().await;
-        drained
+    let meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
+    // Raw pcm_s16le on the wire; `Terminate` is v3's goodbye frame.
+    let pump = Pump {
+        finish: Some("{\"type\":\"Terminate\"}"),
+        ..Pump::default()
     };
+    let forward = ws::forward_audio(write, meter, pcm_rx, pump, |chunk| {
+        Message::Binary(pcm_to_le_bytes(chunk))
+    });
 
     drive_session("assemblyai", forward, read_transcripts(app, source, read)).await
 }

--- a/src-tauri/src/transcription/assemblyai.rs
+++ b/src-tauri/src/transcription/assemblyai.rs
@@ -5,11 +5,14 @@
 //! emitted under speaker 0 (a single speaker in the UI).
 
 use anyhow::{anyhow, Result};
+use futures_util::stream::SplitStream;
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use tauri::AppHandle;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, urlencode, LevelMeter, SegmentBuilder,
@@ -19,6 +22,8 @@ use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const AAI_BASE: &str = "wss://streaming.assemblyai.com/v3/ws";
+
+type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// Universal-Streaming's custom-vocabulary query param, ready to append to the
 /// v3 websocket URL. The wire shape is `keyterms_prompt=<JSON array of terms>`,
@@ -62,6 +67,91 @@ struct AaiMessage {
     error: Option<String>,
 }
 
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended; stop reading.
+    Stop,
+}
+
+/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
+fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
+    match msg {
+        Ok(Message::Text(t)) => Frame::Payload(t.to_string()),
+        Ok(Message::Binary(b)) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Ok(Message::Close(frame)) => {
+            eprintln!("[assemblyai:{source}] closed by server: {frame:?}");
+            Frame::Stop
+        }
+        Ok(_) => Frame::Skip,
+        Err(e) => {
+            eprintln!("[assemblyai:{source}] read error: {e}");
+            Frame::Stop
+        }
+    }
+}
+
+/// Turn one "Turn" message into either a committed segment (settled and
+/// punctuated) or the tentative tail for the in-progress turn.
+fn apply_turn(builder: &mut SegmentBuilder, m: &AaiMessage) {
+    let text = m.transcript.trim();
+    if text.is_empty() {
+        return;
+    }
+    let start_ms = m.words.first().map(|w| w.start).unwrap_or(0);
+    let end_ms = m.words.last().map(|w| w.end).unwrap_or(start_ms);
+
+    if m.end_of_turn && m.turn_is_formatted {
+        // The turn is settled and punctuated → commit it as one segment.
+        builder.push_final(text, 0, start_ms, end_ms);
+        builder.emit_committed();
+        builder.endpoint();
+        builder.emit_tail("", 0, end_ms); // clear the tail
+    } else {
+        // Cumulative interim hypothesis for the in-progress turn.
+        builder.emit_tail(text, 0, start_ms);
+    }
+}
+
+/// Parse server frames into transcript segments until the socket ends or an
+/// in-band error arrives.
+async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+    let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
+    let mut msg_count: u64 = 0;
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, source) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[assemblyai:{source}] RX raw#{msg_count}: {payload}");
+        }
+        let m: AaiMessage = match serde_json::from_str(&payload) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("[assemblyai:{source}] parse error: {e}");
+                continue;
+            }
+        };
+        if let Some(err) = m.error {
+            // In-band errors are terminal (the server closes after) — the
+            // session is dead, so surface it (see run_metered_session).
+            eprintln!("[assemblyai:{source}] error: {err}");
+            return Err(anyhow!("server error: {err}"));
+        }
+        if m.msg_type != "Turn" {
+            continue; // Begin / Termination / etc.
+        }
+        apply_turn(&mut builder, &m);
+    }
+    Ok(())
+}
+
 pub async fn run_session(
     app: AppHandle,
     config: TranscribeConfig,
@@ -75,7 +165,7 @@ pub async fn run_session(
     );
     // AssemblyAI takes the API key directly in the Authorization header.
     let ws = connect_with_headers(&url, &[("Authorization", config.api_key.clone())]).await?;
-    let (mut write, mut read) = ws.split();
+    let (mut write, read) = ws.split();
     eprintln!("[assemblyai:{source}] connected (diarization unsupported → speaker 0)");
 
     let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
@@ -99,65 +189,7 @@ pub async fn run_session(
         drained
     };
 
-    let read_loop = async move {
-        let mut builder = SegmentBuilder::new(app.clone(), source, TRANSCRIPT_EVENT);
-        let mut msg_count: u64 = 0;
-        while let Some(msg) = read.next().await {
-            let payload = match msg {
-                Ok(Message::Text(t)) => t.to_string(),
-                Ok(Message::Binary(b)) => String::from_utf8_lossy(&b).into_owned(),
-                Ok(Message::Close(frame)) => {
-                    eprintln!("[assemblyai:{source}] closed by server: {frame:?}");
-                    break;
-                }
-                Ok(_) => continue,
-                Err(e) => {
-                    eprintln!("[assemblyai:{source}] read error: {e}");
-                    break;
-                }
-            };
-            msg_count += 1;
-            if msg_count <= 3 {
-                eprintln!("[assemblyai:{source}] RX raw#{msg_count}: {payload}");
-            }
-            let m: AaiMessage = match serde_json::from_str(&payload) {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!("[assemblyai:{source}] parse error: {e}");
-                    continue;
-                }
-            };
-            if let Some(err) = m.error {
-                // In-band errors are terminal (the server closes after) — the
-                // session is dead, so surface it (see run_metered_session).
-                eprintln!("[assemblyai:{source}] error: {err}");
-                return Err(anyhow!("server error: {err}"));
-            }
-            if m.msg_type != "Turn" {
-                continue; // Begin / Termination / etc.
-            }
-            let text = m.transcript.trim();
-            if text.is_empty() {
-                continue;
-            }
-            let start_ms = m.words.first().map(|w| w.start).unwrap_or(0);
-            let end_ms = m.words.last().map(|w| w.end).unwrap_or(start_ms);
-
-            if m.end_of_turn && m.turn_is_formatted {
-                // The turn is settled and punctuated → commit it as one segment.
-                builder.push_final(text, 0, start_ms, end_ms);
-                builder.emit_committed();
-                builder.endpoint();
-                builder.emit_tail("", 0, end_ms); // clear the tail
-            } else {
-                // Cumulative interim hypothesis for the in-progress turn.
-                builder.emit_tail(text, 0, start_ms);
-            }
-        }
-        Ok(())
-    };
-
-    drive_session("assemblyai", forward, read_loop).await
+    drive_session("assemblyai", forward, read_transcripts(app, source, read)).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/transcription/deepgram.rs
+++ b/src-tauri/src/transcription/deepgram.rs
@@ -1,29 +1,23 @@
 //! Deepgram realtime adapter. Streams linear16 PCM over a WebSocket and parses
 //! Deepgram's `Results` messages (with optional word-level diarization).
 
-use anyhow::{anyhow, Result};
-use futures_util::stream::{SplitSink, SplitStream};
-use futures_util::{SinkExt, StreamExt};
+use anyhow::Result;
+use futures_util::StreamExt;
 use serde::Deserialize;
 use tauri::AppHandle;
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, urlencode, LevelMeter, SegmentBuilder,
     TranscribeConfig, LEVEL_EVENT, TRANSCRIPT_EVENT,
 };
+use super::ws::{self, Next, OnClose, Pump, WsRead, WsWrite};
 use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const DEEPGRAM_BASE: &str = "wss://api.deepgram.com/v1/listen";
 const DEFAULT_MODEL: &str = "nova-3";
-
-type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
-type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// Deepgram's custom-vocabulary query params, as a string ready to append to a
 /// `/v1/listen` URL (each term gets its OWN param — the API takes them repeated,
@@ -85,18 +79,6 @@ struct DgResponse {
     speech_final: bool,
 }
 
-/// What the read loop should do with one incoming websocket frame.
-enum Frame {
-    /// A JSON payload to parse.
-    Payload(String),
-    /// Nothing of interest — keep reading.
-    Skip,
-    /// The stream ended in a way that isn't an error.
-    Stop,
-    /// The server closed abnormally: terminal, with its reason as the detail.
-    Failed(String),
-}
-
 /// The `/v1/listen` URL for this session: fixed stream shape plus the optional
 /// diarization, language and custom-vocabulary knobs.
 fn listen_url(config: &TranscribeConfig, model: &str) -> String {
@@ -114,65 +96,24 @@ fn listen_url(config: &TranscribeConfig, model: &str) -> String {
     url
 }
 
-/// Forward PCM as binary frames; keep alive; close cleanly. Resolves with
-/// whether the input drained (normal stop) or a send failed (dead socket).
+/// Forward PCM as binary frames; keep alive; close cleanly.
 async fn forward_audio(
-    mut write: WsWrite,
-    mut meter: LevelMeter,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    write: WsWrite,
+    meter: LevelMeter,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
 ) -> bool {
-    let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(5));
-    keepalive.tick().await;
-    let drained = loop {
-        tokio::select! {
-            maybe_chunk = pcm_rx.recv() => {
-                let Some(chunk) = maybe_chunk else { break true };
-                meter.push(&chunk);
-                let bytes = pcm_to_le_bytes(&chunk);
-                if write.send(Message::Binary(bytes)).await.is_err() {
-                    break false;
-                }
-            }
-            _ = keepalive.tick() => {
-                if write.send(Message::Text("{\"type\":\"KeepAlive\"}".to_string())).await.is_err() {
-                    break false;
-                }
-            }
-        }
+    let pump = Pump {
+        keepalive: Some((
+            std::time::Duration::from_secs(5),
+            "{\"type\":\"KeepAlive\"}",
+        )),
+        finish: Some("{\"type\":\"CloseStream\"}"),
+        close: true,
     };
-    let _ = write
-        .send(Message::Text("{\"type\":\"CloseStream\"}".to_string()))
-        .await;
-    let _ = write.close().await;
-    drained
-}
-
-/// Classify one websocket frame. Deepgram has no in-band error messages —
-/// terminal errors arrive as an abnormal close code (1008 DATA-*, 1011 NET-*, …)
-/// whose reason is the only diagnostic we get. A normal close (1000) follows our
-/// CloseStream.
-fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
-    let msg = match msg {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("[deepgram:{source}] read error: {e}");
-            return Frame::Stop;
-        }
-    };
-    match msg {
-        Message::Text(t) => Frame::Payload(t.to_string()),
-        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
-        Message::Close(frame) => {
-            eprintln!("[deepgram:{source}] closed by server: {frame:?}");
-            match frame {
-                Some(f) if f.code != CloseCode::Normal => {
-                    Frame::Failed(format!("{} {}", u16::from(f.code), f.reason))
-                }
-                _ => Frame::Stop,
-            }
-        }
-        _ => Frame::Skip,
-    }
+    ws::forward_audio(write, meter, pcm_rx, pump, |chunk| {
+        Message::Binary(pcm_to_le_bytes(chunk))
+    })
+    .await
 }
 
 /// Settled words → push each into its speaker-run, then commit.
@@ -228,26 +169,26 @@ fn apply_response(builder: &mut SegmentBuilder, resp: DgResponse) {
 }
 
 /// Parse server frames into transcript segments until the socket ends.
-async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+///
+/// Deepgram has no in-band error messages — terminal errors arrive as an
+/// abnormal close code (1008 DATA-*, 1011 NET-*, …) whose reason is the only
+/// diagnostic we get. A normal close (1000) follows our CloseStream.
+async fn read_transcripts(app: AppHandle, source: &'static str, read: WsRead) -> Result<()> {
     let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
-    let mut msg_count: u64 = 0;
-    while let Some(msg) = read.next().await {
-        let payload = match classify(msg, source) {
-            Frame::Payload(p) => p,
-            Frame::Skip => continue,
-            Frame::Stop => break,
-            Frame::Failed(detail) => return Err(anyhow!("closed by server: {detail}")),
-        };
-        msg_count += 1;
-        if msg_count <= 3 {
-            eprintln!("[deepgram:{source}] RX raw#{msg_count}: {payload}");
-        }
-        match serde_json::from_str::<DgResponse>(&payload) {
-            Ok(resp) => apply_response(&mut builder, resp),
-            Err(e) => eprintln!("[deepgram:{source}] parse error: {e}"),
-        }
-    }
-    Ok(())
+    ws::read_frames(
+        "deepgram",
+        source,
+        read,
+        OnClose::FailIfAbnormal,
+        |payload| {
+            match serde_json::from_str::<DgResponse>(payload) {
+                Ok(resp) => apply_response(&mut builder, resp),
+                Err(e) => eprintln!("[deepgram:{source}] parse error: {e}"),
+            }
+            Ok(Next::Continue)
+        },
+    )
+    .await
 }
 
 pub async fn run_session(

--- a/src-tauri/src/transcription/deepgram.rs
+++ b/src-tauri/src/transcription/deepgram.rs
@@ -2,12 +2,15 @@
 //! Deepgram's `Results` messages (with optional word-level diarization).
 
 use anyhow::{anyhow, Result};
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use tauri::AppHandle;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, urlencode, LevelMeter, SegmentBuilder,
@@ -18,6 +21,9 @@ use crate::audio::TARGET_SAMPLE_RATE;
 
 const DEEPGRAM_BASE: &str = "wss://api.deepgram.com/v1/listen";
 const DEFAULT_MODEL: &str = "nova-3";
+
+type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// Deepgram's custom-vocabulary query params, as a string ready to append to a
 /// `/v1/listen` URL (each term gets its OWN param — the API takes them repeated,
@@ -79,17 +85,21 @@ struct DgResponse {
     speech_final: bool,
 }
 
-pub async fn run_session(
-    app: AppHandle,
-    config: TranscribeConfig,
-    source: &'static str,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
-) -> Result<()> {
-    let model = if config.model.trim().is_empty() {
-        DEFAULT_MODEL
-    } else {
-        config.model.as_str()
-    };
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended in a way that isn't an error.
+    Stop,
+    /// The server closed abnormally: terminal, with its reason as the detail.
+    Failed(String),
+}
+
+/// The `/v1/listen` URL for this session: fixed stream shape plus the optional
+/// diarization, language and custom-vocabulary knobs.
+fn listen_url(config: &TranscribeConfig, model: &str) -> String {
     let mut url = format!(
         "{DEEPGRAM_BASE}?encoding=linear16&sample_rate={}&channels=1&interim_results=true&punctuate=true&smart_format=true&model={model}",
         TARGET_SAMPLE_RATE
@@ -101,134 +111,177 @@ pub async fn run_session(
         url.push_str(&format!("&language={lang}"));
     }
     url.push_str(&vocabulary_params(model, &config.vocabulary));
+    url
+}
+
+/// Forward PCM as binary frames; keep alive; close cleanly. Resolves with
+/// whether the input drained (normal stop) or a send failed (dead socket).
+async fn forward_audio(
+    mut write: WsWrite,
+    mut meter: LevelMeter,
+    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> bool {
+    let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(5));
+    keepalive.tick().await;
+    let drained = loop {
+        tokio::select! {
+            maybe_chunk = pcm_rx.recv() => {
+                let Some(chunk) = maybe_chunk else { break true };
+                meter.push(&chunk);
+                let bytes = pcm_to_le_bytes(&chunk);
+                if write.send(Message::Binary(bytes)).await.is_err() {
+                    break false;
+                }
+            }
+            _ = keepalive.tick() => {
+                if write.send(Message::Text("{\"type\":\"KeepAlive\"}".to_string())).await.is_err() {
+                    break false;
+                }
+            }
+        }
+    };
+    let _ = write
+        .send(Message::Text("{\"type\":\"CloseStream\"}".to_string()))
+        .await;
+    let _ = write.close().await;
+    drained
+}
+
+/// Classify one websocket frame. Deepgram has no in-band error messages —
+/// terminal errors arrive as an abnormal close code (1008 DATA-*, 1011 NET-*, …)
+/// whose reason is the only diagnostic we get. A normal close (1000) follows our
+/// CloseStream.
+fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
+    let msg = match msg {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("[deepgram:{source}] read error: {e}");
+            return Frame::Stop;
+        }
+    };
+    match msg {
+        Message::Text(t) => Frame::Payload(t.to_string()),
+        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Message::Close(frame) => {
+            eprintln!("[deepgram:{source}] closed by server: {frame:?}");
+            match frame {
+                Some(f) if f.code != CloseCode::Normal => {
+                    Frame::Failed(format!("{} {}", u16::from(f.code), f.reason))
+                }
+                _ => Frame::Stop,
+            }
+        }
+        _ => Frame::Skip,
+    }
+}
+
+/// Settled words → push each into its speaker-run, then commit.
+fn commit_final(builder: &mut SegmentBuilder, alt: &DgAlternative, speech_final: bool) {
+    for w in &alt.words {
+        let text = w.punctuated_word.as_deref().unwrap_or(&w.word);
+        if text.is_empty() {
+            continue;
+        }
+        let speaker = w.speaker.unwrap_or(0);
+        let start_ms = (w.start * 1000.0) as u64;
+        let end_ms = (w.end * 1000.0) as u64;
+        builder.push_final(&format!("{text} "), speaker, start_ms, end_ms);
+    }
+    builder.emit_committed();
+    // speech_final marks an utterance boundary.
+    if speech_final {
+        builder.endpoint();
+    }
+    // Clear any stale tail now that this chunk is committed.
+    builder.emit_tail("", builder.current_speaker(), builder.current_end());
+}
+
+/// Interim hypothesis → tentative tail, carrying the builder's current speaker
+/// and end time whenever the hypothesis doesn't name its own.
+fn emit_interim(builder: &mut SegmentBuilder, alt: &DgAlternative) {
+    let speaker = alt
+        .words
+        .first()
+        .and_then(|w| w.speaker)
+        .unwrap_or(builder.current_speaker());
+    let start_ms = alt
+        .words
+        .first()
+        .map(|w| (w.start * 1000.0) as u64)
+        .unwrap_or(builder.current_end());
+    builder.emit_tail(&alt.transcript, speaker, start_ms);
+}
+
+/// Fold one `Results` message into the segment builder.
+fn apply_response(builder: &mut SegmentBuilder, resp: DgResponse) {
+    if resp.msg_type != "Results" {
+        return; // Metadata, SpeechStarted, UtteranceEnd, etc.
+    }
+    let Some(alt) = resp.channel.alternatives.into_iter().next() else {
+        return;
+    };
+    if resp.is_final {
+        commit_final(builder, &alt, resp.speech_final);
+    } else if !alt.transcript.trim().is_empty() {
+        emit_interim(builder, &alt);
+    }
+}
+
+/// Parse server frames into transcript segments until the socket ends.
+async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+    let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
+    let mut msg_count: u64 = 0;
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, source) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+            Frame::Failed(detail) => return Err(anyhow!("closed by server: {detail}")),
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[deepgram:{source}] RX raw#{msg_count}: {payload}");
+        }
+        match serde_json::from_str::<DgResponse>(&payload) {
+            Ok(resp) => apply_response(&mut builder, resp),
+            Err(e) => eprintln!("[deepgram:{source}] parse error: {e}"),
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_session(
+    app: AppHandle,
+    config: TranscribeConfig,
+    source: &'static str,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> Result<()> {
+    let model = if config.model.trim().is_empty() {
+        DEFAULT_MODEL
+    } else {
+        config.model.as_str()
+    };
+    let url = listen_url(&config, model);
 
     let ws = connect_with_headers(
         &url,
         &[("Authorization", format!("Token {}", config.api_key))],
     )
     .await?;
-    let (mut write, mut read) = ws.split();
+    let (write, read) = ws.split();
     eprintln!(
         "[deepgram:{source}] connected, model={model}, diarization={}",
         config.diarization
     );
 
-    // Forward PCM as binary frames; keep alive; close cleanly. Resolves with
-    // whether the input drained (normal stop) or a send failed (dead socket).
-    let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
-    let forward = async move {
-        let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(5));
-        keepalive.tick().await;
-        let drained = loop {
-            tokio::select! {
-                maybe_chunk = pcm_rx.recv() => {
-                    let Some(chunk) = maybe_chunk else { break true };
-                    meter.push(&chunk);
-                    let bytes = pcm_to_le_bytes(&chunk);
-                    if write.send(Message::Binary(bytes)).await.is_err() {
-                        break false;
-                    }
-                }
-                _ = keepalive.tick() => {
-                    if write.send(Message::Text("{\"type\":\"KeepAlive\"}".to_string())).await.is_err() {
-                        break false;
-                    }
-                }
-            }
-        };
-        let _ = write
-            .send(Message::Text("{\"type\":\"CloseStream\"}".to_string()))
-            .await;
-        let _ = write.close().await;
-        drained
-    };
+    let meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
 
-    let read_loop = async move {
-        let mut builder = SegmentBuilder::new(app.clone(), source, TRANSCRIPT_EVENT);
-        let mut msg_count: u64 = 0;
-        while let Some(msg) = read.next().await {
-            let payload = match msg {
-                Ok(Message::Text(t)) => t.to_string(),
-                Ok(Message::Binary(b)) => String::from_utf8_lossy(&b).into_owned(),
-                Ok(Message::Close(frame)) => {
-                    eprintln!("[deepgram:{source}] closed by server: {frame:?}");
-                    // Deepgram has no in-band error messages — terminal errors
-                    // arrive as an abnormal close code (1008 DATA-*, 1011
-                    // NET-*, …) whose reason is the only diagnostic we get. A
-                    // normal close (1000) follows our CloseStream.
-                    if let Some(f) = frame {
-                        if f.code != CloseCode::Normal {
-                            return Err(anyhow!(
-                                "closed by server: {} {}",
-                                u16::from(f.code),
-                                f.reason
-                            ));
-                        }
-                    }
-                    break;
-                }
-                Ok(_) => continue,
-                Err(e) => {
-                    eprintln!("[deepgram:{source}] read error: {e}");
-                    break;
-                }
-            };
-            msg_count += 1;
-            if msg_count <= 3 {
-                eprintln!("[deepgram:{source}] RX raw#{msg_count}: {payload}");
-            }
-            let resp: DgResponse = match serde_json::from_str(&payload) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("[deepgram:{source}] parse error: {e}");
-                    continue;
-                }
-            };
-            if resp.msg_type != "Results" {
-                continue; // Metadata, SpeechStarted, UtteranceEnd, etc.
-            }
-            let Some(alt) = resp.channel.alternatives.into_iter().next() else {
-                continue;
-            };
-
-            if resp.is_final {
-                // Settled words → push each into its speaker-run.
-                for w in &alt.words {
-                    let text = w.punctuated_word.clone().unwrap_or_else(|| w.word.clone());
-                    if text.is_empty() {
-                        continue;
-                    }
-                    let speaker = w.speaker.unwrap_or(0);
-                    let start_ms = (w.start * 1000.0) as u64;
-                    let end_ms = (w.end * 1000.0) as u64;
-                    builder.push_final(&format!("{text} "), speaker, start_ms, end_ms);
-                }
-                builder.emit_committed();
-                // speech_final marks an utterance boundary.
-                if resp.speech_final {
-                    builder.endpoint();
-                }
-                // Clear any stale tail now that this chunk is committed.
-                builder.emit_tail("", builder.current_speaker(), builder.current_end());
-            } else if !alt.transcript.trim().is_empty() {
-                // Interim hypothesis → tentative tail.
-                let speaker = alt
-                    .words
-                    .first()
-                    .and_then(|w| w.speaker)
-                    .unwrap_or(builder.current_speaker());
-                let start_ms = alt
-                    .words
-                    .first()
-                    .map(|w| (w.start * 1000.0) as u64)
-                    .unwrap_or(builder.current_end());
-                builder.emit_tail(&alt.transcript, speaker, start_ms);
-            }
-        }
-        Ok(())
-    };
-
-    drive_session("deepgram", forward, read_loop).await
+    drive_session(
+        "deepgram",
+        forward_audio(write, meter, pcm_rx),
+        read_transcripts(app, source, read),
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/transcription/gemini.rs
+++ b/src-tauri/src/transcription/gemini.rs
@@ -5,32 +5,26 @@
 //! Note: Gemini Live does not diarize input audio and gives no per-word
 //! timestamps, so segments are emitted under speaker 0 with zeroed timings.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use base64::Engine;
-use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
 use tauri::AppHandle;
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, LevelMeter, SegmentBuilder,
     TranscribeConfig, LEVEL_EVENT, TRANSCRIPT_EVENT,
 };
+use super::ws::{self, Next, OnClose, Pump, WsRead, WsWrite};
 use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const GEMINI_BASE: &str =
     "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
 const DEFAULT_MODEL: &str = "gemini-2.0-flash-live-001";
-
-type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
-type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Deserialize, Default)]
 struct GeminiTranscription {
@@ -50,18 +44,6 @@ struct GeminiServerContent {
 struct GeminiMessage {
     #[serde(rename = "serverContent", default)]
     server_content: Option<GeminiServerContent>,
-}
-
-/// What the read loop should do with one incoming websocket frame.
-enum Frame {
-    /// A JSON payload to parse.
-    Payload(String),
-    /// Nothing of interest — keep reading.
-    Skip,
-    /// The stream ended in a way that isn't an error.
-    Stop,
-    /// The server closed abnormally: terminal, with its reason as the detail.
-    Failed(String),
 }
 
 /// Build the BidiGenerateContent `setup` frame for `model_path`.
@@ -93,59 +75,23 @@ fn setup_frame(model_path: &str, terms: &[String]) -> serde_json::Value {
     setup
 }
 
-/// Stream PCM as base64 media chunks until the input drains or a send fails.
-/// Resolves with whether the input drained (normal stop) or a send failed (dead
-/// socket) — drive_session reports the latter as a failure.
+/// Stream PCM as base64 media chunks. Gemini Live has no keepalive or goodbye
+/// frame — closing the write half is the whole shutdown.
 async fn forward_audio(
-    mut write: WsWrite,
-    mut meter: LevelMeter,
+    write: WsWrite,
+    meter: LevelMeter,
     mime: String,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
 ) -> bool {
     let b64 = base64::engine::general_purpose::STANDARD;
-    let drained = loop {
-        let Some(chunk) = pcm_rx.recv().await else {
-            break true;
-        };
-        meter.push(&chunk);
-        let bytes = pcm_to_le_bytes(&chunk);
-        let data = b64.encode(&bytes);
+    ws::forward_audio(write, meter, pcm_rx, Pump::default(), move |chunk| {
+        let data = b64.encode(pcm_to_le_bytes(chunk));
         let msg = json!({
             "realtimeInput": { "mediaChunks": [ { "mimeType": mime, "data": data } ] }
         });
-        if write.send(Message::Text(msg.to_string())).await.is_err() {
-            break false;
-        }
-    };
-    let _ = write.close().await;
-    drained
-}
-
-/// Classify one websocket frame. Gemini Live signals terminal errors (bad key,
-/// quota, invalid setup) by closing with an abnormal code + reason rather than
-/// an in-band message; a normal close (1000) follows our own close.
-fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
-    let msg = match msg {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("[gemini:{source}] read error: {e}");
-            return Frame::Stop;
-        }
-    };
-    match msg {
-        Message::Text(t) => Frame::Payload(t.to_string()),
-        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
-        Message::Close(frame) => {
-            eprintln!("[gemini:{source}] closed by server: {frame:?}");
-            match frame {
-                Some(f) if f.code != CloseCode::Normal => {
-                    Frame::Failed(format!("{} {}", u16::from(f.code), f.reason))
-                }
-                _ => Frame::Stop,
-            }
-        }
-        _ => Frame::Skip,
-    }
+        Message::Text(msg.to_string())
+    })
+    .await
 }
 
 /// Fold one parsed server message into the segment builder, growing `interim`
@@ -168,26 +114,20 @@ fn apply_message(builder: &mut SegmentBuilder, interim: &mut String, m: GeminiMe
 }
 
 /// Parse server frames into transcript segments until the socket ends.
-async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+///
+/// Gemini Live signals terminal errors (bad key, quota, invalid setup) by
+/// closing with an abnormal code + reason rather than an in-band message, so an
+/// abnormal close is the failure — a normal close (1000) follows our own.
+async fn read_transcripts(app: AppHandle, source: &'static str, read: WsRead) -> Result<()> {
     let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
     let mut interim = String::new();
-    let mut msg_count: u64 = 0;
-    while let Some(msg) = read.next().await {
-        let payload = match classify(msg, source) {
-            Frame::Payload(p) => p,
-            Frame::Skip => continue,
-            Frame::Stop => break,
-            Frame::Failed(detail) => return Err(anyhow!("closed by server: {detail}")),
-        };
-        msg_count += 1;
-        if msg_count <= 3 {
-            eprintln!("[gemini:{source}] RX raw#{msg_count}: {payload}");
-        }
-        if let Ok(m) = serde_json::from_str::<GeminiMessage>(&payload) {
+    ws::read_frames("gemini", source, read, OnClose::FailIfAbnormal, |payload| {
+        if let Ok(m) = serde_json::from_str::<GeminiMessage>(payload) {
             apply_message(&mut builder, &mut interim, m);
         }
-    }
-    Ok(())
+        Ok(Next::Continue)
+    })
+    .await
 }
 
 pub async fn run_session(

--- a/src-tauri/src/transcription/gemini.rs
+++ b/src-tauri/src/transcription/gemini.rs
@@ -7,13 +7,16 @@
 
 use anyhow::{anyhow, Result};
 use base64::Engine;
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
 use tauri::AppHandle;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, LevelMeter, SegmentBuilder,
@@ -25,6 +28,9 @@ use crate::audio::TARGET_SAMPLE_RATE;
 const GEMINI_BASE: &str =
     "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
 const DEFAULT_MODEL: &str = "gemini-2.0-flash-live-001";
+
+type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Deserialize, Default)]
 struct GeminiTranscription {
@@ -46,26 +52,26 @@ struct GeminiMessage {
     server_content: Option<GeminiServerContent>,
 }
 
-pub async fn run_session(
-    app: AppHandle,
-    config: TranscribeConfig,
-    source: &'static str,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
-) -> Result<()> {
-    let url = format!("{GEMINI_BASE}?key={}", config.api_key);
-    let ws = connect_with_headers(&url, &[]).await?;
-    let (mut write, mut read) = ws.split();
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended in a way that isn't an error.
+    Stop,
+    /// The server closed abnormally: terminal, with its reason as the detail.
+    Failed(String),
+}
 
-    let model = if config.model.trim().is_empty() {
-        DEFAULT_MODEL
-    } else {
-        config.model.as_str()
-    };
-    let model_path = if model.starts_with("models/") {
-        model.to_string()
-    } else {
-        format!("models/{model}")
-    };
+/// Build the BidiGenerateContent `setup` frame for `model_path`.
+///
+/// Gemini Live has no dedicated custom-vocabulary field, but the setup frame
+/// does carry a `systemInstruction` (a Content), which is the documented hook
+/// for steering the model — so the phrase dictionary becomes a spelling
+/// instruction. Only added when the dictionary is non-empty, leaving the setup
+/// frame untouched otherwise.
+fn setup_frame(model_path: &str, terms: &[String]) -> serde_json::Value {
     let mut setup = json!({
         "setup": {
             "model": model_path,
@@ -73,12 +79,6 @@ pub async fn run_session(
             "inputAudioTranscription": {}
         }
     });
-    // Gemini Live has no dedicated custom-vocabulary field, but the
-    // BidiGenerateContent setup frame does carry a `systemInstruction`
-    // (a Content), which is the documented hook for steering the model — so the
-    // phrase dictionary becomes a spelling instruction. Only added when the
-    // dictionary is non-empty, leaving the setup frame untouched otherwise.
-    let terms = clean_vocabulary(&config.vocabulary);
     if !terms.is_empty() {
         setup["setup"]["systemInstruction"] = json!({
             "parts": [{
@@ -90,89 +90,137 @@ pub async fn run_session(
             }]
         });
     }
+    setup
+}
+
+/// Stream PCM as base64 media chunks until the input drains or a send fails.
+/// Resolves with whether the input drained (normal stop) or a send failed (dead
+/// socket) — drive_session reports the latter as a failure.
+async fn forward_audio(
+    mut write: WsWrite,
+    mut meter: LevelMeter,
+    mime: String,
+    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> bool {
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let drained = loop {
+        let Some(chunk) = pcm_rx.recv().await else {
+            break true;
+        };
+        meter.push(&chunk);
+        let bytes = pcm_to_le_bytes(&chunk);
+        let data = b64.encode(&bytes);
+        let msg = json!({
+            "realtimeInput": { "mediaChunks": [ { "mimeType": mime, "data": data } ] }
+        });
+        if write.send(Message::Text(msg.to_string())).await.is_err() {
+            break false;
+        }
+    };
+    let _ = write.close().await;
+    drained
+}
+
+/// Classify one websocket frame. Gemini Live signals terminal errors (bad key,
+/// quota, invalid setup) by closing with an abnormal code + reason rather than
+/// an in-band message; a normal close (1000) follows our own close.
+fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
+    let msg = match msg {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("[gemini:{source}] read error: {e}");
+            return Frame::Stop;
+        }
+    };
+    match msg {
+        Message::Text(t) => Frame::Payload(t.to_string()),
+        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Message::Close(frame) => {
+            eprintln!("[gemini:{source}] closed by server: {frame:?}");
+            match frame {
+                Some(f) if f.code != CloseCode::Normal => {
+                    Frame::Failed(format!("{} {}", u16::from(f.code), f.reason))
+                }
+                _ => Frame::Stop,
+            }
+        }
+        _ => Frame::Skip,
+    }
+}
+
+/// Fold one parsed server message into the segment builder, growing `interim`
+/// with the transcription deltas and committing it on `turnComplete`.
+fn apply_message(builder: &mut SegmentBuilder, interim: &mut String, m: GeminiMessage) {
+    let Some(sc) = m.server_content else { return };
+    if let Some(tr) = sc.input_transcription {
+        if !tr.text.is_empty() {
+            interim.push_str(&tr.text);
+            builder.emit_tail(interim, 0, 0);
+        }
+    }
+    if sc.turn_complete && !interim.trim().is_empty() {
+        builder.push_final(interim.trim(), 0, 0, 0);
+        builder.emit_committed();
+        builder.endpoint();
+        interim.clear();
+        builder.emit_tail("", 0, 0); // clear the tail
+    }
+}
+
+/// Parse server frames into transcript segments until the socket ends.
+async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+    let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
+    let mut interim = String::new();
+    let mut msg_count: u64 = 0;
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, source) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+            Frame::Failed(detail) => return Err(anyhow!("closed by server: {detail}")),
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[gemini:{source}] RX raw#{msg_count}: {payload}");
+        }
+        if let Ok(m) = serde_json::from_str::<GeminiMessage>(&payload) {
+            apply_message(&mut builder, &mut interim, m);
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_session(
+    app: AppHandle,
+    config: TranscribeConfig,
+    source: &'static str,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> Result<()> {
+    let url = format!("{GEMINI_BASE}?key={}", config.api_key);
+    let ws = connect_with_headers(&url, &[]).await?;
+    let (mut write, read) = ws.split();
+
+    let model = if config.model.trim().is_empty() {
+        DEFAULT_MODEL
+    } else {
+        config.model.as_str()
+    };
+    let model_path = if model.starts_with("models/") {
+        model.to_string()
+    } else {
+        format!("models/{model}")
+    };
+    let setup = setup_frame(&model_path, &clean_vocabulary(&config.vocabulary));
     write.send(Message::Text(setup.to_string())).await?;
     eprintln!("[gemini:{source}] connected, model={model} (diarization unsupported → speaker 0)");
 
     let mime = format!("audio/pcm;rate={}", TARGET_SAMPLE_RATE);
-    let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
-    // Resolves with whether the input drained (normal stop) or a send failed
-    // (dead socket) — drive_session reports the latter as a failure.
-    let forward = async move {
-        let b64 = base64::engine::general_purpose::STANDARD;
-        let drained = loop {
-            let Some(chunk) = pcm_rx.recv().await else {
-                break true;
-            };
-            meter.push(&chunk);
-            let bytes = pcm_to_le_bytes(&chunk);
-            let data = b64.encode(&bytes);
-            let msg = json!({
-                "realtimeInput": { "mediaChunks": [ { "mimeType": mime, "data": data } ] }
-            });
-            if write.send(Message::Text(msg.to_string())).await.is_err() {
-                break false;
-            }
-        };
-        let _ = write.close().await;
-        drained
-    };
+    let meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
 
-    let read_loop = async move {
-        let mut builder = SegmentBuilder::new(app.clone(), source, TRANSCRIPT_EVENT);
-        let mut interim = String::new();
-        let mut msg_count: u64 = 0;
-        while let Some(msg) = read.next().await {
-            let payload = match msg {
-                Ok(Message::Text(t)) => t.to_string(),
-                Ok(Message::Binary(b)) => String::from_utf8_lossy(&b).into_owned(),
-                Ok(Message::Close(frame)) => {
-                    eprintln!("[gemini:{source}] closed by server: {frame:?}");
-                    // Gemini Live signals terminal errors (bad key, quota,
-                    // invalid setup) by closing with an abnormal code + reason
-                    // rather than an in-band message. A normal close (1000)
-                    // follows our own close.
-                    if let Some(f) = frame {
-                        if f.code != CloseCode::Normal {
-                            return Err(anyhow!(
-                                "closed by server: {} {}",
-                                u16::from(f.code),
-                                f.reason
-                            ));
-                        }
-                    }
-                    break;
-                }
-                Ok(_) => continue,
-                Err(e) => {
-                    eprintln!("[gemini:{source}] read error: {e}");
-                    break;
-                }
-            };
-            msg_count += 1;
-            if msg_count <= 3 {
-                eprintln!("[gemini:{source}] RX raw#{msg_count}: {payload}");
-            }
-            let m: GeminiMessage = match serde_json::from_str(&payload) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            let Some(sc) = m.server_content else { continue };
-            if let Some(tr) = sc.input_transcription {
-                if !tr.text.is_empty() {
-                    interim.push_str(&tr.text);
-                    builder.emit_tail(&interim, 0, 0);
-                }
-            }
-            if sc.turn_complete && !interim.trim().is_empty() {
-                builder.push_final(interim.trim(), 0, 0, 0);
-                builder.emit_committed();
-                builder.endpoint();
-                interim.clear();
-                builder.emit_tail("", 0, 0); // clear the tail
-            }
-        }
-        Ok(())
-    };
-
-    drive_session("gemini", forward, read_loop).await
+    drive_session(
+        "gemini",
+        forward_audio(write, meter, mime, pcm_rx),
+        read_transcripts(app, source, read),
+    )
+    .await
 }

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -1,6 +1,7 @@
 //! Transcription adapters. Each provider speaks its own wire protocol but
 //! shares the primitives in [`common`] (segment building, level metering,
-//! event emission).
+//! event emission) and the websocket plumbing in [`ws`] (audio pump, frame
+//! classification, read loop).
 //!
 //! The dispatch contract is deliberately minimal: an adapter is handed a PCM
 //! receiver and decides how to consume it. Today every adapter streams audio to
@@ -14,6 +15,7 @@ pub mod deepgram;
 pub mod gemini;
 pub mod openai;
 pub mod soniox;
+pub mod ws;
 
 use anyhow::{anyhow, Result};
 use tauri::AppHandle;

--- a/src-tauri/src/transcription/openai.rs
+++ b/src-tauri/src/transcription/openai.rs
@@ -7,12 +7,15 @@
 
 use anyhow::{anyhow, Result};
 use base64::Engine;
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
 use tauri::AppHandle;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, LevelMeter, SegmentBuilder,
@@ -22,6 +25,9 @@ use crate::audio::resample::pcm_to_le_bytes;
 
 const OPENAI_RT_URL: &str = "wss://api.openai.com/v1/realtime?intent=transcription";
 const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
+
+type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Deserialize, Default)]
 struct OaiError {
@@ -42,11 +48,158 @@ struct OaiEvent {
     error: Option<OaiError>,
 }
 
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended; stop reading.
+    Stop,
+}
+
+/// Build the realtime session's `transcription_session.update` frame.
+///
+/// Custom vocabulary rides on the transcription `prompt` — the only biasing
+/// hook the realtime transcription session exposes. Whisper-style prompts are
+/// free text, and a comma-separated term list is the shape OpenAI documents for
+/// steering spelling.
+fn setup_frame(config: &TranscribeConfig, model: &str) -> serde_json::Value {
+    let mut transcription = json!({ "model": model });
+    if let Some(lang) = config.language_hints.first() {
+        transcription["language"] = json!(lang);
+    }
+    let terms = clean_vocabulary(&config.vocabulary);
+    if !terms.is_empty() {
+        transcription["prompt"] = json!(terms.join(", "));
+    }
+    json!({
+        "type": "transcription_session.update",
+        "session": {
+            "input_audio_format": "pcm16",
+            "input_audio_transcription": transcription,
+            "turn_detection": { "type": "server_vad", "silence_duration_ms": 500 }
+        }
+    })
+}
+
+/// Stream PCM as base64 append events until the input drains or a send fails.
+/// Resolves with whether the input drained (normal stop) or a send failed (dead
+/// socket) — drive_session reports the latter as a failure.
+async fn forward_audio(
+    mut write: WsWrite,
+    mut meter: LevelMeter,
+    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> bool {
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let drained = loop {
+        let Some(chunk) = pcm_rx.recv().await else {
+            break true;
+        };
+        meter.push(&chunk);
+        let bytes = pcm_to_le_bytes(&chunk);
+        let audio = b64.encode(&bytes);
+        let msg = json!({ "type": "input_audio_buffer.append", "audio": audio });
+        if write.send(Message::Text(msg.to_string())).await.is_err() {
+            break false;
+        }
+    };
+    let _ = write.close().await;
+    drained
+}
+
+/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
+fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
+    match msg {
+        Ok(Message::Text(t)) => Frame::Payload(t.to_string()),
+        Ok(Message::Binary(b)) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Ok(Message::Close(frame)) => {
+            eprintln!("[openai:{source}] closed by server: {frame:?}");
+            Frame::Stop
+        }
+        Ok(_) => Frame::Skip,
+        Err(e) => {
+            eprintln!("[openai:{source}] read error: {e}");
+            Frame::Stop
+        }
+    }
+}
+
+/// Fold one transcription event into the segment builder. Returns the terminal
+/// error when the event is a session-level `error` — the server stops
+/// transcribing after it, so it must be surfaced (see `run_metered_session`)
+/// instead of logged into the void.
+fn apply_event(
+    builder: &mut SegmentBuilder,
+    interim: &mut String,
+    ev: OaiEvent,
+    source: &str,
+    payload: &str,
+) -> Option<anyhow::Error> {
+    match ev.event_type.as_str() {
+        "conversation.item.input_audio_transcription.delta" => {
+            interim.push_str(&ev.delta);
+            builder.emit_tail(interim, 0, 0);
+        }
+        "conversation.item.input_audio_transcription.completed" => {
+            let text = if ev.transcript.is_empty() {
+                interim.clone()
+            } else {
+                ev.transcript
+            };
+            if !text.trim().is_empty() {
+                builder.push_final(text.trim(), 0, 0, 0);
+                builder.emit_committed();
+                builder.endpoint();
+            }
+            interim.clear();
+            builder.emit_tail("", 0, 0); // clear the tail
+        }
+        "error" => {
+            eprintln!("[openai:{source}] error event: {payload}");
+            let detail = ev
+                .error
+                .map(|e| e.message)
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| "server error".to_string());
+            return Some(anyhow!("{detail}"));
+        }
+        _ => {}
+    }
+    None
+}
+
+/// Parse server events into transcript segments until the socket ends or a
+/// terminal error event arrives.
+async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+    let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
+    let mut interim = String::new();
+    let mut msg_count: u64 = 0;
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, source) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[openai:{source}] RX raw#{msg_count}: {payload}");
+        }
+        let Ok(ev) = serde_json::from_str::<OaiEvent>(&payload) else {
+            continue;
+        };
+        if let Some(err) = apply_event(&mut builder, &mut interim, ev, source, &payload) {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
 pub async fn run_session(
     app: AppHandle,
     config: TranscribeConfig,
     source: &'static str,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
 ) -> Result<()> {
     let ws = connect_with_headers(
         OPENAI_RT_URL,
@@ -56,121 +209,23 @@ pub async fn run_session(
         ],
     )
     .await?;
-    let (mut write, mut read) = ws.split();
+    let (mut write, read) = ws.split();
 
     let model = if config.model.trim().is_empty() {
         DEFAULT_MODEL
     } else {
         config.model.as_str()
     };
-    let mut transcription = json!({ "model": model });
-    if let Some(lang) = config.language_hints.first() {
-        transcription["language"] = json!(lang);
-    }
-    // Custom vocabulary rides on the transcription `prompt` — the only biasing
-    // hook the realtime transcription session exposes. Whisper-style prompts are
-    // free text, and a comma-separated term list is the shape OpenAI documents
-    // for steering spelling.
-    let terms = clean_vocabulary(&config.vocabulary);
-    if !terms.is_empty() {
-        transcription["prompt"] = json!(terms.join(", "));
-    }
-    let setup = json!({
-        "type": "transcription_session.update",
-        "session": {
-            "input_audio_format": "pcm16",
-            "input_audio_transcription": transcription,
-            "turn_detection": { "type": "server_vad", "silence_duration_ms": 500 }
-        }
-    });
+    let setup = setup_frame(&config, model);
     write.send(Message::Text(setup.to_string())).await?;
     eprintln!("[openai:{source}] connected, model={model} (diarization unsupported → speaker 0)");
 
-    let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
-    // Resolves with whether the input drained (normal stop) or a send failed
-    // (dead socket) — drive_session reports the latter as a failure.
-    let forward = async move {
-        let b64 = base64::engine::general_purpose::STANDARD;
-        let drained = loop {
-            let Some(chunk) = pcm_rx.recv().await else {
-                break true;
-            };
-            meter.push(&chunk);
-            let bytes = pcm_to_le_bytes(&chunk);
-            let audio = b64.encode(&bytes);
-            let msg = json!({ "type": "input_audio_buffer.append", "audio": audio });
-            if write.send(Message::Text(msg.to_string())).await.is_err() {
-                break false;
-            }
-        };
-        let _ = write.close().await;
-        drained
-    };
+    let meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
 
-    let read_loop = async move {
-        let mut builder = SegmentBuilder::new(app.clone(), source, TRANSCRIPT_EVENT);
-        let mut interim = String::new();
-        let mut msg_count: u64 = 0;
-        let mut result: Result<()> = Ok(());
-        while let Some(msg) = read.next().await {
-            let payload = match msg {
-                Ok(Message::Text(t)) => t.to_string(),
-                Ok(Message::Binary(b)) => String::from_utf8_lossy(&b).into_owned(),
-                Ok(Message::Close(frame)) => {
-                    eprintln!("[openai:{source}] closed by server: {frame:?}");
-                    break;
-                }
-                Ok(_) => continue,
-                Err(e) => {
-                    eprintln!("[openai:{source}] read error: {e}");
-                    break;
-                }
-            };
-            msg_count += 1;
-            if msg_count <= 3 {
-                eprintln!("[openai:{source}] RX raw#{msg_count}: {payload}");
-            }
-            let ev: OaiEvent = match serde_json::from_str(&payload) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            match ev.event_type.as_str() {
-                "conversation.item.input_audio_transcription.delta" => {
-                    interim.push_str(&ev.delta);
-                    builder.emit_tail(&interim, 0, 0);
-                }
-                "conversation.item.input_audio_transcription.completed" => {
-                    let text = if ev.transcript.is_empty() {
-                        interim.clone()
-                    } else {
-                        ev.transcript
-                    };
-                    if !text.trim().is_empty() {
-                        builder.push_final(text.trim(), 0, 0, 0);
-                        builder.emit_committed();
-                        builder.endpoint();
-                    }
-                    interim.clear();
-                    builder.emit_tail("", 0, 0); // clear the tail
-                }
-                "error" => {
-                    // A session-level error event is terminal — the server
-                    // stops transcribing after it. Surface it (see
-                    // run_metered_session) instead of logging into the void.
-                    eprintln!("[openai:{source}] error event: {payload}");
-                    let detail = ev
-                        .error
-                        .map(|e| e.message)
-                        .filter(|m| !m.is_empty())
-                        .unwrap_or_else(|| "server error".to_string());
-                    result = Err(anyhow!("{detail}"));
-                    break;
-                }
-                _ => {}
-            }
-        }
-        result
-    };
-
-    drive_session("openai", forward, read_loop).await
+    drive_session(
+        "openai",
+        forward_audio(write, meter, pcm_rx),
+        read_transcripts(app, source, read),
+    )
+    .await
 }

--- a/src-tauri/src/transcription/openai.rs
+++ b/src-tauri/src/transcription/openai.rs
@@ -7,27 +7,22 @@
 
 use anyhow::{anyhow, Result};
 use base64::Engine;
-use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
 use tauri::AppHandle;
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, LevelMeter, SegmentBuilder,
     TranscribeConfig, LEVEL_EVENT, TRANSCRIPT_EVENT,
 };
+use super::ws::{self, Next, OnClose, Pump, WsRead, WsWrite};
 use crate::audio::resample::pcm_to_le_bytes;
 
 const OPENAI_RT_URL: &str = "wss://api.openai.com/v1/realtime?intent=transcription";
 const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
-
-type WsWrite = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
-type WsRead = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Deserialize, Default)]
 struct OaiError {
@@ -46,16 +41,6 @@ struct OaiEvent {
     /// Present on `error` events — the session-level failure detail.
     #[serde(default)]
     error: Option<OaiError>,
-}
-
-/// What the read loop should do with one incoming websocket frame.
-enum Frame {
-    /// A JSON payload to parse.
-    Payload(String),
-    /// Nothing of interest — keep reading.
-    Skip,
-    /// The stream ended; stop reading.
-    Stop,
 }
 
 /// Build the realtime session's `transcription_session.update` frame.
@@ -83,46 +68,20 @@ fn setup_frame(config: &TranscribeConfig, model: &str) -> serde_json::Value {
     })
 }
 
-/// Stream PCM as base64 append events until the input drains or a send fails.
-/// Resolves with whether the input drained (normal stop) or a send failed (dead
-/// socket) — drive_session reports the latter as a failure.
+/// Stream PCM as base64 append events. The realtime session has no keepalive or
+/// goodbye frame — closing the write half is the whole shutdown.
 async fn forward_audio(
-    mut write: WsWrite,
-    mut meter: LevelMeter,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    write: WsWrite,
+    meter: LevelMeter,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
 ) -> bool {
     let b64 = base64::engine::general_purpose::STANDARD;
-    let drained = loop {
-        let Some(chunk) = pcm_rx.recv().await else {
-            break true;
-        };
-        meter.push(&chunk);
-        let bytes = pcm_to_le_bytes(&chunk);
-        let audio = b64.encode(&bytes);
+    ws::forward_audio(write, meter, pcm_rx, Pump::default(), move |chunk| {
+        let audio = b64.encode(pcm_to_le_bytes(chunk));
         let msg = json!({ "type": "input_audio_buffer.append", "audio": audio });
-        if write.send(Message::Text(msg.to_string())).await.is_err() {
-            break false;
-        }
-    };
-    let _ = write.close().await;
-    drained
-}
-
-/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
-fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
-    match msg {
-        Ok(Message::Text(t)) => Frame::Payload(t.to_string()),
-        Ok(Message::Binary(b)) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
-        Ok(Message::Close(frame)) => {
-            eprintln!("[openai:{source}] closed by server: {frame:?}");
-            Frame::Stop
-        }
-        Ok(_) => Frame::Skip,
-        Err(e) => {
-            eprintln!("[openai:{source}] read error: {e}");
-            Frame::Stop
-        }
-    }
+        Message::Text(msg.to_string())
+    })
+    .await
 }
 
 /// Fold one transcription event into the segment builder. Returns the terminal
@@ -171,28 +130,19 @@ fn apply_event(
 
 /// Parse server events into transcript segments until the socket ends or a
 /// terminal error event arrives.
-async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+async fn read_transcripts(app: AppHandle, source: &'static str, read: WsRead) -> Result<()> {
     let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
     let mut interim = String::new();
-    let mut msg_count: u64 = 0;
-    while let Some(msg) = read.next().await {
-        let payload = match classify(msg, source) {
-            Frame::Payload(p) => p,
-            Frame::Skip => continue,
-            Frame::Stop => break,
+    ws::read_frames("openai", source, read, OnClose::Stop, |payload| {
+        let Ok(ev) = serde_json::from_str::<OaiEvent>(payload) else {
+            return Ok(Next::Continue);
         };
-        msg_count += 1;
-        if msg_count <= 3 {
-            eprintln!("[openai:{source}] RX raw#{msg_count}: {payload}");
+        match apply_event(&mut builder, &mut interim, ev, source, payload) {
+            Some(err) => Err(err),
+            None => Ok(Next::Continue),
         }
-        let Ok(ev) = serde_json::from_str::<OaiEvent>(&payload) else {
-            continue;
-        };
-        if let Some(err) = apply_event(&mut builder, &mut interim, ev, source, &payload) {
-            return Err(err);
-        }
-    }
-    Ok(())
+    })
+    .await
 }
 
 pub async fn run_session(

--- a/src-tauri/src/transcription/soniox.rs
+++ b/src-tauri/src/transcription/soniox.rs
@@ -2,11 +2,14 @@
 //! token stream (with speaker diarization) into transcript segments.
 
 use anyhow::{anyhow, Result};
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, ensure_crypto_provider, LevelMeter,
@@ -16,6 +19,10 @@ use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const SONIOX_WS_URL: &str = "wss://stt-rt.soniox.com/transcribe-websocket";
+
+type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsWrite = SplitSink<Ws, Message>;
+type WsRead = SplitStream<Ws>;
 
 /// Soniox endpoint markers. `<end>` closes an utterance; `<fin>` is the final
 /// token emitted when the whole stream ends.
@@ -89,42 +96,43 @@ struct SonioxResponse {
     finished: bool,
 }
 
-/// Run one Soniox realtime session: stream PCM from `pcm_rx`, parse the token
-/// stream, and emit `transcript://segment` events tagged with `source`
-/// ("me" for mic, "them" for system audio).
-pub async fn run_session(
-    app: AppHandle,
-    config: TranscribeConfig,
-    source: &'static str,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
-) -> Result<()> {
-    // Hosted "parley" relay (config.relay_endpoint set): connect to the cloud
-    // WSS with a Bearer token instead of the vendor with an api_key. Otherwise
-    // BYOK: straight to Soniox. Both yield the same Soniox wire protocol below.
-    let ws = match &config.relay_endpoint {
-        Some(relay_url) => {
-            connect_with_headers(
-                relay_url,
-                &[("Authorization", format!("Bearer {}", config.api_key))],
-            )
-            .await?
-        }
-        None => {
-            ensure_crypto_provider();
-            let (ws, _) = tokio_tungstenite::connect_async(SONIOX_WS_URL)
-                .await
-                .map_err(|e| anyhow!("connect failed: {e}"))?;
-            ws
-        }
-    };
-    let (mut write, mut read) = ws.split();
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended; stop reading.
+    Stop,
+}
 
+/// Open the session's socket. Hosted "parley" relay (config.relay_endpoint set):
+/// connect to the cloud WSS with a Bearer token instead of the vendor with an
+/// api_key. Otherwise BYOK: straight to Soniox. Both yield the same Soniox wire
+/// protocol.
+async fn open_socket(config: &TranscribeConfig) -> Result<Ws> {
+    let Some(relay_url) = &config.relay_endpoint else {
+        ensure_crypto_provider();
+        let (ws, _) = tokio_tungstenite::connect_async(SONIOX_WS_URL)
+            .await
+            .map_err(|e| anyhow!("connect failed: {e}"))?;
+        return Ok(ws);
+    };
+    connect_with_headers(
+        relay_url,
+        &[("Authorization", format!("Bearer {}", config.api_key))],
+    )
+    .await
+}
+
+/// The opening config frame Soniox expects.
+fn wire_config(config: &TranscribeConfig) -> SonioxConfig<'_> {
     let language_hints = if config.language_hints.is_empty() {
         None
     } else {
         Some(config.language_hints.clone())
     };
-    let wire = SonioxConfig {
+    SonioxConfig {
         // Relay mode omits the key (the relay injects it); BYOK sends it.
         api_key: if config.relay_endpoint.is_some() {
             None
@@ -139,9 +147,173 @@ pub async fn run_session(
         enable_endpoint_detection: true,
         enable_speaker_diarization: config.diarization,
         context: context_for(&config.vocabulary),
+    }
+}
+
+/// Forward captured PCM, emit a level meter, keep the session alive, then
+/// finalize and close. Resolves `true` when the input drained (normal stop) and
+/// `false` when a send failed, i.e. the socket died under us — drive_session
+/// reports that as a failure.
+async fn forward_audio(
+    mut write: WsWrite,
+    mut meter: LevelMeter,
+    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    source: &'static str,
+    is_relay: bool,
+) -> bool {
+    let mut total: u64 = 0;
+    let mut next_log: u64 = TARGET_SAMPLE_RATE as u64;
+    // Soniox closes with a 408 if it doesn't see traffic regularly; mirror
+    // the SDK and send keep-alives on an interval.
+    let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(2));
+    keepalive.tick().await;
+
+    let drained = loop {
+        tokio::select! {
+            maybe_chunk = pcm_rx.recv() => {
+                let Some(chunk) = maybe_chunk else { break true };
+                meter.push(&chunk);
+                total += chunk.len() as u64;
+                if total >= next_log {
+                    eprintln!("[soniox:{source}] TX {}s audio sent", total / TARGET_SAMPLE_RATE as u64);
+                    next_log += TARGET_SAMPLE_RATE as u64;
+                }
+                let bytes = pcm_to_le_bytes(&chunk);
+                if write.send(Message::Binary(bytes)).await.is_err() {
+                    break false;
+                }
+            }
+            _ = keepalive.tick() => {
+                if write.send(Message::Text("{\"type\":\"keepalive\"}".to_string())).await.is_err() {
+                    break false;
+                }
+            }
+        }
     };
+    let _ = write
+        .send(Message::Text("{\"type\":\"finalize\"}".to_string()))
+        .await;
+    // BYOK: close our write half so Soniox flushes the final tokens to our
+    // still-open read half and then ends. In hosted RELAY mode, do NOT close
+    // here — the relay must forward this finalize to Soniox and stream the
+    // flushed tail BACK to us first; closing now would make the relay's
+    // server socket fire 'close' and stop relaying, truncating the last
+    // utterance. The relay closes the socket once Soniox finishes, which ends
+    // the read loop below (it also breaks on Soniox's `finished` marker).
+    if !is_relay {
+        let _ = write.close().await;
+    }
+    drained
+}
+
+/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
+fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
+    let msg = match msg {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("[soniox:{source}] read error: {e}");
+            return Frame::Stop;
+        }
+    };
+    match msg {
+        Message::Text(t) => Frame::Payload(t.to_string()),
+        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Message::Close(frame) => {
+            eprintln!("[soniox:{source}] socket closed by server: {frame:?}");
+            Frame::Stop
+        }
+        _ => Frame::Skip,
+    }
+}
+
+/// Split one response's tokens into committed speaker-runs (pushed straight into
+/// `builder`) and the tentative tail, then emit both. Returns whether the batch
+/// carried an endpoint marker.
+fn apply_tokens(builder: &mut SegmentBuilder, tokens: &[SonioxToken]) -> bool {
+    let mut tail = String::new();
+    let mut tail_speaker = builder.current_speaker();
+    let mut tail_start = builder.current_end();
+    let mut endpoint = false;
+
+    for tok in tokens {
+        if tok.text == TOKEN_END || tok.text == TOKEN_FIN {
+            endpoint = true;
+            continue;
+        }
+        let spk: i64 = tok.speaker.parse().unwrap_or(0);
+        if tok.is_final {
+            builder.push_final(&tok.text, spk, tok.start_ms, tok.end_ms);
+        } else {
+            if tail.is_empty() {
+                tail_speaker = spk;
+                tail_start = tok.start_ms;
+            }
+            tail.push_str(&tok.text);
+        }
+    }
+
+    builder.emit_committed();
+    builder.emit_tail(&tail, tail_speaker, tail_start);
+    endpoint
+}
+
+/// Read tokens → speaker-runs via the shared SegmentBuilder. Resolves to Err on
+/// an in-band error frame (e.g. a rejected api key) so the caller's error
+/// surface fires — the session is dead from that point, and returning Ok would
+/// leave the UI listening to nothing.
+async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+    let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
+    let mut msg_count: u64 = 0;
+
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, source) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[soniox:{source}] RX raw#{msg_count}: {payload}");
+        }
+
+        let resp: SonioxResponse = match serde_json::from_str(&payload) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[soniox:{source}] RX parse error: {e} — payload: {payload}");
+                continue;
+            }
+        };
+
+        if let Some(code) = resp.error_code {
+            let detail = resp.error_message.unwrap_or_default();
+            eprintln!("[soniox:{source}] error {code}: {detail}");
+            return Err(anyhow!("server error {code}: {detail}"));
+        }
+
+        if apply_tokens(&mut builder, &resp.tokens) {
+            builder.endpoint();
+        }
+        if resp.finished {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Run one Soniox realtime session: stream PCM from `pcm_rx`, parse the token
+/// stream, and emit `transcript://segment` events tagged with `source`
+/// ("me" for mic, "them" for system audio).
+pub async fn run_session(
+    app: AppHandle,
+    config: TranscribeConfig,
+    source: &'static str,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
+) -> Result<()> {
+    let ws = open_socket(&config).await?;
+    let (mut write, read) = ws.split();
+
     write
-        .send(Message::Text(serde_json::to_string(&wire)?))
+        .send(Message::Text(serde_json::to_string(&wire_config(&config))?))
         .await?;
     eprintln!(
         "[soniox:{source}] connected, model={}, diarization={}, vocabulary={}",
@@ -150,135 +322,13 @@ pub async fn run_session(
         config.vocabulary.len()
     );
 
-    // Forward captured PCM, emit a level meter, keep the session alive, then
-    // finalize and close.
-    let mut meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
+    let meter = LevelMeter::new(app.clone(), source, LEVEL_EVENT);
     let is_relay = config.relay_endpoint.is_some();
-    let forward = async move {
-        let mut total: u64 = 0;
-        let mut next_log: u64 = TARGET_SAMPLE_RATE as u64;
-        // Soniox closes with a 408 if it doesn't see traffic regularly; mirror
-        // the SDK and send keep-alives on an interval.
-        let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(2));
-        keepalive.tick().await;
 
-        // `true` = input drained (normal stop); `false` = a send failed, i.e.
-        // the socket died under us — drive_session reports that as a failure.
-        let drained = loop {
-            tokio::select! {
-                maybe_chunk = pcm_rx.recv() => {
-                    let Some(chunk) = maybe_chunk else { break true };
-                    meter.push(&chunk);
-                    total += chunk.len() as u64;
-                    if total >= next_log {
-                        eprintln!("[soniox:{source}] TX {}s audio sent", total / TARGET_SAMPLE_RATE as u64);
-                        next_log += TARGET_SAMPLE_RATE as u64;
-                    }
-                    let bytes = pcm_to_le_bytes(&chunk);
-                    if write.send(Message::Binary(bytes)).await.is_err() {
-                        break false;
-                    }
-                }
-                _ = keepalive.tick() => {
-                    if write.send(Message::Text("{\"type\":\"keepalive\"}".to_string())).await.is_err() {
-                        break false;
-                    }
-                }
-            }
-        };
-        let _ = write
-            .send(Message::Text("{\"type\":\"finalize\"}".to_string()))
-            .await;
-        // BYOK: close our write half so Soniox flushes the final tokens to our
-        // still-open read half and then ends. In hosted RELAY mode, do NOT close
-        // here — the relay must forward this finalize to Soniox and stream the
-        // flushed tail BACK to us first; closing now would make the relay's
-        // server socket fire 'close' and stop relaying, truncating the last
-        // utterance. The relay closes the socket once Soniox finishes, which ends
-        // the read loop below (it also breaks on Soniox's `finished` marker).
-        if !is_relay {
-            let _ = write.close().await;
-        }
-        drained
-    };
-
-    // Read tokens → speaker-runs via the shared SegmentBuilder. Resolves to
-    // Err on an in-band error frame (e.g. a rejected api key) so the caller's
-    // error surface fires — the session is dead from that point, and returning
-    // Ok would leave the UI listening to nothing.
-    let read_loop = async move {
-        let mut builder = SegmentBuilder::new(app.clone(), source, TRANSCRIPT_EVENT);
-        let mut msg_count: u64 = 0;
-
-        while let Some(msg) = read.next().await {
-            let msg = match msg {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!("[soniox:{source}] read error: {e}");
-                    break;
-                }
-            };
-            let payload = match msg {
-                Message::Text(t) => t.to_string(),
-                Message::Binary(b) => String::from_utf8_lossy(&b).into_owned(),
-                Message::Close(frame) => {
-                    eprintln!("[soniox:{source}] socket closed by server: {frame:?}");
-                    break;
-                }
-                _ => continue,
-            };
-            msg_count += 1;
-            if msg_count <= 3 {
-                eprintln!("[soniox:{source}] RX raw#{msg_count}: {payload}");
-            }
-
-            let resp: SonioxResponse = match serde_json::from_str(&payload) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("[soniox:{source}] RX parse error: {e} — payload: {payload}");
-                    continue;
-                }
-            };
-
-            if let Some(code) = resp.error_code {
-                let detail = resp.error_message.unwrap_or_default();
-                eprintln!("[soniox:{source}] error {code}: {detail}");
-                return Err(anyhow!("server error {code}: {detail}"));
-            }
-
-            let mut tail = String::new();
-            let mut tail_speaker = builder.current_speaker();
-            let mut tail_start = builder.current_end();
-            let mut endpoint = false;
-
-            for tok in &resp.tokens {
-                if tok.text == TOKEN_END || tok.text == TOKEN_FIN {
-                    endpoint = true;
-                    continue;
-                }
-                let spk: i64 = tok.speaker.parse().unwrap_or(0);
-                if tok.is_final {
-                    builder.push_final(&tok.text, spk, tok.start_ms, tok.end_ms);
-                } else {
-                    if tail.is_empty() {
-                        tail_speaker = spk;
-                        tail_start = tok.start_ms;
-                    }
-                    tail.push_str(&tok.text);
-                }
-            }
-
-            builder.emit_committed();
-            builder.emit_tail(&tail, tail_speaker, tail_start);
-            if endpoint {
-                builder.endpoint();
-            }
-            if resp.finished {
-                break;
-            }
-        }
-        Ok(())
-    };
-
-    drive_session("soniox", forward, read_loop).await
+    drive_session(
+        "soniox",
+        forward_audio(write, meter, pcm_rx, source, is_relay),
+        read_transcripts(app, source, read),
+    )
+    .await
 }

--- a/src-tauri/src/transcription/soniox.rs
+++ b/src-tauri/src/transcription/soniox.rs
@@ -2,27 +2,21 @@
 //! token stream (with speaker diarization) into transcript segments.
 
 use anyhow::{anyhow, Result};
-use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::common::{
     clean_vocabulary, connect_with_headers, drive_session, ensure_crypto_provider, LevelMeter,
     SegmentBuilder, TranscribeConfig, LEVEL_EVENT, TRANSCRIPT_EVENT,
 };
+use super::ws::{self, Next, OnClose, Pump, Ws, WsRead, WsWrite};
 use crate::audio::resample::pcm_to_le_bytes;
 use crate::audio::TARGET_SAMPLE_RATE;
 
 const SONIOX_WS_URL: &str = "wss://stt-rt.soniox.com/transcribe-websocket";
-
-type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
-type WsWrite = SplitSink<Ws, Message>;
-type WsRead = SplitStream<Ws>;
 
 /// Soniox endpoint markers. `<end>` closes an utterance; `<fin>` is the final
 /// token emitted when the whole stream ends.
@@ -96,16 +90,6 @@ struct SonioxResponse {
     finished: bool,
 }
 
-/// What the read loop should do with one incoming websocket frame.
-enum Frame {
-    /// A JSON payload to parse.
-    Payload(String),
-    /// Nothing of interest — keep reading.
-    Skip,
-    /// The stream ended; stop reading.
-    Stop,
-}
-
 /// Open the session's socket. Hosted "parley" relay (config.relay_endpoint set):
 /// connect to the cloud WSS with a Bearer token instead of the vendor with an
 /// api_key. Otherwise BYOK: straight to Soniox. Both yield the same Soniox wire
@@ -151,79 +135,46 @@ fn wire_config(config: &TranscribeConfig) -> SonioxConfig<'_> {
 }
 
 /// Forward captured PCM, emit a level meter, keep the session alive, then
-/// finalize and close. Resolves `true` when the input drained (normal stop) and
-/// `false` when a send failed, i.e. the socket died under us — drive_session
-/// reports that as a failure.
+/// finalize and close.
 async fn forward_audio(
-    mut write: WsWrite,
-    mut meter: LevelMeter,
-    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    write: WsWrite,
+    meter: LevelMeter,
+    pcm_rx: UnboundedReceiver<Vec<i16>>,
     source: &'static str,
     is_relay: bool,
 ) -> bool {
+    let pump = Pump {
+        // Soniox closes with a 408 if it doesn't see traffic regularly; mirror
+        // the SDK and send keep-alives on an interval.
+        keepalive: Some((
+            std::time::Duration::from_secs(2),
+            "{\"type\":\"keepalive\"}",
+        )),
+        finish: Some("{\"type\":\"finalize\"}"),
+        // BYOK: close our write half so Soniox flushes the final tokens to our
+        // still-open read half and then ends. In hosted RELAY mode, do NOT close
+        // here — the relay must forward this finalize to Soniox and stream the
+        // flushed tail BACK to us first; closing now would make the relay's
+        // server socket fire 'close' and stop relaying, truncating the last
+        // utterance. The relay closes the socket once Soniox finishes, which ends
+        // the read loop below (it also breaks on Soniox's `finished` marker).
+        close: !is_relay,
+    };
+
     let mut total: u64 = 0;
     let mut next_log: u64 = TARGET_SAMPLE_RATE as u64;
-    // Soniox closes with a 408 if it doesn't see traffic regularly; mirror
-    // the SDK and send keep-alives on an interval.
-    let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(2));
-    keepalive.tick().await;
-
-    let drained = loop {
-        tokio::select! {
-            maybe_chunk = pcm_rx.recv() => {
-                let Some(chunk) = maybe_chunk else { break true };
-                meter.push(&chunk);
-                total += chunk.len() as u64;
-                if total >= next_log {
-                    eprintln!("[soniox:{source}] TX {}s audio sent", total / TARGET_SAMPLE_RATE as u64);
-                    next_log += TARGET_SAMPLE_RATE as u64;
-                }
-                let bytes = pcm_to_le_bytes(&chunk);
-                if write.send(Message::Binary(bytes)).await.is_err() {
-                    break false;
-                }
-            }
-            _ = keepalive.tick() => {
-                if write.send(Message::Text("{\"type\":\"keepalive\"}".to_string())).await.is_err() {
-                    break false;
-                }
-            }
+    ws::forward_audio(write, meter, pcm_rx, pump, move |chunk| {
+        total += chunk.len() as u64;
+        if total >= next_log {
+            eprintln!(
+                "[soniox:{source}] TX {}s audio sent",
+                total / TARGET_SAMPLE_RATE as u64
+            );
+            next_log += TARGET_SAMPLE_RATE as u64;
         }
-    };
-    let _ = write
-        .send(Message::Text("{\"type\":\"finalize\"}".to_string()))
-        .await;
-    // BYOK: close our write half so Soniox flushes the final tokens to our
-    // still-open read half and then ends. In hosted RELAY mode, do NOT close
-    // here — the relay must forward this finalize to Soniox and stream the
-    // flushed tail BACK to us first; closing now would make the relay's
-    // server socket fire 'close' and stop relaying, truncating the last
-    // utterance. The relay closes the socket once Soniox finishes, which ends
-    // the read loop below (it also breaks on Soniox's `finished` marker).
-    if !is_relay {
-        let _ = write.close().await;
-    }
-    drained
-}
-
-/// Classify one websocket frame into "parse this" / "ignore" / "we're done".
-fn classify(msg: Result<Message, tokio_tungstenite::tungstenite::Error>, source: &str) -> Frame {
-    let msg = match msg {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("[soniox:{source}] read error: {e}");
-            return Frame::Stop;
-        }
-    };
-    match msg {
-        Message::Text(t) => Frame::Payload(t.to_string()),
-        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
-        Message::Close(frame) => {
-            eprintln!("[soniox:{source}] socket closed by server: {frame:?}");
-            Frame::Stop
-        }
-        _ => Frame::Skip,
-    }
+        Message::Binary(pcm_to_le_bytes(chunk))
+    })
+    .await
 }
 
 /// Split one response's tokens into committed speaker-runs (pushed straight into
@@ -261,26 +212,14 @@ fn apply_tokens(builder: &mut SegmentBuilder, tokens: &[SonioxToken]) -> bool {
 /// an in-band error frame (e.g. a rejected api key) so the caller's error
 /// surface fires — the session is dead from that point, and returning Ok would
 /// leave the UI listening to nothing.
-async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead) -> Result<()> {
+async fn read_transcripts(app: AppHandle, source: &'static str, read: WsRead) -> Result<()> {
     let mut builder = SegmentBuilder::new(app, source, TRANSCRIPT_EVENT);
-    let mut msg_count: u64 = 0;
-
-    while let Some(msg) = read.next().await {
-        let payload = match classify(msg, source) {
-            Frame::Payload(p) => p,
-            Frame::Skip => continue,
-            Frame::Stop => break,
-        };
-        msg_count += 1;
-        if msg_count <= 3 {
-            eprintln!("[soniox:{source}] RX raw#{msg_count}: {payload}");
-        }
-
-        let resp: SonioxResponse = match serde_json::from_str(&payload) {
+    ws::read_frames("soniox", source, read, OnClose::Stop, |payload| {
+        let resp: SonioxResponse = match serde_json::from_str(payload) {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("[soniox:{source}] RX parse error: {e} — payload: {payload}");
-                continue;
+                return Ok(Next::Continue);
             }
         };
 
@@ -293,11 +232,13 @@ async fn read_transcripts(app: AppHandle, source: &'static str, mut read: WsRead
         if apply_tokens(&mut builder, &resp.tokens) {
             builder.endpoint();
         }
-        if resp.finished {
-            break;
-        }
-    }
-    Ok(())
+        Ok(if resp.finished {
+            Next::Stop
+        } else {
+            Next::Continue
+        })
+    })
+    .await
 }
 
 /// Run one Soniox realtime session: stream PCM from `pcm_rx`, parse the token

--- a/src-tauri/src/transcription/ws.rs
+++ b/src-tauri/src/transcription/ws.rs
@@ -1,0 +1,216 @@
+//! WebSocket session machinery shared by the streaming transcription adapters.
+//!
+//! Every realtime provider splits its socket the same way: a write half that
+//! pumps PCM chunks and a read half that turns server frames into JSON payloads
+//! to parse. What differs is the wire dressing — binary PCM vs a base64 JSON
+//! envelope, whether an idle socket needs a keepalive, what the goodbye frame is
+//! called, and whether a close code carries the only error the provider will
+//! ever give us. Those bits stay in the adapters; the plumbing around them lives
+//! here so it isn't copied five times.
+
+use std::future::pending;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::Interval;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use super::common::LevelMeter;
+
+/// A provider socket, and its two halves after `split()`.
+pub type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
+pub type WsWrite = SplitSink<Ws, Message>;
+pub type WsRead = SplitStream<Ws>;
+
+/// What the read loop should do with one incoming websocket frame.
+enum Frame {
+    /// A JSON payload to parse.
+    Payload(String),
+    /// Nothing of interest — keep reading.
+    Skip,
+    /// The stream ended in a way that isn't an error.
+    Stop,
+    /// The server closed abnormally: terminal, with its reason as the detail.
+    Failed(String),
+}
+
+/// How a provider reads a server-initiated close frame.
+#[derive(Clone, Copy)]
+pub enum OnClose {
+    /// Any close just ends the read loop — this provider reports terminal
+    /// failures in band, so the close itself says nothing.
+    Stop,
+    /// A non-1000 close is the only error channel this provider has: terminal,
+    /// with the code and reason as the detail.
+    FailIfAbnormal,
+}
+
+/// What the payload handler wants the read loop to do next.
+pub enum Next {
+    /// Keep reading.
+    Continue,
+    /// The provider signalled end-of-stream in band; stop reading.
+    Stop,
+}
+
+/// Classify one websocket frame into "parse this" / "ignore" / "we're done" /
+/// "the server hung up on us".
+fn classify(
+    msg: Result<Message, tokio_tungstenite::tungstenite::Error>,
+    provider: &str,
+    source: &str,
+    on_close: OnClose,
+) -> Frame {
+    let msg = match msg {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("[{provider}:{source}] read error: {e}");
+            return Frame::Stop;
+        }
+    };
+    match msg {
+        Message::Text(t) => Frame::Payload(t.to_string()),
+        Message::Binary(b) => Frame::Payload(String::from_utf8_lossy(&b).into_owned()),
+        Message::Close(frame) => {
+            eprintln!("[{provider}:{source}] closed by server: {frame:?}");
+            match (on_close, frame) {
+                (OnClose::FailIfAbnormal, Some(f)) if f.code != CloseCode::Normal => {
+                    Frame::Failed(format!("{} {}", u16::from(f.code), f.reason))
+                }
+                _ => Frame::Stop,
+            }
+        }
+        _ => Frame::Skip,
+    }
+}
+
+/// Read server frames until the socket ends, handing every JSON payload to
+/// `on_payload`. The handler folds the payload into the adapter's segment
+/// builder and returns `Err` for a terminal in-band error, which stops the loop
+/// and propagates (see `run_metered_session`'s error surface).
+///
+/// The first three payloads are traced raw — the cheapest way to see what a
+/// provider actually sent when a session misbehaves.
+pub async fn read_frames<F>(
+    provider: &str,
+    source: &str,
+    mut read: WsRead,
+    on_close: OnClose,
+    mut on_payload: F,
+) -> Result<()>
+where
+    F: FnMut(&str) -> Result<Next>,
+{
+    let mut msg_count: u64 = 0;
+    while let Some(msg) = read.next().await {
+        let payload = match classify(msg, provider, source, on_close) {
+            Frame::Payload(p) => p,
+            Frame::Skip => continue,
+            Frame::Stop => break,
+            Frame::Failed(detail) => return Err(anyhow!("closed by server: {detail}")),
+        };
+        msg_count += 1;
+        if msg_count <= 3 {
+            eprintln!("[{provider}:{source}] RX raw#{msg_count}: {payload}");
+        }
+        if matches!(on_payload(&payload)?, Next::Stop) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// The provider-specific shape of the write half's life: how it stays alive and
+/// how it says goodbye.
+pub struct Pump {
+    /// Text frame to send on an interval, for providers that drop a socket that
+    /// goes quiet. `None` = no keepalive.
+    pub keepalive: Option<(Duration, &'static str)>,
+    /// Text frame that tells the server the stream is over, sent once the audio
+    /// stops. `None` = closing the socket is the whole goodbye.
+    pub finish: Option<&'static str>,
+    /// Whether to close the write half afterwards. Soniox's hosted relay needs
+    /// it left open so the relay can forward the flushed tail back to us.
+    pub close: bool,
+}
+
+impl Default for Pump {
+    fn default() -> Self {
+        Self {
+            keepalive: None,
+            finish: None,
+            close: true,
+        }
+    }
+}
+
+/// Wait for the next keepalive tick and yield the frame to send, or never
+/// resolve when the provider has no keepalive — so that `select!` arm simply
+/// stays pending for the life of the session.
+async fn keepalive_tick(keepalive: &mut Option<(Interval, &'static str)>) -> &'static str {
+    match keepalive {
+        Some((timer, frame)) => {
+            timer.tick().await;
+            *frame
+        }
+        None => pending().await,
+    }
+}
+
+/// Pump captured PCM into the socket until the input drains or a send fails,
+/// then run the provider's shutdown handshake. `encode` turns one chunk into
+/// whatever frame that provider expects.
+///
+/// Resolves `true` when the input drained (the capture side closed — a normal
+/// stop) and `false` when a send failed, i.e. the socket died under us; see
+/// [`super::common::drive_session`], which reports the latter as a failure.
+pub async fn forward_audio<F>(
+    mut write: WsWrite,
+    mut meter: LevelMeter,
+    mut pcm_rx: UnboundedReceiver<Vec<i16>>,
+    pump: Pump,
+    mut encode: F,
+) -> bool
+where
+    F: FnMut(&[i16]) -> Message,
+{
+    let mut keepalive = pump
+        .keepalive
+        .map(|(period, frame)| (tokio::time::interval(period), frame));
+    if let Some((timer, _)) = keepalive.as_mut() {
+        // The first tick fires immediately; consume it so the interval counts
+        // from now rather than firing a keepalive before any audio moved.
+        timer.tick().await;
+    }
+
+    let drained = loop {
+        tokio::select! {
+            maybe_chunk = pcm_rx.recv() => {
+                let Some(chunk) = maybe_chunk else { break true };
+                meter.push(&chunk);
+                if write.send(encode(&chunk)).await.is_err() {
+                    break false;
+                }
+            }
+            frame = keepalive_tick(&mut keepalive) => {
+                if write.send(Message::Text(frame.to_string())).await.is_err() {
+                    break false;
+                }
+            }
+        }
+    };
+
+    if let Some(frame) = pump.finish {
+        let _ = write.send(Message::Text(frame.to_string())).await;
+    }
+    if pump.close {
+        let _ = write.close().await;
+    }
+    drained
+}

--- a/src-tauri/src/voice_typing.rs
+++ b/src-tauri/src/voice_typing.rs
@@ -130,36 +130,11 @@ pub async fn start_voice_typing(
         }
         vt.seq
     };
-    let rx = match coord.begin(MicUser::VoiceTyping) {
-        Begin::Started(gate) => {
-            let mic = Microphone {
-                device_name: input_device,
-            };
-            match spawn_capture(&coord, MicUser::VoiceTyping, mic, gate, "voice-typing") {
-                Ok(rx) => rx,
-                Err(e) => {
-                    coord.stop(MicUser::VoiceTyping);
-                    return Err(format!("microphone failed to start: {e}"));
-                }
-            }
-        }
+    let Some(rx) = acquire_mic(&coord, &tap, input_device)? else {
         // Unreachable in practice: the host serializes press/release, so no
         // second voice-typing start can land between the stop above and this
         // begin. Kept for safety.
-        Begin::AlreadyActive => return Ok(()),
-        // Dictating DURING a meeting: the meeting owns the one input stream,
-        // so read a tee of its raw mic instead of opening a second capture.
-        // Everything downstream (session, overlay, cutoff, paste) is
-        // identical; teardown is self-cleaning — when this session's receiver
-        // drops (release cutoff, abort, or new start), the tap unregisters on
-        // its next failed send. The dictated speech naturally also lands in
-        // the meeting transcript, like anything else said aloud.
-        Begin::Busy(MicUser::Meeting) => {
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
-            tap.subscribe(tx)?;
-            rx
-        }
-        Begin::Busy(owner) => return Err(format!("microphone is in use by {owner:?}")),
+        return Ok(());
     };
     let model = model
         .filter(|m| !m.trim().is_empty())
@@ -208,26 +183,69 @@ pub async fn start_voice_typing(
     // can never stop a newer session started in the meantime. No-op if that
     // session already ended (mic not owned, task already taken).
     if let Some(secs) = max_duration_secs.filter(|s| *s > 0) {
-        let app = app.clone();
-        let inner = state.0.clone();
-        let deadline = std::time::Duration::from_secs(secs) + CAP_BACKEND_GRACE;
-        tauri::async_runtime::spawn(async move {
-            tokio::time::sleep(deadline).await;
-            let still_current = { inner.lock().unwrap().seq == my_seq };
-            if !still_current {
-                return;
-            }
-            log::warn!("voice-typing: hosted session exceeded {secs}s cap; backend safety-stop");
-            app.state::<MicCoordinator>().stop(MicUser::VoiceTyping);
-            let mut vt = inner.lock().unwrap();
-            if vt.seq == my_seq {
-                if let Some(task) = vt.task.take() {
-                    task.abort();
-                }
-            }
-        });
+        arm_cap_watchdog(&app, state.0.clone(), my_seq, secs);
     }
     Ok(())
+}
+
+/// Take the microphone for a dictation session: our own capture normally, or a
+/// tee of the meeting's raw mic when a meeting owns the one input stream.
+/// `Ok(None)` means voice typing already holds the mic and the start is a no-op.
+fn acquire_mic(
+    coord: &MicCoordinator,
+    tap: &MicTap,
+    input_device: Option<String>,
+) -> Result<Option<tokio::sync::mpsc::UnboundedReceiver<Vec<i16>>>, String> {
+    match coord.begin(MicUser::VoiceTyping) {
+        Begin::Started(gate) => {
+            let mic = Microphone {
+                device_name: input_device,
+            };
+            match spawn_capture(coord, MicUser::VoiceTyping, mic, gate, "voice-typing") {
+                Ok(rx) => Ok(Some(rx)),
+                Err(e) => {
+                    coord.stop(MicUser::VoiceTyping);
+                    Err(format!("microphone failed to start: {e}"))
+                }
+            }
+        }
+        Begin::AlreadyActive => Ok(None),
+        // Dictating DURING a meeting: the meeting owns the one input stream,
+        // so read a tee of its raw mic instead of opening a second capture.
+        // Everything downstream (session, overlay, cutoff, paste) is
+        // identical; teardown is self-cleaning — when this session's receiver
+        // drops (release cutoff, abort, or new start), the tap unregisters on
+        // its next failed send. The dictated speech naturally also lands in
+        // the meeting transcript, like anything else said aloud.
+        Begin::Busy(MicUser::Meeting) => {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<i16>>();
+            tap.subscribe(tx)?;
+            Ok(Some(rx))
+        }
+        Begin::Busy(owner) => Err(format!("microphone is in use by {owner:?}")),
+    }
+}
+
+/// Force-stop the mic once the hosted per-dictation cap (+ grace) has passed,
+/// unless the session identified by `my_seq` already ended or was superseded.
+fn arm_cap_watchdog(app: &AppHandle, inner: Arc<Mutex<VtInner>>, my_seq: u64, secs: u64) {
+    let app = app.clone();
+    let deadline = std::time::Duration::from_secs(secs) + CAP_BACKEND_GRACE;
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(deadline).await;
+        let still_current = { inner.lock().unwrap().seq == my_seq };
+        if !still_current {
+            return;
+        }
+        log::warn!("voice-typing: hosted session exceeded {secs}s cap; backend safety-stop");
+        app.state::<MicCoordinator>().stop(MicUser::VoiceTyping);
+        let mut vt = inner.lock().unwrap();
+        if vt.seq == my_seq {
+            if let Some(task) = vt.task.take() {
+                task.abort();
+            }
+        }
+    });
 }
 
 /// Name of the voice-typing history file (one JSON object per line) in the app

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,20 @@ function createFullscreenResizeHandler(sync: () => Promise<void>): () => void {
 }
 
 /**
+ * Run the drop-import flow for a set of dropped paths. Extracted to module
+ * scope so the lazy-import `then`/`catch` callbacks don't push the surrounding
+ * drag-drop listener closures past the nested-function depth limit.
+ */
+function importDroppedFiles(paths: string[]): void {
+  import("./lib/replay/ingest")
+    .then(({ importDroppedPaths }) => importDroppedPaths(paths))
+    .catch((error) => {
+      log.error("import: drop failed", { error: String(error) });
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
+}
+
+/**
  * Track main-window fullscreen state. Drives both the rounded corners (a
  * fullscreen window fills the display edge-to-edge, so it squares off; a
  * zoomed/maximized window is still a floating window and stays rounded) and the
@@ -253,12 +267,7 @@ const App = () => {
           if (isMeetingActive(useStore.getState().meetingStatus)) return;
           const { paths } = e.payload;
           log.info("import: files dropped", { count: paths.length });
-          import("./lib/replay/ingest")
-            .then(({ importDroppedPaths }) => importDroppedPaths(paths))
-            .catch((error) => {
-              log.error("import: drop failed", { error: String(error) });
-              toast.error(error instanceof Error ? error.message : String(error));
-            });
+          importDroppedFiles(paths);
         })
       )
       .then((fn) => {

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -22,6 +22,20 @@ import {
 } from "../lib/library/destination";
 
 /**
+ * Fetch one org's shared folders as an `[orgId, folders]` pair. Extracted to
+ * module scope so its `catch`/`map` callbacks don't push the surrounding loader
+ * closures past the nested-function depth limit. The lister is passed in
+ * because the cloud module is only ever reached through a lazy import.
+ */
+async function loadOrgFolderPair(
+  orgId: string,
+  listOrgFolders: (id: string) => Promise<Folder[]>
+): Promise<readonly [string, Folder[]]> {
+  const fs = await listOrgFolders(orgId).catch((): Folder[] => []);
+  return [orgId, fs.map((f) => ({ id: f.id, name: f.name, createdAt: f.createdAt }))] as const;
+}
+
+/**
  * THE control for "where does this recording live".
  *
  * One folder is one customer, so this is also the only "whose call was this"
@@ -95,12 +109,7 @@ export function DestinationPicker({
       const mine = await listMyOrgs();
       if (!alive) return;
       setOrgs(mine.map((o) => ({ id: o.id, name: o.name })));
-      const pairs = await Promise.all(
-        mine.map(async (o) => {
-          const fs = await listOrgFolders(o.id).catch(() => []);
-          return [o.id, fs.map((f) => ({ id: f.id, name: f.name, createdAt: f.createdAt }))] as const;
-        })
-      );
+      const pairs = await Promise.all(mine.map((o) => loadOrgFolderPair(o.id, listOrgFolders)));
       if (alive) setOrgFolders(Object.fromEntries(pairs));
     }
     load().catch((error) => log.warn("destination: org load failed", { error: String(error) }));

--- a/src/components/IngestWizard.tsx
+++ b/src/components/IngestWizard.tsx
@@ -652,13 +652,13 @@ function Stage({
       <span className="text-sm font-medium text-foreground">{label}</span>
       {sub && <span className="text-[11px] text-muted-foreground">{sub}</span>}
       <div className="mt-1 h-1.5 w-48 overflow-hidden rounded-full bg-muted">
-        {progress != null ? (
+        {progress == null ? (
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-emerald-500/70" />
+        ) : (
           <div
             className="h-full rounded-full bg-emerald-500 transition-all"
             style={{ width: `${Math.min(100, Math.round(progress * 100))}%` }}
           />
-        ) : (
-          <div className="h-full w-1/3 animate-pulse rounded-full bg-emerald-500/70" />
         )}
       </div>
     </div>

--- a/src/components/McpStatusChip.tsx
+++ b/src/components/McpStatusChip.tsx
@@ -36,6 +36,21 @@ export function connState(info: McpActivityInfo | null, now: number): McpConnSta
   return "idle";
 }
 
+/** Status-dot classes per connection state. */
+const DOT_CLASS: Record<McpConnState, string> = {
+  active: "bg-emerald-500 animate-pulse",
+  connected: "bg-emerald-500",
+  idle: "bg-muted-foreground/50",
+  none: "bg-muted-foreground/25",
+};
+
+/** "name vX" for the connected client, or null when nobody has connected. */
+export function clientLabel(client: McpActivityInfo["client"] | undefined): string | null {
+  if (!client) return null;
+  const version = client.version ? ` v${client.version}` : "";
+  return `${client.name ?? "?"}${version}`;
+}
+
 export function relativeTime(t: ReturnType<typeof useI18n>["t"], at: number, now: number): string {
   const s = Math.max(0, Math.round((now - at) / 1000));
   if (s < 10) return t("mcp.time.justNow");
@@ -93,14 +108,7 @@ export function McpStatusChip() {
 
   const state = connState(info, now);
   const stateLabel = t(`mcp.state.${state}`);
-  const dotClass =
-    state === "active"
-      ? "bg-emerald-500 animate-pulse"
-      : state === "connected"
-        ? "bg-emerald-500"
-        : state === "idle"
-          ? "bg-muted-foreground/50"
-          : "bg-muted-foreground/25";
+  const dotClass = DOT_CLASS[state];
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
@@ -131,9 +139,7 @@ export function McpStatusChip() {
             <div className="flex items-baseline justify-between gap-2">
               <span className="shrink-0 text-muted-foreground">{t("mcp.panel.client")}</span>
               <span className="truncate font-medium">
-                {info?.client
-                  ? `${info.client.name ?? "?"}${info.client.version ? ` v${info.client.version}` : ""}`
-                  : t("mcp.panel.noClient")}
+                {clientLabel(info?.client ?? null) ?? t("mcp.panel.noClient")}
               </span>
             </div>
             <div className="flex items-baseline justify-between gap-2">

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -23,7 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { AppLanguage, LlmProvider, Settings, SttProviderId } from "../lib/types";
+import type { LlmProvider, Settings, SttProviderId } from "../lib/types";
 
 // systemAudio: unknown | granted | denied | unsupported (macOS < 14.2).
 type Perms = { microphone: string; systemAudio: string };
@@ -106,11 +106,11 @@ export function Onboarding() {
     };
     window.addEventListener("focus", recheckNow);
     document.addEventListener("visibilitychange", recheckNow);
-    const id = window.setInterval(recheckNow, 2000);
+    const id = globalThis.setInterval(recheckNow, 2000);
     return () => {
       window.removeEventListener("focus", recheckNow);
       document.removeEventListener("visibilitychange", recheckNow);
-      window.clearInterval(id);
+      globalThis.clearInterval(id);
     };
   }, [step]);
 
@@ -153,7 +153,7 @@ export function Onboarding() {
                   <button
                     key={lang.value}
                     type="button"
-                    onClick={() => patch({ language: lang.value as AppLanguage })}
+                    onClick={() => patch({ language: lang.value })}
                     className={`flex items-center justify-between rounded-lg border px-3 py-2.5 text-left text-sm transition-colors ${
                       settings.language === lang.value
                         ? "border-primary bg-primary/10"

--- a/src/components/OrgSharePicker.tsx
+++ b/src/components/OrgSharePicker.tsx
@@ -18,8 +18,10 @@ export interface OrgShareTarget {
 }
 
 const OFF = "off";
-const serialize = (v: OrgShareTarget | null): string =>
-  v ? (v.folderId ? `${v.orgId}:${v.folderId}` : v.orgId) : OFF;
+const serialize = (v: OrgShareTarget | null): string => {
+  if (!v) return OFF;
+  return v.folderId ? `${v.orgId}:${v.folderId}` : v.orgId;
+};
 const parse = (v: string): OrgShareTarget | null => {
   if (v === OFF) return null;
   const idx = v.indexOf(":");

--- a/src/components/TranscriptImportDialog.tsx
+++ b/src/components/TranscriptImportDialog.tsx
@@ -19,6 +19,50 @@ import {
   type OrgHandoffMode,
 } from "../lib/library/destination";
 
+/** An org destination — the branch that needs a copy-or-move handoff. */
+type OrgDestination = Extract<LibraryDestination, { scope: "org" }>;
+
+/**
+ * Write the parsed transcripts to local history and return the new entry ids.
+ * Extracted from the dialog's confirm handler to keep it readable.
+ */
+async function saveTranscripts(
+  files: PreparedTranscriptFile[],
+  destination: LibraryDestination,
+): Promise<string[]> {
+  const imported: string[] = [];
+  for (const f of files) {
+    const parsed = f.parsed;
+    if (!parsed) continue;
+    const id = await saveTranscriptToHistory({
+      title: f.title.trim() || f.fileName,
+      segments: parsed.segments,
+      speakerNames: parsed.speakerNames,
+      durationMs: parsed.durationMs,
+      createdAt: f.createdAt,
+      // An org destination still writes locally first: the share endpoint
+      // copies from the user's own cloud keyspace, so the entry has to
+      // exist before it can be handed over.
+      folderId: destination.scope === "personal" ? destination.folderId : null,
+    });
+    if (id) imported.push(id);
+  }
+  return imported;
+}
+
+/** Hand the freshly saved entries over to the chosen org (copy or move). */
+async function handOffToOrg(
+  imported: string[],
+  destination: OrgDestination,
+  handoff: OrgHandoffMode | null,
+): Promise<void> {
+  const { moveRecordingToOrg, shareRecordingToOrg } = await import("../lib/cloud/sync");
+  const hand = handoff === "move" ? moveRecordingToOrg : shareRecordingToOrg;
+  for (const id of imported) {
+    await hand(id, destination.orgId, destination.folderId);
+  }
+}
+
 /**
  * Import picked/dropped .txt transcripts as audio-less history entries (issue
  * #130's text-ingest path). Shows one row per file (parsed stats + editable
@@ -75,33 +119,11 @@ export function TranscriptImportDialog() {
   async function confirm() {
     if (!valid.length || importing) return;
     setImporting(true);
-    const imported: string[] = [];
+    let imported: string[] = [];
     try {
-      for (const f of valid) {
-        const parsed = f.parsed;
-        if (!parsed) continue;
-        const id = await saveTranscriptToHistory({
-          title: f.title.trim() || f.fileName,
-          segments: parsed.segments,
-          speakerNames: parsed.speakerNames,
-          durationMs: parsed.durationMs,
-          createdAt: f.createdAt,
-          // An org destination still writes locally first: the share endpoint
-          // copies from the user's own cloud keyspace, so the entry has to
-          // exist before it can be handed over.
-          folderId: destination.scope === "personal" ? destination.folderId : null,
-        });
-        if (id) imported.push(id);
-      }
+      imported = await saveTranscripts(valid, destination);
       if (destination.scope === "org") {
-        const { moveRecordingToOrg, shareRecordingToOrg } = await import("../lib/cloud/sync");
-        for (const id of imported) {
-          if (handoff === "move") {
-            await moveRecordingToOrg(id, destination.orgId, destination.folderId);
-          } else {
-            await shareRecordingToOrg(id, destination.orgId, destination.folderId);
-          }
-        }
+        await handOffToOrg(imported, destination, handoff);
       }
     } catch (e) {
       log.error("import: transcript save failed", { error: String(e) });

--- a/src/components/analysis/AnalysisTimeline.tsx
+++ b/src/components/analysis/AnalysisTimeline.tsx
@@ -42,12 +42,12 @@ export function cardPosition(
   dot: { left: number; right: number; top: number; bottom: number; width: number },
   cardH: number,
   preferBelow: boolean,
-  viewport: { width: number; height: number } = {
-    width: window.innerWidth,
-    height: window.innerHeight,
-  },
+  // Defaults to the live window; read per call rather than from a parameter
+  // default so a resize between renders isn't captured by a stale literal.
+  viewport?: { width: number; height: number },
 ) {
-  const { width: vw, height: vh } = viewport;
+  const vw = viewport?.width ?? window.innerWidth;
+  const vh = viewport?.height ?? window.innerHeight;
   const x = Math.min(
     Math.max(EDGE_GAP, dot.left + dot.width / 2 - CARD_W / 2),
     vw - CARD_W - EDGE_GAP,

--- a/src/components/delivery/DeliveryPanel.tsx
+++ b/src/components/delivery/DeliveryPanel.tsx
@@ -6,10 +6,16 @@ import { syllablesPerMin, talkTimeRatio } from "../../lib/analysis/delivery";
 import { countFillerSounds } from "../../lib/analysis/fillerWords";
 import { useI18n } from "../../i18n";
 import type { TranslationKey } from "../../i18n";
-import type { DeliveryAssessment, ToneVerdict, TranscriptSegment } from "../../lib/types";
+import type {
+  DeliveryAssessment,
+  DeliveryToggles,
+  ToneVerdict,
+  TranscriptSegment,
+} from "../../lib/types";
 
 type TFn = ReturnType<typeof useI18n>["t"];
 type DeliveryStatus = ReturnType<typeof useStore.getState>["deliveryStatus"];
+type Prosody = ReturnType<typeof useProsody>;
 
 /** Accent color per tone verdict — neutral/firm are fine, sharp+ warn. */
 function toneClass(tone: ToneVerdict): string {
@@ -40,10 +46,10 @@ const TONE_KEY: Record<ToneVerdict, TranslationKey> = {
  *  ~180 字/分 normal conversation, ~240–300 presentation, 300+ fast. The single
  *  tuning knob is `FAST_HZ`: lower it to make "too fast" trigger sooner.
  *  4.0/s ≈ 240 字/分 (upper-presentation — deliberately on the sensitive side). */
-const FAST_HZ = 4.0;
+const FAST_HZ = 4;
 function paceBand(hz: number): { key: TranslationKey; watch: boolean } {
   if (hz > FAST_HZ) return { key: "delivery.pace.fast", watch: true };
-  if (hz >= 2.0) return { key: "delivery.pace.comfortable", watch: false };
+  if (hz >= 2) return { key: "delivery.pace.comfortable", watch: false };
   return { key: "delivery.pace.slow", watch: false };
 }
 
@@ -220,10 +226,18 @@ function StatTile({
   );
 }
 
+/** One slice of the talk-volume strip. `startMs` doubles as its identity — the
+ *  buckets tile a recording of at least 3 min into at most 60 slices, so no two
+ *  ever start at the same offset. */
+interface TalkBucket {
+  startMs: number;
+  voicedMs: number;
+}
+
 /** Per-bucket voiced ms of the user's own speech across the recording — a cheap,
  *  fully local "where was I talking (a lot)" strip. Empty for short recordings
  *  (< 3 min) and when the session has no source-split "me" segments. */
-function talkVolumeBuckets(segments: TranscriptSegment[]): number[] {
+function talkVolumeBuckets(segments: TranscriptSegment[]): TalkBucket[] {
   const spoken = segments.filter((s) => s.isFinal && s.source === "me" && s.text.trim());
   if (spoken.length === 0) return [];
   let endMs = 0;
@@ -231,27 +245,30 @@ function talkVolumeBuckets(segments: TranscriptSegment[]): number[] {
   if (endMs < 3 * 60_000) return [];
   const count = Math.min(60, Math.ceil(endMs / 60_000));
   const bucketMs = endMs / count;
-  const buckets = new Array<number>(count).fill(0);
+  const buckets: TalkBucket[] = Array.from({ length: count }, (_, i) => ({
+    startMs: Math.round(i * bucketMs),
+    voicedMs: 0,
+  }));
   for (const s of spoken) {
     const i = Math.min(count - 1, Math.floor(s.startMs / bucketMs));
-    buckets[i] += Math.max(0, s.endMs - s.startMs);
+    buckets[i].voicedMs += Math.max(0, s.endMs - s.startMs);
   }
   return buckets;
 }
 
-function TalkVolumeStrip({ buckets, title }: Readonly<{ buckets: number[]; title: string }>) {
-  const max = Math.max(...buckets, 1);
+function TalkVolumeStrip({ buckets, title }: Readonly<{ buckets: TalkBucket[]; title: string }>) {
+  const max = Math.max(...buckets.map((b) => b.voicedMs), 1);
   return (
     <div className="rounded-lg border bg-muted/20 p-3">
       <div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
         {title}
       </div>
       <div className="flex h-10 items-end gap-px">
-        {buckets.map((v, i) => (
+        {buckets.map((b) => (
           <span
-            key={i}
-            className={`min-w-0 flex-1 rounded-t-sm ${v === max ? "bg-primary" : "bg-primary/50"}`}
-            style={{ height: `${Math.max(4, Math.round((v / max) * 100))}%` }}
+            key={b.startMs}
+            className={`min-w-0 flex-1 rounded-t-sm ${b.voicedMs === max ? "bg-primary" : "bg-primary/50"}`}
+            style={{ height: `${Math.max(4, Math.round((b.voicedMs / max) * 100))}%` }}
           />
         ))}
       </div>
@@ -264,6 +281,240 @@ function talkBand(me: number): { key: TranslationKey; watch: boolean } {
   if (me >= 0.65) return { key: "delivery.talk.high", watch: true };
   if (me <= 0.35) return { key: "delivery.talk.low", watch: false };
   return { key: "delivery.talk.balanced", watch: false };
+}
+
+/** Everything the full-variant scorecard derives from the saved transcript. */
+interface LocalDeliveryStats {
+  ratio: ReturnType<typeof talkTimeRatio>;
+  fillers: number;
+  buckets: TalkBucket[];
+}
+
+/** Replay stats straight from the saved transcript — no model call. */
+function computeLocalStats(segments: TranscriptSegment[]): LocalDeliveryStats {
+  const ratio = talkTimeRatio(segments);
+  let fillers = 0;
+  for (const s of segments) {
+    if (s.isFinal && s.source === "me") fillers += countFillerSounds(s.text);
+  }
+  return { ratio, fillers, buckets: talkVolumeBuckets(segments) };
+}
+
+/** The pace tile's sub-label: the measured band when there is one, otherwise
+ *  the LLM's coarse read, otherwise nothing. */
+function paceTileSub(
+  t: TFn,
+  measuredRate: number | null,
+  band: ReturnType<typeof paceBand> | null,
+  assessment: DeliveryAssessment | null,
+): string | undefined {
+  if (measuredRate && band) return `${t("delivery.unit.sylPerMin")} · ${t(band.key)}`;
+  if (assessment) return t(`delivery.pace.${assessment.pace}` as TranslationKey);
+  return undefined;
+}
+
+/** The tone tile's value: the verdict once assessed, an ellipsis while the pass
+ *  is still running, a dash when there is nothing to say. */
+function toneTileValue(t: TFn, assessment: DeliveryAssessment | null, running: boolean): string {
+  if (assessment) return t(TONE_KEY[assessment.tone]);
+  return running ? "…" : "—";
+}
+
+/** Sharp and above warrants an amber tile. */
+function toneNeedsWatch(assessment: DeliveryAssessment | null): boolean {
+  if (!assessment) return false;
+  return assessment.tone === "sharp" || assessment.tone === "aggressive" || assessment.tone === "rude";
+}
+
+/** The study tense's locally-computed scorecard (`variant="full"`). */
+function DeliveryScorecard({
+  mode,
+  stats,
+  measuredRate,
+  assessment,
+  status,
+  running,
+  t,
+}: Readonly<{
+  mode: "live" | "replay";
+  stats: LocalDeliveryStats;
+  measuredRate: number | null;
+  assessment: DeliveryAssessment | null;
+  status: DeliveryStatus;
+  running: boolean;
+  t: TFn;
+}>) {
+  const measuredBand = measuredRate ? paceBand(measuredRate) : null;
+  const ratioBand = stats.ratio ? talkBand(stats.ratio.me) : null;
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <StatTile
+          label={t("delivery.card.pace")}
+          value={measuredRate ? `${syllablesPerMin(measuredRate)}` : "—"}
+          sub={paceTileSub(t, measuredRate, measuredBand, assessment)}
+          watch={!!measuredBand?.watch}
+        />
+        {stats.ratio && ratioBand && (
+          <StatTile
+            label={t("delivery.card.talkRatio")}
+            value={`${Math.round(stats.ratio.me * 100)}%`}
+            sub={t(ratioBand.key)}
+            watch={ratioBand.watch}
+          />
+        )}
+        <StatTile
+          label={t("delivery.tile.fillers")}
+          value={`${stats.fillers}`}
+          sub={t("delivery.unit.times")}
+          watch={stats.fillers >= 10}
+        />
+        <StatTile
+          label={t("delivery.card.tone")}
+          value={toneTileValue(t, assessment, running)}
+          sub={assessment?.toneEvidence ? `“${assessment.toneEvidence}”` : undefined}
+          watch={toneNeedsWatch(assessment)}
+        />
+      </div>
+
+      {stats.buckets.length > 0 && (
+        <TalkVolumeStrip buckets={stats.buckets} title={t("delivery.card.paceTimeline")} />
+      )}
+
+      <div className="rounded-lg border bg-muted/20 p-3">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-xs font-semibold tracking-tight">{t("delivery.card.llmRead")}</span>
+          {status === "running" && assessment && (
+            <Loader2 className="size-3 animate-spin text-muted-foreground" />
+          )}
+        </div>
+        <div className="flex flex-col gap-1.5 text-[11px]">
+          <DeliveryReadout mode={mode} status={status} running={running} assessment={assessment} t={t} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Live ambient meters (mic-anchored): pace and intonation. */
+function LiveMeters({
+  t,
+  prosody,
+  paceOn,
+  pitchOn,
+}: Readonly<{ t: TFn; prosody: Prosody; paceOn: boolean; pitchOn: boolean }>) {
+  if (!paceOn && !pitchOn) return null;
+  // Null prosody → muted "—" until the first sample.
+  const paceHz = prosody?.speechRateHz ?? 0;
+  const sd = prosody?.pitchVarSemitones ?? 0;
+  const band = paceBand(paceHz);
+  const hasProsody = !!prosody;
+  return (
+    <MeterGroup>
+      {paceOn && (
+        <MeterRow
+          label={t("delivery.card.pace")}
+          pct={Math.min(100, Math.round((paceHz / 6) * 100))}
+          watch={band.watch}
+          muted={!hasProsody || paceHz <= 1}
+          value={livePaceValue(t, hasProsody, paceHz, band)}
+        />
+      )}
+      {pitchOn && (
+        <MeterRow
+          label={t("delivery.card.intonation")}
+          pct={Math.min(100, Math.round((sd / 3) * 100))}
+          watch={sd > 0 && sd < 1.2}
+          muted={!hasProsody || sd <= 0}
+          value={intonationValue(t, hasProsody, sd)}
+        />
+      )}
+    </MeterGroup>
+  );
+}
+
+/** Replay's acoustically MEASURED pace — from Rust, not an LLM guess. */
+function MeasuredPaceMeter({ t, rate }: Readonly<{ t: TFn; rate: number }>) {
+  const band = paceBand(rate);
+  return (
+    <MeterGroup>
+      <MeterRow
+        label={t("delivery.card.pace")}
+        pct={Math.min(100, Math.round((rate / 6) * 100))}
+        watch={band.watch}
+        muted={false}
+        value={`${syllablesPerMin(rate)} ${t("delivery.unit.sylPerMin")} · ${t(band.key)}`}
+      />
+    </MeterGroup>
+  );
+}
+
+/** The compact card: live meters + filler tally, or replay's measured pace,
+ *  topped off with the LLM tone/filler read. */
+function DeliveryCard({
+  mode,
+  t,
+  toggles,
+  prosody,
+  measuredRate,
+  filledPauseCount,
+  status,
+  assessment,
+  running,
+}: Readonly<{
+  mode: "live" | "replay";
+  t: TFn;
+  toggles: DeliveryToggles;
+  prosody: Prosody;
+  /** The measured rate, already gated on this being a replay that has one. */
+  measuredRate: number | null;
+  filledPauseCount: number;
+  status: DeliveryStatus;
+  assessment: DeliveryAssessment | null;
+  running: boolean;
+}>) {
+  // The LLM tone/filler block shows in replay always; live only when opted in.
+  const showLlm = mode === "replay" || toggles.tone;
+  return (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <div className="mb-1.5 flex items-center justify-between">
+        <span className="text-xs font-semibold tracking-tight">{t("delivery.card.title")}</span>
+        {status === "running" && assessment && (
+          <Loader2 className="size-3 animate-spin text-muted-foreground" />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5 text-[11px]">
+        {mode === "live" && (
+          <LiveMeters t={t} prosody={prosody} paceOn={toggles.pace} pitchOn={toggles.pitch} />
+        )}
+        {/* Live filler-sound ("um/uh/嗯/呃") tally — counted from your own
+            transcript against a global, cross-language filler map, in real time. */}
+        {mode === "live" && toggles.pauses && <LiveFillerCount count={filledPauseCount} t={t} />}
+
+        {/* Replay: the measured (not guessed) pace. */}
+        {measuredRate ? <MeasuredPaceMeter t={t} rate={measuredRate} /> : null}
+
+        {/* LLM read: tone (+ evidence) and over-frequent fillers. */}
+        {showLlm && (
+          <DeliveryReadout mode={mode} status={status} running={running} assessment={assessment} t={t} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Whether the card has anything to say. Replay speaks up once analysis has been
+ *  attempted or a rate was measured; live only when a signal is opted in. */
+function shouldShow(
+  mode: "live" | "replay",
+  toggles: DeliveryToggles,
+  status: DeliveryStatus,
+  assessment: DeliveryAssessment | null,
+  hasMeasured: boolean,
+): boolean {
+  if (mode === "replay") return status !== "idle" || !!assessment || hasMeasured;
+  return toggles.tone || toggles.pace || toggles.pitch || toggles.pauses;
 }
 
 /**
@@ -305,149 +556,42 @@ export function DeliveryPanel({
   const measuredRate = useStore((s) => s.replay?.speechRateHz ?? null);
   const segments = useStore((s) => s.segments);
 
+  const toggles: DeliveryToggles = { tone: toneOn, pace: paceOn, pitch: pitchOn, pauses: pausesOn };
   const full = variant === "full" && mode === "replay";
   // Local replay stats (full variant only) — computed straight from the saved
   // transcript, no model call. Ratio is null for diarized "mix" sessions.
-  const localStats = useMemo(() => {
-    if (!full) return null;
-    const ratio = talkTimeRatio(segments);
-    let fillers = 0;
-    for (const s of segments) {
-      if (s.isFinal && s.source === "me") fillers += countFillerSounds(s.text);
-    }
-    return { ratio, fillers, buckets: talkVolumeBuckets(segments) };
-  }, [full, segments]);
+  const localStats = useMemo(() => (full ? computeLocalStats(segments) : null), [full, segments]);
 
   const hasMeasured = mode === "replay" && !!measuredRate;
-  const showLive = toneOn || paceOn || pitchOn || pausesOn;
-  const show = full || (mode === "replay" ? status !== "idle" || !!assessment || hasMeasured : showLive);
-  if (!show) return null;
+  if (!full && !shouldShow(mode, toggles, status, assessment, hasMeasured)) return null;
 
   const running = status === "running" && !assessment;
 
   if (full && localStats) {
-    const mBandFull = measuredRate ? paceBand(measuredRate) : null;
-    const ratioBand = localStats.ratio ? talkBand(localStats.ratio.me) : null;
     return (
-      <div className="flex flex-col gap-3">
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-          <StatTile
-            label={t("delivery.card.pace")}
-            value={measuredRate ? `${syllablesPerMin(measuredRate)}` : "—"}
-            sub={
-              measuredRate && mBandFull
-                ? `${t("delivery.unit.sylPerMin")} · ${t(mBandFull.key)}`
-                : assessment
-                  ? t(`delivery.pace.${assessment.pace}` as TranslationKey)
-                  : undefined
-            }
-            watch={!!mBandFull?.watch}
-          />
-          {localStats.ratio && ratioBand && (
-            <StatTile
-              label={t("delivery.card.talkRatio")}
-              value={`${Math.round(localStats.ratio.me * 100)}%`}
-              sub={t(ratioBand.key)}
-              watch={ratioBand.watch}
-            />
-          )}
-          <StatTile
-            label={t("delivery.tile.fillers")}
-            value={`${localStats.fillers}`}
-            sub={t("delivery.unit.times")}
-            watch={localStats.fillers >= 10}
-          />
-          <StatTile
-            label={t("delivery.card.tone")}
-            value={assessment ? t(TONE_KEY[assessment.tone]) : running ? "…" : "—"}
-            sub={assessment?.toneEvidence ? `“${assessment.toneEvidence}”` : undefined}
-            watch={!!assessment && (assessment.tone === "sharp" || assessment.tone === "aggressive" || assessment.tone === "rude")}
-          />
-        </div>
-
-        {localStats.buckets.length > 0 && (
-          <TalkVolumeStrip buckets={localStats.buckets} title={t("delivery.card.paceTimeline")} />
-        )}
-
-        <div className="rounded-lg border bg-muted/20 p-3">
-          <div className="mb-1.5 flex items-center justify-between">
-            <span className="text-xs font-semibold tracking-tight">{t("delivery.card.llmRead")}</span>
-            {status === "running" && assessment && (
-              <Loader2 className="size-3 animate-spin text-muted-foreground" />
-            )}
-          </div>
-          <div className="flex flex-col gap-1.5 text-[11px]">
-            <DeliveryReadout mode={mode} status={status} running={running} assessment={assessment} t={t} />
-          </div>
-        </div>
-      </div>
+      <DeliveryScorecard
+        mode={mode}
+        stats={localStats}
+        measuredRate={measuredRate}
+        assessment={assessment}
+        status={status}
+        running={running}
+        t={t}
+      />
     );
   }
-  // Live meter inputs (null prosody → muted "—" until the first sample).
-  const paceHz = prosody?.speechRateHz ?? 0;
-  const liveBand = paceBand(paceHz);
-  const sd = prosody?.pitchVarSemitones ?? 0;
-  const mBand = measuredRate ? paceBand(measuredRate) : null;
-  const hasProsody = !!prosody;
-
-  // The LLM tone/filler block shows in replay always; live only when opted in.
-  const showLlm = mode === "replay" || toneOn;
 
   return (
-    <div className="rounded-lg border bg-muted/20 p-3">
-      <div className="mb-1.5 flex items-center justify-between">
-        <span className="text-xs font-semibold tracking-tight">{t("delivery.card.title")}</span>
-        {status === "running" && assessment && (
-          <Loader2 className="size-3 animate-spin text-muted-foreground" />
-        )}
-      </div>
-
-      <div className="flex flex-col gap-1.5 text-[11px]">
-        {/* Live ambient meters (mic-anchored). */}
-        {mode === "live" && (paceOn || pitchOn) && (
-          <MeterGroup>
-            {paceOn && (
-              <MeterRow
-                label={t("delivery.card.pace")}
-                pct={Math.min(100, Math.round((paceHz / 6) * 100))}
-                watch={liveBand.watch}
-                muted={!prosody || paceHz <= 1}
-                value={livePaceValue(t, hasProsody, paceHz, liveBand)}
-              />
-            )}
-            {pitchOn && (
-              <MeterRow
-                label={t("delivery.card.intonation")}
-                pct={Math.min(100, Math.round((sd / 3) * 100))}
-                watch={sd > 0 && sd < 1.2}
-                muted={!prosody || sd <= 0}
-                value={intonationValue(t, hasProsody, sd)}
-              />
-            )}
-          </MeterGroup>
-        )}
-        {/* Live filler-sound ("um/uh/嗯/呃") tally — counted from your own
-            transcript against a global, cross-language filler map, in real time. */}
-        {mode === "live" && pausesOn && <LiveFillerCount count={filledPauseCount} t={t} />}
-
-        {/* Replay: the measured (not guessed) pace. */}
-        {hasMeasured && mBand && (
-          <MeterGroup>
-            <MeterRow
-              label={t("delivery.card.pace")}
-              pct={Math.min(100, Math.round((measuredRate! / 6) * 100))}
-              watch={mBand.watch}
-              muted={false}
-              value={`${syllablesPerMin(measuredRate!)} ${t("delivery.unit.sylPerMin")} · ${t(mBand.key)}`}
-            />
-          </MeterGroup>
-        )}
-
-        {/* LLM read: tone (+ evidence) and over-frequent fillers. */}
-        {showLlm && (
-          <DeliveryReadout mode={mode} status={status} running={running} assessment={assessment} t={t} />
-        )}
-      </div>
-    </div>
+    <DeliveryCard
+      mode={mode}
+      t={t}
+      toggles={toggles}
+      prosody={prosody}
+      measuredRate={hasMeasured ? measuredRate : null}
+      filledPauseCount={filledPauseCount}
+      status={status}
+      assessment={assessment}
+      running={running}
+    />
   );
 }

--- a/src/components/library/LibraryCards.tsx
+++ b/src/components/library/LibraryCards.tsx
@@ -99,9 +99,8 @@ function MenuShell({
   const { t } = useI18n();
   return (
     <>
-      <div
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
         aria-label={t("common.cancel")}
         className="fixed inset-0 z-30"
         onClick={(ev) => {
@@ -117,7 +116,6 @@ function MenuShell({
         }}
       />
       <div
-        role="presentation"
         className="absolute right-0 top-7 z-40 max-h-64 min-w-40 overflow-y-auto rounded-md border bg-popover p-1 shadow-md"
         onClick={(ev) => ev.stopPropagation()}
         onKeyDown={(ev) => ev.stopPropagation()}
@@ -287,27 +285,25 @@ export function MoveDialog({
 }>) {
   const { t } = useI18n();
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-label={t("history.move.cancel")}
-      // z-[100]: this is raised from the library grid, from inside a Sheet
-      // (z-[91]) and from the import modals (z-[70]) — it has to clear all three.
-      className="fixed inset-0 z-[100] grid place-items-center bg-black/40 p-6"
-      onClick={onCancel}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
-          e.preventDefault();
-          onCancel();
-        }
-      }}
-    >
-      <div
-        role="presentation"
-        className="w-full max-w-sm rounded-lg border bg-popover p-4 shadow-lg"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+    // z-[100]: this is raised from the library grid, from inside a Sheet
+    // (z-[91]) and from the import modals (z-[70]) — it has to clear all three.
+    <div className="fixed inset-0 z-[100] grid place-items-center p-6">
+      {/* The scrim is a SIBLING of the panel, not its parent: a real <button>
+          cannot wrap the panel's own buttons, and this way a click on the panel
+          never has to be stopped from reaching the scrim. */}
+      <button
+        type="button"
+        aria-label={t("history.move.cancel")}
+        className="absolute inset-0 bg-black/40"
+        onClick={onCancel}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+      />
+      <div className="relative w-full max-w-sm rounded-lg border bg-popover p-4 shadow-lg">
         <div className="mb-1 flex items-center gap-1.5 text-sm font-semibold">
           <UsersRound className="size-4 text-sky-500" />
           {t("history.move.title", { org: orgName })}
@@ -328,6 +324,81 @@ export function MoveDialog({
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+/** The hover toolbar in a card's top-right corner: move, share, rename, delete. */
+function CardActions({
+  entry,
+  isOrgContext,
+  isCloudOnly,
+  canShare,
+  orgs,
+  orgFolders,
+  busy,
+  sharing,
+  folders,
+  onDelete,
+  onRenameStart,
+  onShare,
+  onMove,
+}: Readonly<{
+  entry: HistoryCardItem;
+  isOrgContext: boolean;
+  isCloudOnly: boolean;
+  canShare: boolean;
+  orgs: CloudOrg[];
+  orgFolders: Record<string, LocalFolder[]>;
+  busy: boolean;
+  sharing: boolean;
+  folders: LocalFolder[];
+  onDelete: () => void;
+  onRenameStart: () => void;
+  onShare: (org: CloudOrg, folderId: string | null) => void;
+  onMove: (folderId: string | null) => void;
+}>) {
+  const { t } = useI18n();
+  // An org card files into org folders (so it needs at least one); a personal
+  // one needs local meta to retag, which a cloud-only card does not have.
+  const canMove = isOrgContext ? folders.length > 0 : !isCloudOnly;
+  const canRename = !isCloudOnly && !isOrgContext;
+  const deleteLabel = isOrgContext ? t("history.org.remove") : t("history.delete");
+  return (
+    <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100">
+      {canMove && (
+        <MoveMenu folders={folders} currentFolderId={entry.folderId ?? null} onMove={onMove} />
+      )}
+      {canShare && (
+        <ShareMenu orgs={orgs} orgFolders={orgFolders} sharing={sharing} onPick={onShare} />
+      )}
+      {canRename && (
+        <button
+          type="button"
+          aria-label={t("history.rename")}
+          title={t("history.rename")}
+          onClick={(ev) => {
+            ev.stopPropagation();
+            onRenameStart();
+          }}
+          className="grid size-6 place-items-center rounded-md bg-background/70 text-muted-foreground backdrop-blur transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Pencil className="size-3.5" />
+        </button>
+      )}
+      <button
+        type="button"
+        aria-label={deleteLabel}
+        title={deleteLabel}
+        disabled={busy}
+        onClick={(ev) => {
+          ev.stopPropagation();
+          onDelete();
+        }}
+        className="grid size-6 place-items-center rounded-md bg-background/70 text-muted-foreground backdrop-blur transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-40"
+      >
+        <Trash2 className="size-3.5" />
+      </button>
     </div>
   );
 }
@@ -471,45 +542,21 @@ export function LibraryCard({
       }`}
     >
       {!editing && (
-        <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100">
-          {(isOrgContext ? folders.length > 0 : !isCloudOnly) && (
-            <MoveMenu
-              folders={folders}
-              currentFolderId={entry.folderId ?? null}
-              onMove={onMove}
-            />
-          )}
-          {canShare && (
-            <ShareMenu orgs={orgs} orgFolders={orgFolders} sharing={sharing} onPick={onShare} />
-          )}
-          {!isCloudOnly && !isOrgContext && (
-            <button
-              type="button"
-              aria-label={t("history.rename")}
-              title={t("history.rename")}
-              onClick={(ev) => {
-                ev.stopPropagation();
-                startEdit();
-              }}
-              className="grid size-6 place-items-center rounded-md bg-background/70 text-muted-foreground backdrop-blur transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <Pencil className="size-3.5" />
-            </button>
-          )}
-          <button
-            type="button"
-            aria-label={isOrgContext ? t("history.org.remove") : t("history.delete")}
-            title={isOrgContext ? t("history.org.remove") : t("history.delete")}
-            disabled={busy}
-            onClick={(ev) => {
-              ev.stopPropagation();
-              onDelete();
-            }}
-            className="grid size-6 place-items-center rounded-md bg-background/70 text-muted-foreground backdrop-blur transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-40"
-          >
-            <Trash2 className="size-3.5" />
-          </button>
-        </div>
+        <CardActions
+          entry={entry}
+          isOrgContext={isOrgContext}
+          isCloudOnly={isCloudOnly}
+          canShare={canShare}
+          orgs={orgs}
+          orgFolders={orgFolders}
+          busy={busy}
+          sharing={sharing}
+          folders={folders}
+          onDelete={onDelete}
+          onRenameStart={startEdit}
+          onShare={onShare}
+          onMove={onMove}
+        />
       )}
 
       {editing ? (

--- a/src/components/library/LibraryScreen.tsx
+++ b/src/components/library/LibraryScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ChevronRight, Folder, Loader2, Plus, RefreshCw, Search, UsersRound, X } from "lucide-react";
 import { toast } from "sonner";
 import { useI18n } from "../../i18n";
-import { useStore } from "../../lib/store";
+import { useStore, type LibrarySelection } from "../../lib/store";
 import {
   deleteHistoryEntry,
   loadHistoryEntry,
@@ -30,6 +30,7 @@ import { isTauri } from "../../lib/tauriEvents";
 import { VoiceTypingHistory } from "../../history/VoiceTypingHistory";
 import { LibraryCard, MoveDialog } from "./LibraryCards";
 import type { LibraryTree } from "../shell/useLibraryTree";
+import type { Folder as LocalFolder } from "../../lib/history/folders";
 import type { CloudOrg, CloudRecordingSummary } from "../../lib/cloud/types";
 
 const errText = (e: unknown) => (e instanceof Error ? e.message : String(e));
@@ -51,6 +52,49 @@ function orgCard(c: CloudRecordingSummary): HistoryCardItem {
     sync: "cloud",
     cloudUpdatedAt: c.updatedAt,
   };
+}
+
+type Translate = ReturnType<typeof useI18n>["t"];
+
+/** The name of the folder the selection points at, or null at a scope root. */
+function openFolderName(selection: LibrarySelection, folders: LocalFolder[]): string | null {
+  let id: string | null = null;
+  if (selection.kind === "org") id = selection.folderId;
+  else if (selection.kind === "personal" && selection.node.kind === "folder") {
+    id = selection.node.folderId;
+  }
+  if (!id) return null;
+  return folders.find((f) => f.id === id)?.name ?? null;
+}
+
+/** "Pathors AI / 和運租車" or "Pathors AI （根目錄）" — the dialog says exactly
+ *  where the copy is about to land. */
+function handoffTarget(
+  t: Translate,
+  prompt: Readonly<{ org: CloudOrg; folderId: string | null }> | null,
+  orgFolders: Record<string, LocalFolder[]>
+): string {
+  if (!prompt) return "";
+  const folder = prompt.folderId
+    ? (orgFolders[prompt.org.id] ?? []).find((f) => f.id === prompt.folderId)
+    : undefined;
+  if (folder) return `${prompt.org.name} / ${folder.name}`;
+  return `${prompt.org.name} ${t("history.move.rootLabel")}`;
+}
+
+/** Which "nothing here" copy fits the open scope. */
+function emptyStateCopy(
+  t: Translate,
+  scope: Readonly<{ searching: boolean; hasFolder: boolean; isOrg: boolean }>
+): { title: string; hint: string } {
+  if (scope.searching) {
+    return { title: t("history.searchEmpty"), hint: t("history.searchEmptyHint") };
+  }
+  if (scope.hasFolder) {
+    return { title: t("history.folder.empty"), hint: t("history.folder.emptyHint") };
+  }
+  if (scope.isOrg) return { title: t("history.org.empty"), hint: t("history.org.emptyHint") };
+  return { title: t("library.unassigned.empty"), hint: t("library.unassigned.emptyHint") };
 }
 
 /** "+ Import": the shared import flow (R7) — audio → ingest wizard, .txt →
@@ -333,37 +377,10 @@ export function LibraryScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
   }
 
   // ── Header identity: name the node the way the tree names it ──────────────
-  let folderName: string | null = null;
-  if (isOrg && selection.kind === "org" && selection.folderId) {
-    folderName = scopeFolders.find((f) => f.id === selection.folderId)?.name ?? null;
-  } else if (node?.kind === "folder") {
-    folderName = scopeFolders.find((f) => f.id === node.folderId)?.name ?? null;
-  }
-
+  const folderName = openFolderName(selection, scopeFolders);
   const searching = searchQuery.length > 0;
-
-  // "Pathors AI / 和運租車" or "Pathors AI （根目錄）" — the dialog says exactly
-  // where the copy is about to land.
-  let promptTarget = "";
-  if (movePrompt) {
-    const folder = movePrompt.folderId
-      ? (tree.orgFolders[movePrompt.org.id] ?? []).find((f) => f.id === movePrompt.folderId)
-      : undefined;
-    promptTarget = folder
-      ? `${movePrompt.org.name} / ${folder.name}`
-      : `${movePrompt.org.name} ${t("history.move.rootLabel")}`;
-  }
-  let emptyTitle: string;
-  if (searching) emptyTitle = t("history.searchEmpty");
-  else if (folderName) emptyTitle = t("history.folder.empty");
-  else if (isOrg) emptyTitle = t("history.org.empty");
-  else emptyTitle = t("library.unassigned.empty");
-
-  let emptyHint: string;
-  if (searching) emptyHint = t("history.searchEmptyHint");
-  else if (folderName) emptyHint = t("history.folder.emptyHint");
-  else if (isOrg) emptyHint = t("history.org.emptyHint");
-  else emptyHint = t("library.unassigned.emptyHint");
+  const promptTarget = handoffTarget(t, movePrompt, tree.orgFolders);
+  const empty = emptyStateCopy(t, { searching, hasFolder: !!folderName, isOrg });
 
   let body;
   if (entries === null) {
@@ -376,8 +393,8 @@ export function LibraryScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
   } else if (visible.length === 0) {
     body = (
       <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
-        <p className="text-sm text-muted-foreground">{emptyTitle}</p>
-        <p className="max-w-80 text-xs text-muted-foreground/70">{emptyHint}</p>
+        <p className="text-sm text-muted-foreground">{empty.title}</p>
+        <p className="max-w-80 text-xs text-muted-foreground/70">{empty.hint}</p>
       </div>
     );
   } else {
@@ -478,8 +495,12 @@ export function LibraryScreen({ tree }: Readonly<{ tree: LibraryTree }>) {
         <MoveDialog
           orgName={movePrompt.org.name}
           target={promptTarget}
-          onCopy={() => void resolveOrgHandoff("copy")}
-          onMove={() => void resolveOrgHandoff("move")}
+          onCopy={() => {
+            resolveOrgHandoff("copy").catch(() => {});
+          }}
+          onMove={() => {
+            resolveOrgHandoff("move").catch(() => {});
+          }}
           onCancel={() => setMovePrompt(null)}
         />
       )}

--- a/src/components/live/CoachFeed.tsx
+++ b/src/components/live/CoachFeed.tsx
@@ -77,6 +77,30 @@ interface AskCard {
   busy: boolean;
 }
 
+/** Replace one ask card by id, leaving the rest untouched. */
+function patchCard(cards: AskCard[], id: string, patch: Partial<AskCard>): AskCard[] {
+  return cards.map((x) => (x.id === id ? { ...x, ...patch } : x));
+}
+
+/** Append a streamed chunk to one ask card's answer. */
+function appendToCard(cards: AskCard[], id: string, chunk: string): AskCard[] {
+  return cards.map((x) => (x.id === id ? { ...x, answer: x.answer + chunk } : x));
+}
+
+/**
+ * The header upload button's other replacement: import from the idle feed —
+ * the shared flow (R7), so it takes .txt transcripts too, not just audio.
+ */
+async function importRecording() {
+  try {
+    const { startImportFlow } = await import("../../lib/replay/ingest");
+    await startImportFlow();
+  } catch (e) {
+    log.error("feed: import failed", { error: String(e) });
+    toast.error(e instanceof Error ? e.message : String(e));
+  }
+}
+
 /** Rotating ask-bar suggestions (same catalog the old Ask pane used). */
 const SUGGESTIONS = [
   "ask.suggestion.next",
@@ -172,9 +196,7 @@ export function CoachFeed({ onSeek }: Readonly<{ onSeek: (ms: number) => void }>
     setAskCards((c) => [...c, { id, question: q, answer: "", busy: true }]);
     const state = useStore.getState();
     if (!hasProviderKey(state.settings, "realtime")) {
-      setAskCards((c) =>
-        c.map((x) => (x.id === id ? { ...x, answer: t("ask.missingKey"), busy: false } : x))
-      );
+      setAskCards((c) => patchCard(c, id, { answer: t("ask.missingKey"), busy: false }));
       return;
     }
     try {
@@ -186,35 +208,19 @@ export function CoachFeed({ onSeek }: Readonly<{ onSeek: (ms: number) => void }>
         meetingContext: meetingBriefText(state),
         names: state.speakerNames,
         onDelta: (chunk) => {
-          setAskCards((c) =>
-            c.map((x) => (x.id === id ? { ...x, answer: x.answer + chunk } : x))
-          );
+          setAskCards((c) => appendToCard(c, id, chunk));
         },
       });
     } catch (e) {
       log.error("feed: ask failed", { error: String(e) });
-      setAskCards((c) =>
-        c.map((x) => (x.id === id ? { ...x, answer: String(e), busy: false } : x))
-      );
+      setAskCards((c) => patchCard(c, id, { answer: String(e), busy: false }));
     } finally {
-      setAskCards((c) => c.map((x) => (x.id === id ? { ...x, busy: false } : x)));
+      setAskCards((c) => patchCard(c, id, { busy: false }));
     }
   }
 
   const empty = findings.length === 0 && askCards.length === 0;
   const recording = useStore((s) => s.meetingStatus === "recording");
-
-  // The header upload button's other replacement: import from the idle feed —
-  // the shared flow (R7), so it takes .txt transcripts too, not just audio.
-  async function importRecording() {
-    try {
-      const { startImportFlow } = await import("../../lib/replay/ingest");
-      await startImportFlow();
-    } catch (e) {
-      log.error("feed: import failed", { error: String(e) });
-      toast.error(e instanceof Error ? e.message : String(e));
-    }
-  }
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/src/components/live/LiveScreen.tsx
+++ b/src/components/live/LiveScreen.tsx
@@ -57,7 +57,7 @@ export function LiveScreen() {
       layout === "coach" ? ["transcript", "feed", "todos"] : ["transcript", "findings"],
     [layout]
   );
-  const saved = useDefaultLayout({ id: "parley:live", panelIds, storage: window.localStorage });
+  const saved = useDefaultLayout({ id: "parley:live", panelIds, storage: globalThis.localStorage });
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/src/components/replay/ActionItemsPanel.tsx
+++ b/src/components/replay/ActionItemsPanel.tsx
@@ -56,7 +56,10 @@ export function ActionItemsPanel({
             <p className="px-1 pt-4 text-center text-xs text-muted-foreground">{t("actionItems.empty")}</p>
           )}
 
-          {items.map((a) => (
+          {items.map((a) => {
+            // Bound to a const so the seek callback keeps the non-null narrowing.
+            const atMs = a.atMs;
+            return (
             <div key={a.id} className="rounded-lg border px-2.5 py-2">
               <label className="flex cursor-pointer items-start gap-2">
                 <input
@@ -70,23 +73,24 @@ export function ActionItemsPanel({
                     {a.text}
                   </span>
                   <span className="mt-0.5 block text-[11px] leading-snug text-muted-foreground">{a.rationale}</span>
-                  {a.atMs !== null && (
+                  {atMs !== null && (
                     <button
                       type="button"
                       onClick={(e) => {
                         e.preventDefault();
-                        onSeek(a.atMs!);
+                        onSeek(atMs);
                       }}
                       className="mt-1 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
                     >
                       <span className={cn("size-2 rounded-full", a.severity ? SEVERITY_DOT[a.severity] : "bg-muted-foreground")} />
-                      <span className="font-mono tabular-nums">{formatClock(a.atMs)}</span>
+                      <span className="font-mono tabular-nums">{formatClock(atMs)}</span>
                     </button>
                   )}
                 </span>
               </label>
             </div>
-          ))}
+            );
+          })}
 
       {/* Still streaming, but rows are already showing. */}
       {!keyMissing && running && items.length > 0 && (

--- a/src/components/replay/ReplayScreen.tsx
+++ b/src/components/replay/ReplayScreen.tsx
@@ -54,7 +54,7 @@ export function ReplayScreen() {
   // Persist the dragged column proportions (transcript / findings) to
   // localStorage so they survive reloads. v2 id: the old key stored a 3-column
   // layout that no longer matches this 2-panel group.
-  const saved = useDefaultLayout({ id: "parley:replay-v2", storage: window.localStorage });
+  const saved = useDefaultLayout({ id: "parley:replay-v2", storage: globalThis.localStorage });
 
   if (!session) {
     return (

--- a/src/components/replay/ReplayTranscript.tsx
+++ b/src/components/replay/ReplayTranscript.tsx
@@ -115,8 +115,8 @@ export function ReplayTranscript({
         });
       }
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    globalThis.addEventListener("keydown", onKeyDown);
+    return () => globalThis.removeEventListener("keydown", onKeyDown);
   }, [preview]);
 
   // Typing a new query restarts at the first match.

--- a/src/components/replay/VoiceDiarizeDialog.tsx
+++ b/src/components/replay/VoiceDiarizeDialog.tsx
@@ -125,7 +125,31 @@ export function VoiceDiarizeDialog({ onClose }: Readonly<{ onClose: () => void }
         </div>
 
         <div className="flex min-h-0 flex-col gap-3 overflow-y-auto px-4 py-3.5">
-          {!named ? (
+          {named ? (
+            <>
+              <p className="text-[12px] leading-relaxed text-muted-foreground">
+                {t("speakers.voiceFound", { speakers: speakers.length })}
+              </p>
+              <div className="flex flex-col gap-2.5">
+                {speakers.map((sp) => (
+                  <div key={sp.key} className="flex items-start gap-2">
+                    <span className={`mt-2.5 size-2 shrink-0 rounded-full ${speakerDotClass(sp)}`} />
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <Input
+                        value={speakerNames[sp.key] ?? ""}
+                        onChange={(e) => setSpeakerName(sp.key, e.target.value)}
+                        placeholder={defaultSpeakerLabel(sp)}
+                        className="h-8 text-sm"
+                      />
+                      <span className="truncate text-[11px] text-muted-foreground" title={sp.sample}>
+                        “{sp.sample}”
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
             <>
               <p className="text-[12px] leading-relaxed text-muted-foreground">{t("speakers.voiceIntro")}</p>
 
@@ -161,35 +185,15 @@ export function VoiceDiarizeDialog({ onClose }: Readonly<{ onClose: () => void }
                 </p>
               )}
             </>
-          ) : (
-            <>
-              <p className="text-[12px] leading-relaxed text-muted-foreground">
-                {t("speakers.voiceFound", { speakers: speakers.length })}
-              </p>
-              <div className="flex flex-col gap-2.5">
-                {speakers.map((sp) => (
-                  <div key={sp.key} className="flex items-start gap-2">
-                    <span className={`mt-2.5 size-2 shrink-0 rounded-full ${speakerDotClass(sp)}`} />
-                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <Input
-                        value={speakerNames[sp.key] ?? ""}
-                        onChange={(e) => setSpeakerName(sp.key, e.target.value)}
-                        placeholder={defaultSpeakerLabel(sp)}
-                        className="h-8 text-sm"
-                      />
-                      <span className="truncate text-[11px] text-muted-foreground" title={sp.sample}>
-                        “{sp.sample}”
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
           )}
         </div>
 
         <div className="flex justify-end gap-2 border-t px-4 py-3">
-          {!named ? (
+          {named ? (
+            <Button size="sm" className="h-8" onClick={onClose}>
+              {t("speakers.voiceDone")}
+            </Button>
+          ) : (
             <>
               <button
                 type="button"
@@ -209,10 +213,6 @@ export function VoiceDiarizeDialog({ onClose }: Readonly<{ onClose: () => void }
                 {busy ? t("speakers.voiceRunning") : t("speakers.voiceRun")}
               </Button>
             </>
-          ) : (
-            <Button size="sm" className="h-8" onClick={onClose}>
-              {t("speakers.voiceDone")}
-            </Button>
           )}
         </div>
       </div>

--- a/src/components/replay/spine.ts
+++ b/src/components/replay/spine.ts
@@ -11,7 +11,7 @@ import { useStore, type ReplayTrim } from "../../lib/store";
 // Canonical contract published by the ingest module.
 import type { ReplaySession } from "../../lib/replay/types";
 
-export type { ReplaySession };
+export type { ReplaySession } from "../../lib/replay/types";
 
 export function useAppMode(): "live" | "replay" {
   // The library route never hosts a replay spine; treat it as live for the

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -34,7 +34,7 @@ export function AppShell() {
   const saved = useDefaultLayout({
     id: "parley:shell",
     panelIds: ["tree", "route"],
-    storage: window.localStorage,
+    storage: globalThis.localStorage,
   });
 
   if (focused) {

--- a/src/components/shell/AppSidebar.tsx
+++ b/src/components/shell/AppSidebar.tsx
@@ -17,6 +17,8 @@ import { beginMeeting } from "../../lib/meeting/start";
 import { useStore, type LibrarySelection } from "../../lib/store";
 import { useI18n } from "../../i18n";
 import type { LibraryTree } from "./useLibraryTree";
+import type { Folder as LocalFolder } from "../../lib/history/folders";
+import type { CloudOrg } from "../../lib/cloud/types";
 
 /**
  * The one tree (issue #195).
@@ -161,32 +163,19 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
                 />
                 {open &&
                   (tree.orgFolders[o.id] ?? []).map((f) => (
-                    <Row
+                    <OrgFolderRow
                       key={f.id}
-                      depth={1}
-                      icon={<Folder className="size-3.5" />}
-                      label={f.name}
+                      tree={tree}
+                      org={o}
+                      folder={f}
                       active={libraryActive && orgSel?.id === o.id && orgSel.folderId === f.id}
                       onSelect={() =>
                         selectLibrary({ kind: "org", id: o.id, name: o.name, folderId: f.id })
                       }
-                      onRename={(name) => {
-                        tree.renameOrgFolder(o.id, f.id, name).catch(() => {});
-                      }}
-                      onDelete={() => {
-                        tree
-                          .deleteOrgFolder(o.id, f)
-                          .then((deleted) => {
-                            if (deleted && orgSel?.id === o.id && orgSel.folderId === f.id) {
-                              selectLibrary({
-                                kind: "org",
-                                id: o.id,
-                                name: o.name,
-                                folderId: null,
-                              });
-                            }
-                          })
-                          .catch(() => {});
+                      onDeleted={() => {
+                        if (orgSel?.id === o.id && orgSel.folderId === f.id) {
+                          selectLibrary({ kind: "org", id: o.id, name: o.name, folderId: null });
+                        }
                       }}
                     />
                   ))}
@@ -216,6 +205,48 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
       )}
 
     </nav>
+  );
+}
+
+/**
+ * One shared folder under an org. Its own component so the rename/delete
+ * promise handlers don't sit five callbacks deep inside the org list.
+ */
+function OrgFolderRow({
+  tree,
+  org,
+  folder,
+  active,
+  onSelect,
+  onDeleted,
+}: Readonly<{
+  tree: LibraryTree;
+  org: CloudOrg;
+  folder: LocalFolder;
+  active: boolean;
+  onSelect: () => void;
+  /** Called only when the delete actually went through. */
+  onDeleted: () => void;
+}>) {
+  return (
+    <Row
+      depth={1}
+      icon={<Folder className="size-3.5" />}
+      label={folder.name}
+      active={active}
+      onSelect={onSelect}
+      onRename={(name) => {
+        tree.renameOrgFolder(org.id, folder.id, name).catch(() => {});
+      }}
+      onDelete={() => {
+        tree
+          .deleteOrgFolder(org.id, folder)
+          .then((deleted) => {
+            if (deleted) onDeleted();
+          })
+          .catch(() => {});
+      }}
+    />
   );
 }
 

--- a/src/components/shell/useLibraryTree.ts
+++ b/src/components/shell/useLibraryTree.ts
@@ -202,7 +202,7 @@ export function useLibraryTree(): LibraryTree {
 
   const deletePersonalFolder = useCallback(
     (folder: LocalFolder) => {
-      if (!window.confirm(t("history.folder.deleteConfirm", { name: folder.name }))) return;
+      if (!globalThis.confirm(t("history.folder.deleteConfirm", { name: folder.name }))) return;
       deleteLocalFolder(folder.id);
       setPersonalFolders(listLocalFolders());
       if (CLOUD_ENABLED && syncEnabled()) {
@@ -247,7 +247,8 @@ export function useLibraryTree(): LibraryTree {
    *  a selection that pointed at it). */
   const deleteOrgFolderUI = useCallback(
     async (orgId: string, folder: LocalFolder) => {
-      if (!window.confirm(t("history.folder.deleteConfirm", { name: folder.name }))) return false;
+      if (!globalThis.confirm(t("history.folder.deleteConfirm", { name: folder.name })))
+        return false;
       try {
         await deleteOrgFolder(orgId, folder.id);
         ensureOrgFolders(orgId, true);

--- a/src/components/study/StudyGenerationChip.tsx
+++ b/src/components/study/StudyGenerationChip.tsx
@@ -172,16 +172,18 @@ export function StudyGenerationChip() {
 type TFn = ReturnType<typeof useI18n>["t"];
 type Pipeline = ReturnType<typeof useStudyPipeline>;
 
+/** Chip tone, in priority order: missing key → running → errors → idle. */
+function chipTone(p: Pipeline): string {
+  if (!p.hasDeepKey) return "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400";
+  if (p.active) return "border-violet-500/40 bg-violet-500/10 text-violet-600 dark:text-violet-400";
+  if (p.errors > 0) return "border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400";
+  return "border-transparent text-muted-foreground hover:border-border hover:text-foreground";
+}
+
 function chipClass(p: Pipeline): string {
   return cn(
     "flex h-6 items-center gap-1.5 rounded-full border px-2.5 text-[11px] font-medium transition-colors",
-    !p.hasDeepKey
-      ? "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
-      : p.active
-        ? "border-violet-500/40 bg-violet-500/10 text-violet-600 dark:text-violet-400"
-        : p.errors > 0
-          ? "border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400"
-          : "border-transparent text-muted-foreground hover:border-border hover:text-foreground",
+    chipTone(p),
   );
 }
 

--- a/src/components/ui/flag.tsx
+++ b/src/components/ui/flag.tsx
@@ -6,7 +6,7 @@ import { cn } from "../../lib/utils";
  * no CDN or runtime library. Renders nothing for an unknown/empty code so it
  * degrades gracefully next to the text label.
  */
-export function Flag({ code, className }: { code?: string; className?: string }) {
+export function Flag({ code, className }: Readonly<{ code?: string; className?: string }>) {
   if (!code) return null;
   return (
     <img

--- a/src/diagnostics/DiagnosticsApp.tsx
+++ b/src/diagnostics/DiagnosticsApp.tsx
@@ -112,10 +112,10 @@ export function DiagnosticsApp() {
         .catch((e) => log.warn("diagnostics: read_log_tail failed", { error: String(e) }));
     };
     tick();
-    const timer = window.setInterval(tick, POLL_MS);
+    const timer = globalThis.setInterval(tick, POLL_MS);
     return () => {
       alive = false;
-      window.clearInterval(timer);
+      globalThis.clearInterval(timer);
     };
   }, []);
 

--- a/src/finding-solution/FindingSolutionApp.tsx
+++ b/src/finding-solution/FindingSolutionApp.tsx
@@ -99,8 +99,8 @@ export function FindingSolutionApp() {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") dismiss().catch((error) => log.error("finding-solution: dismiss failed", { error: String(error) }));
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    globalThis.addEventListener("keydown", onKey);
+    return () => globalThis.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/ai/timeline.ts
+++ b/src/lib/ai/timeline.ts
@@ -111,9 +111,9 @@ export function parseClockMs(raw: string | undefined): number | null {
   if (!m) return null;
   const a = Number(m[1]);
   const b = Number(m[2]);
-  const c = m[3] !== undefined ? Number(m[3]) : null;
-  // [h:mm:ss] vs [m:ss]
-  const totalSec = c !== null ? a * 3600 + b * 60 + c : a * 60 + b;
+  const c = m[3] === undefined ? null : Number(m[3]);
+  // [m:ss] vs [h:mm:ss]
+  const totalSec = c === null ? a * 60 + b : a * 3600 + b * 60 + c;
   if (!Number.isFinite(totalSec)) return null;
   return totalSec * 1000;
 }

--- a/src/lib/analysis/delivery.ts
+++ b/src/lib/analysis/delivery.ts
@@ -74,7 +74,7 @@ export interface DeliveryThresholds {
 export const DEFAULT_THRESHOLDS: DeliveryThresholds = {
   calibrationSec: 30,
   paceZ: 1.5,
-  paceAbsHz: 4.0,
+  paceAbsHz: 4,
   monotoneSemitones: 1.2,
   monotoneMinVoiced: 0.55,
   deadAirMs: 6000,

--- a/src/lib/analysis/engine.ts
+++ b/src/lib/analysis/engine.ts
@@ -8,7 +8,15 @@ import { clearStudyCache } from "../history/studyCache";
 import { makeRunGuard } from "./runGuard";
 import { translate } from "../../i18n";
 import { isTauri } from "../tauriEvents";
-import type { EvalDef, Settings, TimelineEvent, TranscriptSegment } from "../types";
+import type {
+  DeliveryAssessment,
+  EvalDef,
+  LlmWorkload,
+  Settings,
+  TimelineEvent,
+  ToneVerdict,
+  TranscriptSegment,
+} from "../types";
 
 /** Bump when the analysis prompt/output shape changes, to invalidate caches. */
 const ANALYSIS_CACHE_VERSION = "7";
@@ -71,6 +79,49 @@ export async function listenForCacheClear(): Promise<() => void> {
   });
 }
 
+type AnalysisMode = "live" | "replay";
+type StoreState = ReturnType<typeof useStore.getState>;
+
+/** LIVE vs REPLAY for this run: an explicit request wins, else the app mode. */
+function resolveMode(state: StoreState, requested?: AnalysisMode): AnalysisMode {
+  if (requested) return requested;
+  return state.appMode === "study" ? "replay" : "live";
+}
+
+/** REPLAY honors the trim keep-window — trimmed segments are excluded. */
+function segmentsForMode(state: StoreState, mode: AnalysisMode): TranscriptSegment[] {
+  if (mode === "replay") return state.segments.filter((s) => !isTrimmed(s, state.replayTrim));
+  return state.segments;
+}
+
+/** Replay analyses ride the deep lane; live ones the realtime lane. */
+function workloadForMode(mode: AnalysisMode): LlmWorkload {
+  return mode === "replay" ? "deep" : "realtime";
+}
+
+/** Apply a cached replay analysis, if there is one. True when it was applied. */
+function applyCachedAnalysis(cacheKey: string, evalSig: string): boolean {
+  const cached = readJsonCache<TimelineEvent[]>(cacheKey);
+  if (!cached) return false;
+  const state = useStore.getState();
+  state.setFindings(cached);
+  state.setAnalysisStatus("done");
+  useStore.setState({ analyzedEvalSig: evalSig });
+  return true;
+}
+
+/** The message the UI shows for a failed pass — hosted credit/auth exhaustion
+ *  gets its own copy, everything else falls back to the raw provider error. */
+async function analysisErrorMessage(err: unknown, provider: string): Promise<string> {
+  const { describeAiError, hostedLlmErrorCode } = await import("../ai/errors");
+  const { translate } = await import("../../i18n/messages");
+  const code = hostedLlmErrorCode(err, provider);
+  const lang = useStore.getState().settings.language;
+  if (code === "credits") return translate(lang, "analysis.error.credits");
+  if (code === "auth") return translate(lang, "analysis.error.auth");
+  return describeAiError(err);
+}
+
 /**
  * Run the unified analysis over the current transcript and write time-anchored
  * findings into the shared store slice. Used by LIVE's "Analyze" button (mode
@@ -83,17 +134,14 @@ export async function listenForCacheClear(): Promise<() => void> {
  */
 const analysisGuard = makeRunGuard();
 export async function runAnalysis(opts?: {
-  mode?: "live" | "replay";
+  mode?: AnalysisMode;
   force?: boolean;
 }): Promise<void> {
   const state = useStore.getState();
   const { settings, speakerNames } = state;
-  const mode = opts?.mode ?? (state.appMode === "study" ? "replay" : "live");
-  // REPLAY: honor the trim keep-window — trimmed segments are excluded from analysis.
-  const segments =
-    mode === "replay" ? state.segments.filter((s) => !isTrimmed(s, state.replayTrim)) : state.segments;
-
-  const workload = mode === "replay" ? ("deep" as const) : ("realtime" as const);
+  const mode = resolveMode(state, opts?.mode);
+  const segments = segmentsForMode(state, mode);
+  const workload = workloadForMode(mode);
 
   // Reentrancy guard: the status IS the lock (set synchronously below, so two
   // back-to-back calls can't interleave — JS is single-threaded between awaits).
@@ -117,15 +165,7 @@ export async function runAnalysis(opts?: {
   // Remember which eval set these findings reflect, so the UI can flag them as
   // stale when the template / evals change before the next re-analysis.
   const evalSig = evalSignature(settings.evaluations);
-  if (cacheKey && !opts?.force) {
-    const cached = readJsonCache<TimelineEvent[]>(cacheKey);
-    if (cached) {
-      state.setFindings(cached);
-      state.setAnalysisStatus("done");
-      useStore.setState({ analyzedEvalSig: evalSig });
-      return;
-    }
-  }
+  if (cacheKey && !opts?.force && applyCachedAnalysis(cacheKey, evalSig)) return;
 
   const alive = analysisGuard.begin();
   state.setAnalysisError(null);
@@ -153,16 +193,7 @@ export async function runAnalysis(opts?: {
   } catch (err) {
     console.error("[analysis]", err);
     if (!alive()) return;
-    const { describeAiError, hostedLlmErrorCode } = await import("../ai/errors");
-    const { translate } = await import("../../i18n/messages");
-    const code = hostedLlmErrorCode(err, settings.llmProviders[workload]);
-    const lang = useStore.getState().settings.language;
-    const message =
-      code === "credits"
-        ? translate(lang, "analysis.error.credits")
-        : code === "auth"
-          ? translate(lang, "analysis.error.auth")
-          : describeAiError(err);
+    const message = await analysisErrorMessage(err, settings.llmProviders[workload]);
     useStore.getState().setAnalysisError(message);
     useStore.getState().setAnalysisStatus("error");
   }
@@ -178,6 +209,35 @@ export async function runAnalysis(opts?: {
 const TONE_COOLDOWN_MS = 15_000;
 /** New finalized speech (ms) required since the last tone check before re-running. */
 const TONE_MIN_NEW_SPEECH_MS = 2_000;
+
+/**
+ * Store a fresh delivery assessment and raise at most ONE nudge from it: tone
+ * first when it's sharp/aggressive/rude, otherwise over-frequent fillers — the
+ * two never stack.
+ */
+function applyDeliveryAssessment(
+  res: DeliveryAssessment,
+  toneFlagged: ReadonlySet<ToneVerdict>
+): void {
+  const store = useStore.getState();
+  store.setDeliveryAssessment(res);
+  const lang = store.settings.language;
+  if (toneFlagged.has(res.tone)) {
+    store.pushDeliveryNudge({
+      kind: "tone",
+      severity: res.tone === "sharp" ? "info" : "warn",
+      message: translate(lang, "delivery.nudge.tone"),
+      evidence: res.toneEvidence || undefined,
+    });
+  } else if (res.fillers.level === "frequent") {
+    store.pushDeliveryNudge({
+      kind: "filler",
+      severity: "info",
+      message: translate(lang, "delivery.nudge.filler"),
+      evidence: res.fillers.examples.slice(0, 3).join("、") || undefined,
+    });
+  }
+}
 
 export function useAnalysisEngine() {
   const meetingStatus = useStore((s) => s.meetingStatus);
@@ -252,33 +312,16 @@ export function useAnalysisEngine() {
         toneBusy.current = true;
         const prosody = useStore.getState().prosody;
         import("../ai/delivery")
-          .then(({ analyzeDelivery, TONE_FLAGGED }) =>
-            analyzeDelivery({ settings, segments, names: speakerNames, prosody, mode: "live" }).then(
-              (res) => {
-                if (!res) return;
-                const store = useStore.getState();
-                store.setDeliveryAssessment(res);
-                const lang = store.settings.language;
-                // Tone nudge when sharp/aggressive/rude.
-                if (TONE_FLAGGED.has(res.tone)) {
-                  store.pushDeliveryNudge({
-                    kind: "tone",
-                    severity: res.tone === "sharp" ? "info" : "warn",
-                    message: translate(lang, "delivery.nudge.tone"),
-                    evidence: res.toneEvidence || undefined,
-                  });
-                } else if (res.fillers.level === "frequent") {
-                  // Otherwise, nudge on over-frequent fillers (don't stack two).
-                  store.pushDeliveryNudge({
-                    kind: "filler",
-                    severity: "info",
-                    message: translate(lang, "delivery.nudge.filler"),
-                    evidence: res.fillers.examples.slice(0, 3).join("、") || undefined,
-                  });
-                }
-              }
-            )
-          )
+          .then(async ({ analyzeDelivery, TONE_FLAGGED }) => {
+            const res = await analyzeDelivery({
+              settings,
+              segments,
+              names: speakerNames,
+              prosody,
+              mode: "live",
+            });
+            if (res) applyDeliveryAssessment(res, TONE_FLAGGED);
+          })
           .catch((e) => console.error("[delivery]", e))
           .finally(() => {
             toneBusy.current = false;

--- a/src/lib/analysis/studyPipeline.ts
+++ b/src/lib/analysis/studyPipeline.ts
@@ -279,17 +279,22 @@ export function chainQueued(
  * ("while anything is missing, every artifact is visibly either generating,
  * queued, or failed") falls out of the same facts the scheduler acts on.
  */
+/** An untouched ("idle") artifact reads QUEUED while a run is still coming. */
+function displayStatus(status: AsyncTaskStatus, queued: boolean): StudyArtifactDisplay {
+  if (status === "idle") return queued ? "queued" : "idle";
+  return status;
+}
+
 export function deriveStudyPipeline(f: StudyPipelineFacts): StudyPipelineState {
   // "queued" is a promise that the scheduler WILL dispatch. With auto-analysis
   // off nothing is coming, so every untouched artifact reads idle rather than
   // queuing forever against a pipeline that will never run.
   const can = f.autoAnalyze && f.hasDeepKey && f.hasTranscript;
 
-  const findings: StudyArtifactDisplay =
-    f.analysisStatus !== "idle" ? f.analysisStatus : can ? "queued" : "idle";
+  const findings = displayStatus(f.analysisStatus, can);
 
   const chained = (status: AsyncTaskStatus): StudyArtifactDisplay =>
-    status !== "idle" ? status : chainQueued(f) ? "queued" : "idle";
+    displayStatus(status, chainQueued(f));
 
   const artifacts: StudyArtifactState[] = [
     { key: "findings", display: findings },

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -26,7 +26,7 @@ export function clearCacheByPrefix(prefix: string): number {
   try {
     for (let i = localStorage.length - 1; i >= 0; i--) {
       const k = localStorage.key(i);
-      if (k && k.startsWith(prefix)) {
+      if (k?.startsWith(prefix)) {
         localStorage.removeItem(k);
         removed++;
       }

--- a/src/lib/cloud/client.ts
+++ b/src/lib/cloud/client.ts
@@ -55,7 +55,8 @@ export async function signInWithGoogle(signal?: AbortSignal): Promise<void> {
     signal?.addEventListener("abort", onAbort);
 
     listen<{ token?: string; error?: string }>("auth://callback", (e) => {
-      if (e.payload.token) settle(() => resolve(e.payload.token!));
+      const received = e.payload.token;
+      if (received) settle(() => resolve(received));
       else settle(() => reject(new Error(e.payload.error || "sign-in failed")));
     }).then((fn) => {
       unlisten = fn;

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -13,7 +13,7 @@ const VIEW_LOGS_MENU = "menu://view-logs";
  */
 export async function openDiagnosticsWindow(): Promise<void> {
   if (!isTauri()) {
-    window.location.hash = "diagnostics";
+    globalThis.location.hash = "diagnostics";
     return;
   }
   const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");

--- a/src/lib/dictionary/diffCorrection.ts
+++ b/src/lib/dictionary/diffCorrection.ts
@@ -17,7 +17,7 @@ const MIN_INSERTED_LENGTH = 2;
 /** Replacing more than this share of what we pasted is a rewrite, not a fix. */
 const REWRITE_RATIO = 0.4;
 
-const WORD_CHAR = /[A-Za-z0-9_]/;
+const WORD_CHAR = /\w/;
 
 function isWord(cp: string | undefined): boolean {
   return !!cp && WORD_CHAR.test(cp);
@@ -44,28 +44,7 @@ export function detectCorrection(
 
   const a = [...baseline];
   const b = [...current];
-  const max = Math.min(a.length, b.length);
-
-  let start = 0;
-  while (start < max && a[start] === b[start]) start++;
-  let suffix = 0;
-  while (suffix < max - start && a[a.length - 1 - suffix] === b[b.length - 1 - suffix]) suffix++;
-  let endA = a.length - suffix;
-  let endB = b.length - suffix;
-
-  // The common prefix/suffix happily stops mid-word: editing "Parle" into
-  // "Parley" shares everything but the trailing "y", which on its own reads as
-  // a pure insertion. When a boundary cuts an ASCII word, push it out to the
-  // word's edge so the pair becomes the whole word on each side.
-  if (cutsWordAtStart(a, b, start, endA, endB)) {
-    while (start > 0 && isWord(a[start - 1])) start--;
-  }
-  if (cutsWordAtEnd(a, b, start, endA, endB)) {
-    while (endA < a.length && endB < b.length && isWord(a[endA])) {
-      endA++;
-      endB++;
-    }
-  }
+  const { start, endA, endB } = editSpan(a, b);
 
   const from = a.slice(start, endA).join("").trim();
   const to = b.slice(start, endB).join("").trim();
@@ -82,6 +61,41 @@ export function detectCorrection(
   if (from.length > REWRITE_RATIO * insertedText.length) return null;
 
   return { from, to };
+}
+
+/**
+ * The one stretch where `a` and `b` differ: the shared prefix stripped off the
+ * front, the shared suffix off the back.
+ *
+ * Those boundaries happily stop mid-word: editing "Parle" into "Parley" shares
+ * everything but the trailing "y", which on its own reads as a pure insertion.
+ * When a boundary cuts an ASCII word, push it out to the word's edge so the
+ * pair becomes the whole word on each side.
+ */
+function editSpan(
+  a: readonly string[],
+  b: readonly string[],
+): { start: number; endA: number; endB: number } {
+  const max = Math.min(a.length, b.length);
+
+  let start = 0;
+  while (start < max && a[start] === b[start]) start++;
+  let suffix = 0;
+  while (suffix < max - start && a[a.length - 1 - suffix] === b[b.length - 1 - suffix]) suffix++;
+  let endA = a.length - suffix;
+  let endB = b.length - suffix;
+
+  if (cutsWordAtStart(a, b, start, endA, endB)) {
+    while (start > 0 && isWord(a[start - 1])) start--;
+  }
+  if (cutsWordAtEnd(a, b, start, endA, endB)) {
+    while (endA < a.length && endB < b.length && isWord(a[endA])) {
+      endA++;
+      endB++;
+    }
+  }
+
+  return { start, endA, endB };
 }
 
 /** True when the leading boundary sits inside an ASCII word: the shared char

--- a/src/lib/dictionary/index.ts
+++ b/src/lib/dictionary/index.ts
@@ -282,9 +282,9 @@ export function updateEntry(
     ...file,
     entries: file.entries.map((e) => {
       if (e.id !== id) return e;
-      const phrase = patch.phrase !== undefined ? patch.phrase.trim() : e.phrase;
+      const phrase = patch.phrase === undefined ? e.phrase : patch.phrase.trim();
       const variants =
-        patch.variants !== undefined ? cleanVariants(patch.variants, phrase) : e.variants;
+        patch.variants === undefined ? e.variants : cleanVariants(patch.variants, phrase);
       return { ...e, phrase, variants, source: patch.source ?? e.source };
     }),
   });
@@ -341,11 +341,36 @@ export function vocabularyTerms(): string[] {
 }
 
 const ASCII_ONLY = /^[\x00-\x7F]+$/;
-const WORD_EDGE_START = /^[A-Za-z0-9_]/;
-const WORD_EDGE_END = /[A-Za-z0-9_]$/;
+const WORD_EDGE_START = /^\w/;
+const WORD_EDGE_END = /\w$/;
 
 function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return s.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+/** Every (variant → phrase) rewrite on file, longest variant first: with both
+ *  "Parley" and "Parley Cloud" known, the longer one has to win. */
+function replacementPairs(
+  entries: readonly DictionaryEntry[],
+): { variant: string; phrase: string }[] {
+  const pairs: { variant: string; phrase: string }[] = [];
+  for (const e of entries) {
+    const phrase = e.phrase.trim();
+    if (!phrase) continue;
+    for (const variant of e.variants) {
+      if (variant.trim()) pairs.push({ variant, phrase });
+    }
+  }
+  pairs.sort((a, b) => b.variant.length - a.variant.length);
+  return pairs;
+}
+
+/** Case-insensitive matcher for an ASCII variant, asserting a word boundary on
+ *  whichever sides actually start/end with a word character. */
+function asciiVariantRe(variant: string): RegExp {
+  const before = WORD_EDGE_START.test(variant) ? "(?<![A-Za-z0-9_])" : "";
+  const after = WORD_EDGE_END.test(variant) ? "(?![A-Za-z0-9_])" : "";
+  return new RegExp(`${before}${escapeRegExp(variant)}${after}`, "gi");
 }
 
 /**
@@ -367,22 +392,11 @@ export function applyReplacements(
   entries: readonly DictionaryEntry[] = listEntries(),
 ): string {
   if (!text) return text;
-  const pairs: { variant: string; phrase: string }[] = [];
-  for (const e of entries) {
-    const phrase = e.phrase.trim();
-    if (!phrase) continue;
-    for (const variant of e.variants) {
-      if (variant.trim()) pairs.push({ variant, phrase });
-    }
-  }
-  pairs.sort((a, b) => b.variant.length - a.variant.length);
   let out = text;
-  for (const { variant, phrase } of pairs) {
+  for (const { variant, phrase } of replacementPairs(entries)) {
     if (ASCII_ONLY.test(variant)) {
-      const before = WORD_EDGE_START.test(variant) ? "(?<![A-Za-z0-9_])" : "";
-      const after = WORD_EDGE_END.test(variant) ? "(?![A-Za-z0-9_])" : "";
       // A function replacer, so a `$` in the phrase stays literal.
-      out = out.replace(new RegExp(`${before}${escapeRegExp(variant)}${after}`, "gi"), () => phrase);
+      out = out.replace(asciiVariantRe(variant), () => phrase);
     } else {
       out = out.split(variant).join(phrase);
     }

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -26,7 +26,12 @@ import type { OrgHandoffMode } from "../library/destination";
 import { rediarizeSegments } from "../speakers/postDiarize";
 import { translate } from "../../i18n/messages";
 import type { ReplaySession } from "../replay/types";
-import type { ActionItem, TimelineEvent, TranscriptSegment } from "../types";
+import type {
+  ActionItem,
+  DefaultSaveLocation,
+  TimelineEvent,
+  TranscriptSegment,
+} from "../types";
 import type { HistoryEntry, HistoryEntrySummary } from "./types";
 
 const HISTORY_UPDATED_EVENT = "history://updated";
@@ -190,6 +195,20 @@ export type MeetingShare = OrgShareChoice | "off" | null;
  * shared copy (this call's pick, else the settings default). A shared copy is a
  * second destination, never a move — the local entry always lands.
  */
+/** The org share this meeting asks for, before the cloud/sync gate: the
+ *  meeting's own pick, else the settings default. `"off"` suppresses both. */
+function wantedOrgShare(
+  meetingOrgShare: MeetingShare,
+  def: DefaultSaveLocation,
+): OrgShareChoice | null {
+  if (meetingOrgShare === "off") return null;
+  if (meetingOrgShare) return meetingOrgShare;
+  if (def.scope === "org" && def.orgId) {
+    return { orgId: def.orgId, folderId: def.folderId ?? null, mode: "copy" };
+  }
+  return null;
+}
+
 export function resolveMeetingSave(): MeetingSaveTarget {
   const s = useStore.getState();
   const def = s.settings.defaultSaveLocation;
@@ -202,16 +221,7 @@ export function resolveMeetingSave(): MeetingSaveTarget {
     origin: picked ? "meeting" : "default",
   };
 
-  let wanted: OrgShareChoice | null = null;
-  if (s.meetingOrgShare === "off") {
-    wanted = null;
-  } else if (s.meetingOrgShare) {
-    wanted = s.meetingOrgShare;
-  } else {
-    if (def.scope === "org" && def.orgId) {
-      wanted = { orgId: def.orgId, folderId: def.folderId ?? null, mode: "copy" };
-    }
-  }
+  const wanted = wantedOrgShare(s.meetingOrgShare, def);
   if (!wanted) return base;
   // An org share needs the cloud edition, signed in, sync on.
   if (!CLOUD_ENABLED || !syncEnabled()) return { ...base, fallback: "syncOff" };
@@ -610,7 +620,7 @@ export async function updateEntryMeta(id: string, patch: EntryMetaPatch): Promis
     : meta.speakerNames;
   const updated: HistoryEntry = {
     ...meta,
-    ...(patch.meetingContext !== undefined ? { meetingContext: patch.meetingContext } : {}),
+    ...(patch.meetingContext === undefined ? {} : { meetingContext: patch.meetingContext }),
     speakerNames,
   };
   await invoke("save_history_entry", {
@@ -673,8 +683,8 @@ export async function setEntryAnalysis(
     ...meta,
     ...(patch.findings ? { findings: patch.findings } : {}),
     ...(patch.actionItems ? { actionItems: patch.actionItems } : {}),
-    ...(patch.brief !== undefined ? { brief: patch.brief } : {}),
-    ...(patch.analyzed !== undefined ? { analyzed: patch.analyzed } : {}),
+    ...(patch.brief === undefined ? {} : { brief: patch.brief }),
+    ...(patch.analyzed === undefined ? {} : { analyzed: patch.analyzed }),
   };
   await invoke("save_history_entry", {
     id,
@@ -719,6 +729,45 @@ export async function setEntryAnalysis(
  *
  * Idempotent, no flag, no cloud push of entries (a push re-uploads audio).
  */
+/** Refile one saved recording onto the surviving folder. Returns false when the
+ *  entry couldn't be rewritten — logged, never fatal: the sweep goes on. */
+async function repointEntryFolder(id: string, target: string): Promise<boolean> {
+  try {
+    const { meta } = await invoke<HistoryReadResult>("read_history_entry", { id });
+    const updated: HistoryEntry = { ...meta, folderId: target };
+    await invoke("save_history_entry", {
+      id,
+      summaryJson: JSON.stringify(buildSummary(updated)),
+      metaJson: JSON.stringify(updated),
+      audioSourcePath: null, // leave the recording untouched
+      compress: false,
+    });
+    return true;
+  } catch (e) {
+    log.warn("history: folder dedupe failed for entry", { id, error: String(e) });
+    return false;
+  }
+}
+
+/** Refile every recording filed in a twin folder onto its survivor. `swept` is
+ *  false when the pass itself failed, so the twins must be kept for now. */
+async function repointRecordings(
+  survivorOf: ReadonlyMap<string, string>,
+): Promise<{ moved: number; swept: boolean }> {
+  let moved = 0;
+  try {
+    for (const summary of await listHistory()) {
+      const target = summary.folderId ? survivorOf.get(summary.folderId) : undefined;
+      if (!target) continue;
+      if (await repointEntryFolder(summary.id, target)) moved++;
+    }
+  } catch (e) {
+    log.warn("history: folder dedupe sweep failed", { error: String(e) });
+    return { moved, swept: false };
+  }
+  return { moved, swept: true };
+}
+
 export async function migrateDuplicateFolders(): Promise<number> {
   if (!isTauri()) return 0;
   const merges = planFolderDedupe(listLocalFolders());
@@ -726,35 +775,10 @@ export async function migrateDuplicateFolders(): Promise<number> {
   const survivorOf = new Map<string, string>();
   for (const m of merges) for (const twin of m.twinIds) survivorOf.set(twin, m.canonicalId);
 
-  let moved = 0;
-  try {
-    for (const summary of await listHistory()) {
-      const target = summary.folderId ? survivorOf.get(summary.folderId) : undefined;
-      if (!target) continue;
-      try {
-        const { meta } = await invoke<HistoryReadResult>("read_history_entry", {
-          id: summary.id,
-        });
-        const updated: HistoryEntry = { ...meta, folderId: target };
-        await invoke("save_history_entry", {
-          id: summary.id,
-          summaryJson: JSON.stringify(buildSummary(updated)),
-          metaJson: JSON.stringify(updated),
-          audioSourcePath: null, // leave the recording untouched
-          compress: false,
-        });
-        moved++;
-      } catch (e) {
-        log.warn("history: folder dedupe failed for entry", {
-          id: summary.id,
-          error: String(e),
-        });
-      }
-    }
-  } catch (e) {
-    log.warn("history: folder dedupe sweep failed", { error: String(e) });
-    return moved;
-  }
+  const { moved, swept } = await repointRecordings(survivorOf);
+  // A sweep that blew up may have left recordings on a twin — leave the twins in
+  // place; the next startup runs this again and converges.
+  if (!swept) return moved;
 
   // Recordings are safely off the twins — now the twins can go.
   for (const [twin] of survivorOf) {

--- a/src/lib/mockStream.ts
+++ b/src/lib/mockStream.ts
@@ -64,11 +64,11 @@ export function startMockStream() {
           endMs: Date.now() - base,
         });
       });
-      if (!isFinal) {
-        timer = setTimeout(emitWord, 90 + Math.random() * 120); // NOSONAR — non-cryptographic jitter for mock stream timing, not security-sensitive
-      } else {
+      if (isFinal) {
         line++;
         timer = setTimeout(emitLine, 1200);
+      } else {
+        timer = setTimeout(emitWord, 90 + Math.random() * 120); // NOSONAR — non-cryptographic jitter for mock stream timing, not security-sensitive
       }
     }
     emitWord();

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -15,7 +15,7 @@ function normalizeVersion(version: string): string {
 
 function storage(): Storage | null {
   try {
-    return window.localStorage;
+    return globalThis.localStorage;
   } catch {
     return null;
   }

--- a/src/lib/replay/importTranscript.ts
+++ b/src/lib/replay/importTranscript.ts
@@ -68,7 +68,7 @@ function parseStampLine(line: string): { ms: number; text: string } | null {
 }
 
 /** A speaker label: short, no sentence punctuation — "Speaker 1", "Jojo", "業務". */
-const LABEL_TEXT_RE = /^[^\s:：。，,.?？!！""''()（）\d][^:：。，,.?？!！]{0,30}$/;
+const LABEL_TEXT_RE = /^[^\s:：。，,.?？!！"'()（）\d][^:：。，,.?？!！]{0,30}$/;
 /** Generic labels that are speakers even when they appear only once. */
 const GENERIC_LABEL_RE = /^(speaker|說話者|发言人|講者|讲者)\s*\d*$/i;
 
@@ -250,14 +250,12 @@ function titleFromPreamble(preamble: string[]): string | null {
 
 // ── Entry point ─────────────────────────────────────────────────────────────
 
-/**
- * Parse a transcript's raw text. Returns null when there is no spoken content
- * at all (empty / whitespace-only file).
- */
-export function parseTranscript(raw: string): ParsedTranscript | null {
-  const lines = raw.replace(/\r\n?/g, "\n").split("\n");
-
-  const inlineSpeakers = collectInlineSpeakers(lines);
+/** How many lines look like a `[MM:SS]` stamp vs. a speaker label — the vote
+ *  that picks which parser runs. */
+function countFormatSignals(
+  lines: string[],
+  inlineSpeakers: Set<string>,
+): { stampCount: number; labelCount: number } {
   let stampCount = 0;
   let labelCount = 0;
   for (const l of lines) {
@@ -274,40 +272,40 @@ export function parseTranscript(raw: string): ParsedTranscript | null {
     const inline = inlineLabel(line);
     if (inline && inlineSpeakers.has(inline.label)) labelCount++;
   }
+  return { stampCount, labelCount };
+}
 
-  if (stampCount >= 2 && stampCount >= labelCount) {
-    const { segments, preamble } = parseTimestamped(lines);
-    if (segments.length) {
-      return {
-        segments,
-        speakerNames: {},
-        durationMs: segments[segments.length - 1].endMs,
-        embeddedTitle: titleFromPreamble(preamble),
-        format: "timestamps",
-      };
-    }
-  }
+/** Timestamped parse, or null when it yields nothing usable. */
+function asTimestamped(lines: string[]): ParsedTranscript | null {
+  const { segments, preamble } = parseTimestamped(lines);
+  if (!segments.length) return null;
+  return {
+    segments,
+    speakerNames: {},
+    durationMs: segments[segments.length - 1].endMs,
+    embeddedTitle: titleFromPreamble(preamble),
+    format: "timestamps",
+  };
+}
 
-  if (labelCount >= 1) {
-    const { blocks, preamble } = parseSpeakerBlocks(lines, inlineSpeakers);
-    const { segments, speakerNames } = synthesizeSegments(
-      blocks.map((b) => ({ label: b.label, text: b.lines.join("\n") })),
-    );
-    if (segments.length) {
-      return {
-        segments,
-        speakerNames,
-        durationMs: segments[segments.length - 1].endMs,
-        embeddedTitle: titleFromPreamble(preamble),
-        format: "speakers",
-      };
-    }
-  }
+/** Speaker-block parse, or null when it yields nothing usable. */
+function asSpeakerBlocks(lines: string[], inlineSpeakers: Set<string>): ParsedTranscript | null {
+  const { blocks, preamble } = parseSpeakerBlocks(lines, inlineSpeakers);
+  const { segments, speakerNames } = synthesizeSegments(
+    blocks.map((b) => ({ label: b.label, text: b.lines.join("\n") })),
+  );
+  if (!segments.length) return null;
+  return {
+    segments,
+    speakerNames,
+    durationMs: segments[segments.length - 1].endMs,
+    embeddedTitle: titleFromPreamble(preamble),
+    format: "speakers",
+  };
+}
 
-  // Plain fallback: paragraphs (blank-line separated) become segments. Long
-  // unbroken paragraphs — a whole meeting exported as one run of text is common
-  // — are further split at sentence boundaries so the synthesized timeline
-  // spreads across the recording (readable replay, anchorable findings).
+/** Blank-line separated paragraphs, with leading/trailing whitespace dropped. */
+function toParagraphs(lines: string[]): string[] {
   const paragraphs: string[] = [];
   let acc: string[] = [];
   for (const l of lines) {
@@ -319,7 +317,17 @@ export function parseTranscript(raw: string): ParsedTranscript | null {
     }
   }
   if (acc.length) paragraphs.push(acc.join("\n"));
-  const chunks = paragraphs.flatMap((p) => splitLongRun(p));
+  return paragraphs;
+}
+
+/**
+ * Plain fallback: paragraphs (blank-line separated) become segments. Long
+ * unbroken paragraphs — a whole meeting exported as one run of text is common
+ * — are further split at sentence boundaries so the synthesized timeline
+ * spreads across the recording (readable replay, anchorable findings).
+ */
+function asPlain(lines: string[]): ParsedTranscript | null {
+  const chunks = toParagraphs(lines).flatMap((p) => splitLongRun(p));
   const { segments } = synthesizeSegments(chunks.map((text) => ({ label: null, text })));
   if (!segments.length) return null;
   return {
@@ -329,6 +337,29 @@ export function parseTranscript(raw: string): ParsedTranscript | null {
     embeddedTitle: null,
     format: "plain",
   };
+}
+
+/**
+ * Parse a transcript's raw text. Returns null when there is no spoken content
+ * at all (empty / whitespace-only file).
+ */
+export function parseTranscript(raw: string): ParsedTranscript | null {
+  const lines = raw.replace(/\r\n?/g, "\n").split("\n");
+
+  const inlineSpeakers = collectInlineSpeakers(lines);
+  const { stampCount, labelCount } = countFormatSignals(lines, inlineSpeakers);
+
+  if (stampCount >= 2 && stampCount >= labelCount) {
+    const parsed = asTimestamped(lines);
+    if (parsed) return parsed;
+  }
+
+  if (labelCount >= 1) {
+    const parsed = asSpeakerBlocks(lines, inlineSpeakers);
+    if (parsed) return parsed;
+  }
+
+  return asPlain(lines);
 }
 
 // ── File-name helpers (shared by the dialog) ────────────────────────────────

--- a/src/lib/replay/ingest.ts
+++ b/src/lib/replay/ingest.ts
@@ -59,7 +59,7 @@ export function isTranscriptPath(path: string): boolean {
   return /\.txt$/i.test(path);
 }
 
-const AUDIO_RE = new RegExp(`\\.(${AUDIO_EXTENSIONS.join("|")})$`, "i");
+const AUDIO_RE = new RegExp(String.raw`\.(${AUDIO_EXTENSIONS.join("|")})$`, "i");
 
 /** Whether a picked/dropped path is an audio recording we can transcribe. */
 export function isAudioPath(path: string): boolean {

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -58,6 +58,55 @@ function normalizeSeverity(v: unknown): TimelineEvent["severity"] {
   return "info";
 }
 
+// ── Loose-value coercions ───────────────────────────────────────────────────
+// MCP payloads are untyped JSON, so every field needs the same "is it really a
+// string?" dance. These keep that noise out of the normalizers below.
+
+/** `v` when it is a string, else `fallback`. */
+function asString(v: unknown, fallback: string): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+/** A string field that is simply absent when it isn't one. */
+function asOptionalString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+/** A trimmed string, or undefined when missing/blank. */
+function asTrimmed(v: unknown): string | undefined {
+  const s = typeof v === "string" ? v.trim() : "";
+  return s || undefined;
+}
+
+/** A boolean field that is simply absent when it isn't one. */
+function asOptionalBoolean(v: unknown): boolean | undefined {
+  return typeof v === "boolean" ? v : undefined;
+}
+
+/** A finite number, else `fallback`. */
+function asNumber(v: unknown, fallback: number): number {
+  return Number.isFinite(v) ? Number(v) : fallback;
+}
+
+/** A non-empty string, else undefined. Unlike {@link asTrimmed} it keeps the
+ *  value verbatim — used for ids, which are opaque. */
+function asNonEmptyString(v: unknown): string | undefined {
+  return typeof v === "string" && v ? v : undefined;
+}
+
+/** A caller-supplied id when it's a non-empty string, else a fresh one. */
+function idOrNew(v: unknown): string {
+  return asNonEmptyString(v) ?? crypto.randomUUID();
+}
+
+/** An array coerced to strings, else undefined. Blank entries are dropped when
+ *  `dropEmpty` — quotes are user-visible, ids are not. */
+function asStringArray(v: unknown, dropEmpty = false): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.map(String);
+  return dropEmpty ? out.filter(Boolean) : out;
+}
+
 /**
  * Coerce a loosely-shaped finding (e.g. from an MCP client) into a valid
  * {@link TimelineEvent}, filling defaults and minting an id when missing. Returns
@@ -66,23 +115,28 @@ function normalizeSeverity(v: unknown): TimelineEvent["severity"] {
 function normalizeFinding(raw: unknown): TimelineEvent | null {
   if (!raw || typeof raw !== "object") return null;
   const o = raw as Record<string, unknown>;
-  const title = typeof o.title === "string" ? o.title : "";
-  const detail = typeof o.detail === "string" ? o.detail : "";
+  const title = asString(o.title, "");
+  const detail = asString(o.detail, "");
   if (!title.trim() && !detail.trim()) return null;
   return {
-    id: typeof o.id === "string" && o.id ? o.id : crypto.randomUUID(),
-    atMs: Number.isFinite(o.atMs) ? Number(o.atMs) : 0,
+    id: idOrNew(o.id),
+    atMs: asNumber(o.atMs, 0),
     side: o.side === "me" ? "me" : "them",
     severity: normalizeSeverity(o.severity),
     source: o.source === "eval" ? "eval" : "extra",
-    evalIds: Array.isArray(o.evalIds) ? o.evalIds.map(String) : undefined,
+    evalIds: asStringArray(o.evalIds),
     title,
     detail,
-    resolved: typeof o.resolved === "boolean" ? o.resolved : undefined,
-    resolution: typeof o.resolution === "string" ? o.resolution : undefined,
-    quotes: Array.isArray(o.quotes) ? o.quotes.map(String).filter(Boolean) : undefined,
-    author: typeof o.author === "string" && o.author.trim() ? o.author.trim() : undefined,
+    resolved: asOptionalBoolean(o.resolved),
+    resolution: asOptionalString(o.resolution),
+    quotes: asStringArray(o.quotes, true),
+    author: asTrimmed(o.author),
   };
+}
+
+/** The action-item severities an MCP client may set; anything else is dropped. */
+function normalizeActionSeverity(v: unknown): ActionItem["severity"] {
+  return v === "info" || v === "warn" || v === "critical" ? v : undefined;
 }
 
 /**
@@ -92,20 +146,16 @@ function normalizeFinding(raw: unknown): TimelineEvent | null {
 function normalizeActionItem(raw: unknown): ActionItem | null {
   if (!raw || typeof raw !== "object") return null;
   const o = raw as Record<string, unknown>;
-  const text = typeof o.text === "string" ? o.text.trim() : "";
+  const text = asTrimmed(o.text);
   if (!text) return null;
-  const severity =
-    o.severity === "info" || o.severity === "warn" || o.severity === "critical"
-      ? o.severity
-      : undefined;
   return {
-    id: typeof o.id === "string" && o.id ? o.id : crypto.randomUUID(),
+    id: idOrNew(o.id),
     text,
-    rationale: typeof o.rationale === "string" ? o.rationale : "",
+    rationale: asString(o.rationale, ""),
     done: o.done === true,
-    linkedEventId: typeof o.linkedEventId === "string" && o.linkedEventId ? o.linkedEventId : null,
+    linkedEventId: asNonEmptyString(o.linkedEventId) ?? null,
     atMs: Number.isFinite(o.atMs) ? Number(o.atMs) : null,
-    severity,
+    severity: normalizeActionSeverity(o.severity),
   };
 }
 
@@ -211,286 +261,347 @@ async function mirrorFolderToCloud(
   }
 }
 
+/** Loosely-typed argument bag carried by an RPC command. */
+type RpcArgs = Record<string, unknown>;
+
+// ── RPC handlers ────────────────────────────────────────────────────────────
+// One function per MCP tool. They reach the pieces the Rust MCP server can't
+// touch directly: cloud/org HTTP calls (the bearer token lives in this process)
+// and the localStorage folder registry. Throwing surfaces as the tool's error.
+
+async function rpcRenameRecording(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  const title = argStr(a.title).trim();
+  if (!id || !title) throw new Error("id and title are required");
+  const { renameHistoryEntry } = await import("./history/history");
+  await renameHistoryEntry(id, title);
+  // If that recording is open in replay, reflect the new name immediately.
+  const s = useStore.getState();
+  if (s.loadedHistoryId === id) s.renameReplay(title);
+  return { id, title };
+}
+
+/**
+ * Fix a saved recording's FRAME (context / speaker names) so later reads and
+ * analysis passes get the right picture — the repair path for a missing
+ * description or a wrong me/them speaker mapping.
+ */
+async function rpcUpdateRecordingMeta(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  const { updateEntryMeta } = await import("./history/history");
+  const patch: import("./history/history").EntryMetaPatch = {};
+  if (typeof a.meetingContext === "string") patch.meetingContext = a.meetingContext;
+  if (a.speakerNames && typeof a.speakerNames === "object" && !Array.isArray(a.speakerNames)) {
+    const names: Record<string, string> = {};
+    for (const [key, name] of Object.entries(a.speakerNames)) names[key] = argStr(name);
+    patch.speakerNames = names;
+  }
+  if (!Object.keys(patch).length) {
+    throw new Error("nothing to update — pass meetingContext and/or speakerNames");
+  }
+  const updated = await updateEntryMeta(id, patch);
+  return {
+    id,
+    meetingContext: updated.meetingContext ?? "",
+    speakerNames: updated.speakerNames ?? {},
+  };
+}
+
+/**
+ * External-analyst write-back: replace whole analysis fields on a saved
+ * recording. Normalization mirrors the live finding path so an MCP payload can
+ * never write an invalid shape to disk.
+ */
+async function rpcSetRecordingAnalysis(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  const { setEntryAnalysis } = await import("./history/history");
+  const patch: import("./history/history").EntryAnalysisPatch = {};
+  if (Array.isArray(a.findings)) {
+    patch.findings = a.findings.map(normalizeFinding).filter((f): f is TimelineEvent => f !== null);
+  }
+  if (Array.isArray(a.actionItems)) {
+    patch.actionItems = a.actionItems
+      .map(normalizeActionItem)
+      .filter((i): i is ActionItem => i !== null);
+  }
+  if (typeof a.brief === "string") patch.brief = a.brief;
+  if (typeof a.analyzed === "boolean") patch.analyzed = a.analyzed;
+  if (!Object.keys(patch).length) {
+    throw new Error("nothing to write — pass findings, actionItems, brief and/or analyzed");
+  }
+  return await setEntryAnalysis(id, patch);
+}
+
+async function rpcMoveRecordingToFolder(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  const folderId = a.folderId ? argStr(a.folderId) : null;
+  const { setEntryFolder, emitHistoryUpdated } = await import("./history/history");
+  await setEntryFolder(id, folderId);
+  await emitHistoryUpdated(id);
+  return { id, folderId };
+}
+
+async function rpcListFolders(): Promise<unknown> {
+  // Fresh read: another INSTANCE (packaged vs dev) may have changed the shared
+  // registry — MCP answers must reflect the file, not this window's cache.
+  const { listFoldersFresh } = await import("./history/folders");
+  return (await listFoldersFresh()).map((f) => ({ id: f.id, name: f.name }));
+}
+
+async function rpcCreateFolder(a: RpcArgs): Promise<unknown> {
+  const name = argStr(a.name).trim();
+  if (!name) throw new Error("name is required");
+  const { listFoldersFresh, createLocalFolder, emitFoldersUpdated } = await import(
+    "./history/folders"
+  );
+  // Adopt a same-name folder when one exists (the import_transcript rule), so
+  // repeated calls stay idempotent. Fresh read first: another instance may have
+  // created it since this window loaded.
+  const existing = (await listFoldersFresh()).find((f) => f.name === name);
+  if (existing) return { id: existing.id, name: existing.name, existed: true };
+  const folder = createLocalFolder(name);
+  await mirrorFolderToCloud("create", folder.id, folder.name, folder.createdAt);
+  await emitFoldersUpdated().catch(() => {});
+  return { id: folder.id, name: folder.name, existed: false };
+}
+
+async function rpcRenameFolder(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  const name = argStr(a.name).trim();
+  if (!id || !name) throw new Error("id and name are required");
+  const { listFoldersFresh, renameLocalFolder, emitFoldersUpdated } = await import(
+    "./history/folders"
+  );
+  if (!(await listFoldersFresh()).some((f) => f.id === id)) {
+    throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
+  }
+  renameLocalFolder(id, name);
+  await mirrorFolderToCloud("rename", id, name);
+  await emitFoldersUpdated().catch(() => {});
+  return { id, name };
+}
+
+async function rpcDeleteFolder(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  const { listFoldersFresh, deleteLocalFolder, emitFoldersUpdated } = await import(
+    "./history/folders"
+  );
+  const existing = (await listFoldersFresh()).find((f) => f.id === id);
+  if (!existing) {
+    throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
+  }
+  deleteLocalFolder(id);
+  await mirrorFolderToCloud("delete", id, existing.name);
+  await emitFoldersUpdated().catch(() => {});
+  return { id, name: existing.name };
+}
+
+async function rpcListOrgs(): Promise<unknown> {
+  const { listMyOrgs } = await import("./cloud/orgs");
+  return await listMyOrgs();
+}
+
+async function rpcListOrgRecordings(a: RpcArgs): Promise<unknown> {
+  const { listOrgRecordings } = await import("./cloud/sync");
+  return await listOrgRecordings(argStr(a.orgId));
+}
+
+async function rpcListOrgFolders(a: RpcArgs): Promise<unknown> {
+  const { listOrgFolders } = await import("./cloud/folders");
+  const folders = await listOrgFolders(argStr(a.orgId));
+  return folders.map((f) => ({ id: f.id, name: f.name }));
+}
+
+async function rpcCreateOrgFolder(a: RpcArgs): Promise<unknown> {
+  const orgId = argStr(a.orgId);
+  const name = argStr(a.name).trim();
+  if (!orgId || !name) throw new Error("orgId and name are required");
+  const { listOrgFolders, createOrgFolder } = await import("./cloud/folders");
+  // Same idempotence rule as create_folder: adopt an existing same-name folder
+  // rather than minting a server-side twin.
+  const existing = (await listOrgFolders(orgId)).find((f) => f.name === name);
+  if (existing) return { id: existing.id, name: existing.name, existed: true };
+  const folder = await createOrgFolder(orgId, name);
+  return { id: folder.id, name: folder.name, existed: false };
+}
+
+async function rpcRenameOrgFolder(a: RpcArgs): Promise<unknown> {
+  const orgId = argStr(a.orgId);
+  const id = argStr(a.id);
+  const name = argStr(a.name).trim();
+  if (!orgId || !id || !name) throw new Error("orgId, id and name are required");
+  const { renameOrgFolder } = await import("./cloud/folders");
+  await renameOrgFolder(orgId, id, name);
+  return { orgId, id, name };
+}
+
+async function rpcDeleteOrgFolder(a: RpcArgs): Promise<unknown> {
+  const orgId = argStr(a.orgId);
+  const id = argStr(a.id);
+  if (!orgId || !id) throw new Error("orgId and id are required");
+  const { deleteOrgFolder } = await import("./cloud/folders");
+  await deleteOrgFolder(orgId, id);
+  return { orgId, id };
+}
+
+async function rpcMoveOrgRecordingToFolder(a: RpcArgs): Promise<unknown> {
+  const orgId = argStr(a.orgId);
+  const id = argStr(a.id);
+  if (!orgId || !id) throw new Error("orgId and id are required");
+  const folderId = a.folderId ? argStr(a.folderId) : null;
+  const { setOrgRecordingFolder } = await import("./cloud/folders");
+  await setOrgRecordingFolder(orgId, id, folderId);
+  return { orgId, id, folderId };
+}
+
+async function rpcShareRecordingToOrg(a: RpcArgs): Promise<unknown> {
+  const { shareRecordingToOrg } = await import("./cloud/sync");
+  return await shareRecordingToOrg(
+    argStr(a.id),
+    argStr(a.orgId),
+    a.folderId ? argStr(a.folderId) : null,
+  );
+}
+
+async function rpcMoveRecordingToOrg(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  const { moveRecordingToOrg } = await import("./cloud/sync");
+  const shared = await moveRecordingToOrg(id, argStr(a.orgId), a.folderId ? argStr(a.folderId) : null);
+  const { emitHistoryUpdated } = await import("./history/history");
+  await emitHistoryUpdated(id);
+  return shared;
+}
+
+/** Resolve the personal folder an import lands in, creating it when needed. */
+async function resolveImportFolder(folderName: string): Promise<string | null> {
+  if (!folderName) return null;
+  const { listFoldersFresh, createLocalFolder, emitFoldersUpdated } = await import(
+    "./history/folders"
+  );
+  // Adopt a same-name folder if there is one, else create it. Fresh read first:
+  // another instance may have added it since this window loaded.
+  const existing = (await listFoldersFresh()).find((f) => f.name === folderName);
+  if (existing) return existing.id;
+  const created = createLocalFolder(folderName);
+  await emitFoldersUpdated().catch(() => {});
+  return created.id;
+}
+
+/**
+ * Text-ingest over MCP (issue #130): parse .txt transcripts and save them as
+ * audio-less history entries — same pipeline as the import dialog. Never
+ * touches the live store, so it's safe during a meeting.
+ */
+async function rpcImportTranscript(a: RpcArgs): Promise<unknown> {
+  const paths = Array.isArray(a.paths) ? a.paths.map(argStr).filter(Boolean) : [];
+  if (!paths.length) throw new Error("paths (array of absolute .txt paths) is required");
+  const folderName = a.folder ? argStr(a.folder).trim() : "";
+  const folderId = await resolveImportFolder(folderName);
+  const { prepareTranscriptFile } = await import("./replay/importFiles");
+  const { saveTranscriptToHistory } = await import("./history/history");
+  const imported: { id: string; title: string; segments: number; format: string }[] = [];
+  const failed: { path: string; error: string }[] = [];
+  for (const path of paths) {
+    const file = await prepareTranscriptFile(path);
+    if (!file.parsed) {
+      failed.push({ path, error: file.error ?? "unreadable" });
+      continue;
+    }
+    const id = await saveTranscriptToHistory({
+      title: file.title,
+      segments: file.parsed.segments,
+      speakerNames: file.parsed.speakerNames,
+      durationMs: file.parsed.durationMs,
+      createdAt: file.createdAt,
+      folderId,
+    });
+    if (id) imported.push({
+      id,
+      title: file.title,
+      segments: file.parsed.segments.length,
+      format: file.parsed.format,
+    });
+  }
+  return { imported, failed, folderId, folder: folderName || null };
+}
+
+async function rpcCopyOrgRecordingToPersonal(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  const { saveOrgRecordingToPersonal } = await import("./cloud/sync");
+  await saveOrgRecordingToPersonal(argStr(a.orgId), id);
+  const { emitHistoryUpdated } = await import("./history/history");
+  await emitHistoryUpdated(id);
+  return { id };
+}
+
+async function rpcDeleteOrgRecording(a: RpcArgs): Promise<unknown> {
+  const orgId = argStr(a.orgId);
+  const id = argStr(a.id);
+  if (!orgId || !id) throw new Error("orgId and id are required");
+  const { deleteOrgRecording } = await import("./cloud/sync");
+  await deleteOrgRecording(orgId, id);
+  return { orgId, id, deleted: true };
+}
+
+async function rpcDeleteRecording(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  const { listHistory, deleteHistoryEntry, emitHistoryUpdated } = await import(
+    "./history/history"
+  );
+  if (!(await listHistory()).some((e) => e.id === id)) {
+    throw new Error(`no local recording with id ${id} — get ids from list_recordings`);
+  }
+  // Same order as the library UI delete: cloud first (tombstone, so the sweep
+  // can't resurrect the copy), then the local files.
+  if (CLOUD_ENABLED && syncEnabled()) {
+    const { deleteCloudRecording } = await import("./cloud/sync");
+    await deleteCloudRecording(id);
+  }
+  await deleteHistoryEntry(id);
+  await emitHistoryUpdated(id);
+  return { id, deleted: true };
+}
+
+/** Every RPC action the frontend answers, keyed by the MCP tool's name. A Map,
+ *  not an object: the action string comes off disk and must never resolve to
+ *  something inherited from Object.prototype. */
+const RPC_HANDLERS = new Map<string, (a: RpcArgs) => Promise<unknown>>([
+  ["rename_recording", rpcRenameRecording],
+  ["update_recording_meta", rpcUpdateRecordingMeta],
+  ["set_recording_analysis", rpcSetRecordingAnalysis],
+  ["move_recording_to_folder", rpcMoveRecordingToFolder],
+  ["list_folders", rpcListFolders],
+  ["create_folder", rpcCreateFolder],
+  ["rename_folder", rpcRenameFolder],
+  ["delete_folder", rpcDeleteFolder],
+  ["list_orgs", rpcListOrgs],
+  ["list_org_recordings", rpcListOrgRecordings],
+  ["list_org_folders", rpcListOrgFolders],
+  ["create_org_folder", rpcCreateOrgFolder],
+  ["rename_org_folder", rpcRenameOrgFolder],
+  ["delete_org_folder", rpcDeleteOrgFolder],
+  ["move_org_recording_to_folder", rpcMoveOrgRecordingToFolder],
+  ["share_recording_to_org", rpcShareRecordingToOrg],
+  ["move_recording_to_org", rpcMoveRecordingToOrg],
+  ["import_transcript", rpcImportTranscript],
+  ["copy_org_recording_to_personal", rpcCopyOrgRecordingToPersonal],
+  ["delete_org_recording", rpcDeleteOrgRecording],
+  ["delete_recording", rpcDeleteRecording],
+]);
+
 /**
  * Execute an RPC command (one that carries an id) and return its result data.
- * These reach the pieces the Rust MCP server can't touch directly: cloud/org
- * HTTP calls (the bearer token lives in this process) and the localStorage
- * folder registry. Throwing here surfaces as the MCP tool's error message.
+ * Throwing here surfaces as the MCP tool's error message.
  */
-async function applyRpcCommand(action: string, a: Record<string, unknown>): Promise<unknown> {
-  switch (action) {
-    case "rename_recording": {
-      const id = argStr(a.id);
-      const title = argStr(a.title).trim();
-      if (!id || !title) throw new Error("id and title are required");
-      const { renameHistoryEntry } = await import("./history/history");
-      await renameHistoryEntry(id, title);
-      // If that recording is open in replay, reflect the new name immediately.
-      const s = useStore.getState();
-      if (s.loadedHistoryId === id) s.renameReplay(title);
-      return { id, title };
-    }
-    case "update_recording_meta": {
-      // Fix a saved recording's FRAME (context / speaker names) so later reads
-      // and analysis passes get the right picture — the repair path for a
-      // missing description or a wrong me/them speaker mapping.
-      const id = argStr(a.id);
-      if (!id) throw new Error("id is required");
-      const { updateEntryMeta } = await import("./history/history");
-      const patch: import("./history/history").EntryMetaPatch = {};
-      if (typeof a.meetingContext === "string") patch.meetingContext = a.meetingContext;
-      if (a.speakerNames && typeof a.speakerNames === "object" && !Array.isArray(a.speakerNames)) {
-        const names: Record<string, string> = {};
-        for (const [key, name] of Object.entries(a.speakerNames)) names[key] = argStr(name);
-        patch.speakerNames = names;
-      }
-      if (!Object.keys(patch).length) {
-        throw new Error("nothing to update — pass meetingContext and/or speakerNames");
-      }
-      const updated = await updateEntryMeta(id, patch);
-      return {
-        id,
-        meetingContext: updated.meetingContext ?? "",
-        speakerNames: updated.speakerNames ?? {},
-      };
-    }
-    case "set_recording_analysis": {
-      // External-analyst write-back: replace whole analysis fields on a saved
-      // recording. Normalization mirrors the live finding path so an MCP payload
-      // can never write an invalid shape to disk.
-      const id = argStr(a.id);
-      if (!id) throw new Error("id is required");
-      const { setEntryAnalysis } = await import("./history/history");
-      const patch: import("./history/history").EntryAnalysisPatch = {};
-      if (Array.isArray(a.findings)) {
-        patch.findings = a.findings
-          .map(normalizeFinding)
-          .filter((f): f is TimelineEvent => f !== null);
-      }
-      if (Array.isArray(a.actionItems)) {
-        patch.actionItems = a.actionItems
-          .map(normalizeActionItem)
-          .filter((i): i is ActionItem => i !== null);
-      }
-      if (typeof a.brief === "string") patch.brief = a.brief;
-      if (typeof a.analyzed === "boolean") patch.analyzed = a.analyzed;
-      if (!Object.keys(patch).length) {
-        throw new Error("nothing to write — pass findings, actionItems, brief and/or analyzed");
-      }
-      return await setEntryAnalysis(id, patch);
-    }
-    case "move_recording_to_folder": {
-      const id = argStr(a.id);
-      if (!id) throw new Error("id is required");
-      const folderId = a.folderId ? argStr(a.folderId) : null;
-      const { setEntryFolder, emitHistoryUpdated } = await import("./history/history");
-      await setEntryFolder(id, folderId);
-      await emitHistoryUpdated(id);
-      return { id, folderId };
-    }
-    case "list_folders": {
-      // Fresh read: another INSTANCE (packaged vs dev) may have changed the
-      // shared registry — MCP answers must reflect the file, not this
-      // window's cache.
-      const { listFoldersFresh } = await import("./history/folders");
-      return (await listFoldersFresh()).map((f) => ({ id: f.id, name: f.name }));
-    }
-    case "create_folder": {
-      const name = argStr(a.name).trim();
-      if (!name) throw new Error("name is required");
-      const { listFoldersFresh, createLocalFolder, emitFoldersUpdated } = await import(
-        "./history/folders"
-      );
-      // Adopt a same-name folder when one exists (the import_transcript rule),
-      // so repeated calls stay idempotent. Fresh read first: another instance
-      // may have created it since this window loaded.
-      const existing = (await listFoldersFresh()).find((f) => f.name === name);
-      if (existing) return { id: existing.id, name: existing.name, existed: true };
-      const folder = createLocalFolder(name);
-      await mirrorFolderToCloud("create", folder.id, folder.name, folder.createdAt);
-      await emitFoldersUpdated().catch(() => {});
-      return { id: folder.id, name: folder.name, existed: false };
-    }
-    case "rename_folder": {
-      const id = argStr(a.id);
-      const name = argStr(a.name).trim();
-      if (!id || !name) throw new Error("id and name are required");
-      const { listFoldersFresh, renameLocalFolder, emitFoldersUpdated } = await import(
-        "./history/folders"
-      );
-      if (!(await listFoldersFresh()).some((f) => f.id === id)) {
-        throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
-      }
-      renameLocalFolder(id, name);
-      await mirrorFolderToCloud("rename", id, name);
-      await emitFoldersUpdated().catch(() => {});
-      return { id, name };
-    }
-    case "delete_folder": {
-      const id = argStr(a.id);
-      if (!id) throw new Error("id is required");
-      const { listFoldersFresh, deleteLocalFolder, emitFoldersUpdated } = await import(
-        "./history/folders"
-      );
-      const existing = (await listFoldersFresh()).find((f) => f.id === id);
-      if (!existing) {
-        throw new Error(`no personal folder with id ${id} — get ids from list_folders`);
-      }
-      deleteLocalFolder(id);
-      await mirrorFolderToCloud("delete", id, existing.name);
-      await emitFoldersUpdated().catch(() => {});
-      return { id, name: existing.name };
-    }
-    case "list_orgs": {
-      const { listMyOrgs } = await import("./cloud/orgs");
-      return await listMyOrgs();
-    }
-    case "list_org_recordings": {
-      const { listOrgRecordings } = await import("./cloud/sync");
-      return await listOrgRecordings(argStr(a.orgId));
-    }
-    case "list_org_folders": {
-      const { listOrgFolders } = await import("./cloud/folders");
-      const folders = await listOrgFolders(argStr(a.orgId));
-      return folders.map((f) => ({ id: f.id, name: f.name }));
-    }
-    case "create_org_folder": {
-      const orgId = argStr(a.orgId);
-      const name = argStr(a.name).trim();
-      if (!orgId || !name) throw new Error("orgId and name are required");
-      const { listOrgFolders, createOrgFolder } = await import("./cloud/folders");
-      // Same idempotence rule as create_folder: adopt an existing same-name
-      // folder rather than minting a server-side twin.
-      const existing = (await listOrgFolders(orgId)).find((f) => f.name === name);
-      if (existing) return { id: existing.id, name: existing.name, existed: true };
-      const folder = await createOrgFolder(orgId, name);
-      return { id: folder.id, name: folder.name, existed: false };
-    }
-    case "rename_org_folder": {
-      const orgId = argStr(a.orgId);
-      const id = argStr(a.id);
-      const name = argStr(a.name).trim();
-      if (!orgId || !id || !name) throw new Error("orgId, id and name are required");
-      const { renameOrgFolder } = await import("./cloud/folders");
-      await renameOrgFolder(orgId, id, name);
-      return { orgId, id, name };
-    }
-    case "delete_org_folder": {
-      const orgId = argStr(a.orgId);
-      const id = argStr(a.id);
-      if (!orgId || !id) throw new Error("orgId and id are required");
-      const { deleteOrgFolder } = await import("./cloud/folders");
-      await deleteOrgFolder(orgId, id);
-      return { orgId, id };
-    }
-    case "move_org_recording_to_folder": {
-      const orgId = argStr(a.orgId);
-      const id = argStr(a.id);
-      if (!orgId || !id) throw new Error("orgId and id are required");
-      const folderId = a.folderId ? argStr(a.folderId) : null;
-      const { setOrgRecordingFolder } = await import("./cloud/folders");
-      await setOrgRecordingFolder(orgId, id, folderId);
-      return { orgId, id, folderId };
-    }
-    case "share_recording_to_org": {
-      const { shareRecordingToOrg } = await import("./cloud/sync");
-      return await shareRecordingToOrg(
-        argStr(a.id),
-        argStr(a.orgId),
-        a.folderId ? argStr(a.folderId) : null,
-      );
-    }
-    case "move_recording_to_org": {
-      const id = argStr(a.id);
-      const { moveRecordingToOrg } = await import("./cloud/sync");
-      const shared = await moveRecordingToOrg(id, argStr(a.orgId), a.folderId ? argStr(a.folderId) : null);
-      const { emitHistoryUpdated } = await import("./history/history");
-      await emitHistoryUpdated(id);
-      return shared;
-    }
-    case "import_transcript": {
-      // Text-ingest over MCP (issue #130): parse .txt transcripts and save them
-      // as audio-less history entries — same pipeline as the import dialog.
-      // Never touches the live store, so it's safe during a meeting.
-      const paths = Array.isArray(a.paths) ? a.paths.map(argStr).filter(Boolean) : [];
-      if (!paths.length) throw new Error("paths (array of absolute .txt paths) is required");
-      const folderName = a.folder ? argStr(a.folder).trim() : "";
-      const { listFoldersFresh, createLocalFolder, emitFoldersUpdated } = await import(
-        "./history/folders"
-      );
-      let folderId: string | null = null;
-      if (folderName) {
-        // Adopt a same-name folder if there is one, else create it. Fresh read
-        // first: another instance may have added it since this window loaded.
-        const existing = (await listFoldersFresh()).find((f) => f.name === folderName);
-        folderId = existing?.id ?? createLocalFolder(folderName).id;
-        if (!existing) await emitFoldersUpdated().catch(() => {});
-      }
-      const { prepareTranscriptFile } = await import("./replay/importFiles");
-      const { saveTranscriptToHistory } = await import("./history/history");
-      const imported: { id: string; title: string; segments: number; format: string }[] = [];
-      const failed: { path: string; error: string }[] = [];
-      for (const path of paths) {
-        const file = await prepareTranscriptFile(path);
-        if (!file.parsed) {
-          failed.push({ path, error: file.error ?? "unreadable" });
-          continue;
-        }
-        const id = await saveTranscriptToHistory({
-          title: file.title,
-          segments: file.parsed.segments,
-          speakerNames: file.parsed.speakerNames,
-          durationMs: file.parsed.durationMs,
-          createdAt: file.createdAt,
-          folderId,
-        });
-        if (id) imported.push({
-          id,
-          title: file.title,
-          segments: file.parsed.segments.length,
-          format: file.parsed.format,
-        });
-      }
-      return { imported, failed, folderId, folder: folderName || null };
-    }
-    case "copy_org_recording_to_personal": {
-      const id = argStr(a.id);
-      const { saveOrgRecordingToPersonal } = await import("./cloud/sync");
-      await saveOrgRecordingToPersonal(argStr(a.orgId), id);
-      const { emitHistoryUpdated } = await import("./history/history");
-      await emitHistoryUpdated(id);
-      return { id };
-    }
-    case "delete_org_recording": {
-      const orgId = argStr(a.orgId);
-      const id = argStr(a.id);
-      if (!orgId || !id) throw new Error("orgId and id are required");
-      const { deleteOrgRecording } = await import("./cloud/sync");
-      await deleteOrgRecording(orgId, id);
-      return { orgId, id, deleted: true };
-    }
-    case "delete_recording": {
-      const id = argStr(a.id);
-      if (!id) throw new Error("id is required");
-      const { listHistory, deleteHistoryEntry, emitHistoryUpdated } = await import(
-        "./history/history"
-      );
-      if (!(await listHistory()).some((e) => e.id === id)) {
-        throw new Error(`no local recording with id ${id} — get ids from list_recordings`);
-      }
-      // Same order as the library UI delete: cloud first (tombstone, so the
-      // sweep can't resurrect the copy), then the local files.
-      if (CLOUD_ENABLED && syncEnabled()) {
-        const { deleteCloudRecording } = await import("./cloud/sync");
-        await deleteCloudRecording(id);
-      }
-      await deleteHistoryEntry(id);
-      await emitHistoryUpdated(id);
-      return { id, deleted: true };
-    }
-    default:
-      throw new Error(`unknown command: ${action}`);
-  }
+async function applyRpcCommand(action: string, a: RpcArgs): Promise<unknown> {
+  const handler = RPC_HANDLERS.get(action);
+  if (!handler) throw new Error(`unknown command: ${action}`);
+  return await handler(a);
 }
 
 /** Report an RPC command's outcome for the MCP server to pick up. */
@@ -502,38 +613,47 @@ async function writeResult(id: string, result: { ok: boolean; data?: unknown; er
   }
 }
 
+/** Run one RPC command and append its outcome for the MCP server to pick up. */
+async function runRpcCommand(id: string, cmd: SessionCommand): Promise<void> {
+  try {
+    const data = await applyRpcCommand(cmd.action, cmd.args ?? {});
+    await writeResult(id, { ok: true, data });
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    await writeResult(id, { ok: false, error });
+  }
+}
+
+/** Apply one queued line. Malformed lines and other instances' commands are
+ *  skipped; a failing fire-and-forget command is swallowed. */
+async function runQueuedLine(line: string): Promise<void> {
+  let cmd: SessionCommand;
+  try {
+    cmd = JSON.parse(line) as SessionCommand;
+  } catch {
+    return; // skip a malformed line
+  }
+  // Another instance's command (shared config-dir queue) — ITS frontend
+  // executes and answers it; running it here too would double-apply.
+  if (cmd.instance && ownEndpoint && cmd.instance !== ownEndpoint) return;
+  if (cmd.id) {
+    await runRpcCommand(cmd.id, cmd);
+    return;
+  }
+  try {
+    applyCommand(cmd);
+  } catch {
+    /* skip a failing command */
+  }
+}
+
 async function poll(): Promise<void> {
   try {
     const all = lines(await invoke<string>("read_session_commands"));
     if (all.length <= cursor) return;
     const fresh = all.slice(cursor);
     cursor = all.length;
-    for (const line of fresh) {
-      let cmd: SessionCommand;
-      try {
-        cmd = JSON.parse(line) as SessionCommand;
-      } catch {
-        continue; // skip a malformed line
-      }
-      // Another instance's command (shared config-dir queue) — ITS frontend
-      // executes and answers it; running it here too would double-apply.
-      if (cmd.instance && ownEndpoint && cmd.instance !== ownEndpoint) continue;
-      if (cmd.id) {
-        try {
-          const data = await applyRpcCommand(cmd.action, cmd.args ?? {});
-          await writeResult(cmd.id, { ok: true, data });
-        } catch (e) {
-          const error = e instanceof Error ? e.message : String(e);
-          await writeResult(cmd.id, { ok: false, error });
-        }
-      } else {
-        try {
-          applyCommand(cmd);
-        } catch {
-          /* skip a failing command */
-        }
-      }
-    }
+    for (const line of fresh) await runQueuedLine(line);
   } catch {
     /* read failed; try again next tick */
   }

--- a/src/lib/settingsSync.ts
+++ b/src/lib/settingsSync.ts
@@ -20,7 +20,7 @@ export const SETTINGS_NAVIGATE_EVENT = "settings://navigate";
 export async function openSettingsWindow(category?: SettingsCategory): Promise<void> {
   const hash = category ? `settings/${category}` : "settings";
   if (!isTauri()) {
-    window.location.hash = hash;
+    globalThis.location.hash = hash;
     return;
   }
   const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
@@ -101,9 +101,9 @@ export async function listenForSettings(): Promise<UnlistenFn> {
     // Cloud sign-in/out done in the other window (it's persisted under the same key).
     useStore.getState().setCloudAuth(cloudAuthFromPersist(e.newValue));
   };
-  window.addEventListener("storage", onStorage);
+  globalThis.addEventListener("storage", onStorage);
 
-  if (!isTauri()) return () => window.removeEventListener("storage", onStorage);
+  if (!isTauri()) return () => globalThis.removeEventListener("storage", onStorage);
 
   // Channel 1: the Tauri broadcast (fast path).
   const unlisten = await listen<Settings>(SETTINGS_EVENT, (e) => {
@@ -114,7 +114,7 @@ export async function listenForSettings(): Promise<UnlistenFn> {
     useStore.getState().applySettings(e.payload);
   });
   return () => {
-    window.removeEventListener("storage", onStorage);
+    globalThis.removeEventListener("storage", onStorage);
     unlisten();
   };
 }

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -24,7 +24,7 @@ interface TranscriptEventPayload {
  * Tauri (e.g. plain `vite` in a browser) — it just resolves to a no-op.
  */
 export async function listenForTranscript(): Promise<UnlistenFn> {
-  if (!("__TAURI_INTERNALS__" in window)) {
+  if (!("__TAURI_INTERNALS__" in globalThis)) {
     return () => {};
   }
   return listen<TranscriptEventPayload>("transcript://segment", (event) => {
@@ -72,7 +72,7 @@ interface ProsodyEventPayload {
  * outside Tauri. Only "me" is ever emitted, but we filter defensively.
  */
 export async function listenForProsody(): Promise<UnlistenFn> {
-  if (!("__TAURI_INTERNALS__" in window)) {
+  if (!("__TAURI_INTERNALS__" in globalThis)) {
     return () => {};
   }
   return listen<ProsodyEventPayload>("audio://prosody", (event) => {
@@ -119,7 +119,7 @@ const MEETING_ERROR_KEY_BY_CODE: Partial<Record<string, TranslationKey>> = {
  * toast. No-op outside Tauri.
  */
 export async function listenForMeetingError(): Promise<UnlistenFn> {
-  if (!("__TAURI_INTERNALS__" in window)) {
+  if (!("__TAURI_INTERNALS__" in globalThis)) {
     return () => {};
   }
   return listen<MeetingErrorPayload>("meeting://error", (event) => {
@@ -150,7 +150,7 @@ interface MeetingWarningPayload {
  */
 let warnedSystemAudio = false;
 export async function listenForMeetingWarning(): Promise<UnlistenFn> {
-  if (!("__TAURI_INTERNALS__" in window)) {
+  if (!("__TAURI_INTERNALS__" in globalThis)) {
     return () => {};
   }
   const unStatus = await listen<string>("meeting://status", () => {
@@ -173,5 +173,5 @@ export async function listenForMeetingWarning(): Promise<UnlistenFn> {
 
 /** True when running inside the Tauri shell (vs a plain browser dev session). */
 export function isTauri(): boolean {
-  return "__TAURI_INTERNALS__" in window;
+  return "__TAURI_INTERNALS__" in globalThis;
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,7 +11,7 @@ export function useThemePreference() {
   const theme = useStore((s) => s.settings.theme);
 
   useEffect(() => {
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const media = globalThis.matchMedia("(prefers-color-scheme: dark)");
 
     function apply() {
       const resolved = resolveTheme(theme, media.matches);

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -505,8 +505,8 @@ async function observePastedField(text: string, sessionGen: number): Promise<voi
   });
   // listen() resolves asynchronously — a dictation that started meanwhile owns
   // the overlay now, so drop this subscription instead of leaking it.
-  if (gen !== sessionGen) un();
-  else correctionUnlisten = un;
+  if (gen === sessionGen) correctionUnlisten = un;
+  else un();
 }
 
 function stopObserving(): void {

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -31,7 +31,7 @@ export function initZoomShortcuts(): void {
     apply(zoom).catch((e) => log.warn("zoom: restore failed", { error: String(e) }));
   }
 
-  window.addEventListener("keydown", (e) => {
+  globalThis.addEventListener("keydown", (e) => {
     // ⌘ on macOS, Ctrl elsewhere — exclusively, so combos like Ctrl+⌘ pass through.
     const mod = isMac() ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
     if (!mod || e.altKey) return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,7 +30,7 @@ void initDictionary().catch((error) =>
 
 // Secondary windows load the same bundle at a `#<route>` hash; main.tsx routes
 // each to its own root component (Settings / Field Log / How-to-reply).
-const route = window.location.hash.replace(/^#/, "");
+const route = globalThis.location.hash.replace(/^#/, "");
 // `history` is deliberately NOT here: the recordings library is a route inside
 // the main window's shell now (#195), not a window of its own.
 const ROUTES = [

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -28,7 +28,7 @@ import { isTauri } from "../lib/tauriEvents";
 import { fetchLatestReleaseNotes, markReleaseNotesSeen, type ReleaseNotes } from "../lib/releaseNotes";
 import { useThemePreference } from "../lib/theme";
 import { LevelMeter } from "../components/LevelMeter";
-import { connState, relativeTime, type McpActivityInfo } from "../components/McpStatusChip";
+import { clientLabel, connState, relativeTime, type McpActivityInfo } from "../components/McpStatusChip";
 import { ReleaseNotesDialog } from "../components/ReleaseNotesDialog";
 import { UsagePanel } from "./UsagePanel";
 import { STT_PROVIDERS, STT_BY_ID } from "../lib/transcription/providers";
@@ -110,7 +110,7 @@ const NAV: {
 
 /** The nav panel a `#settings/<category>` deep-link hash asks for, if valid. */
 function categoryFromHash(): Category | null {
-  const seg = window.location.hash.replace(/^#settings\/?/, "");
+  const seg = globalThis.location.hash.replace(/^#settings\/?/, "");
   return NAV.some((n) => n.id === seg) ? (seg as Category) : null;
 }
 
@@ -238,11 +238,11 @@ export function SettingsApp() {
         );
     };
     refreshMcpInfo();
-    const mcpTimer = window.setInterval(() => {
+    const mcpTimer = globalThis.setInterval(() => {
       if (!mcpInfo?.running) refreshMcpInfo();
     }, 1000);
     return () => {
-      window.clearInterval(mcpTimer);
+      globalThis.clearInterval(mcpTimer);
       invoke("stop_mic_test").catch((error) => log.warn("settings: stop mic test on cleanup failed", { error: String(error) }));
     };
   }, [mcpInfo?.running]);
@@ -260,10 +260,10 @@ export function SettingsApp() {
         .catch(() => {});
     };
     refresh();
-    const id = window.setInterval(refresh, 3000);
+    const id = globalThis.setInterval(refresh, 3000);
     return () => {
       alive = false;
-      window.clearInterval(id);
+      globalThis.clearInterval(id);
     };
   }, [cat]);
 
@@ -1004,9 +1004,7 @@ export function SettingsApp() {
                   {t(`mcp.state.${connState(mcpActivity, Date.now())}`)}
                 </span>
                 <span className="ml-auto truncate text-xs text-muted-foreground">
-                  {mcpActivity?.client
-                    ? `${mcpActivity.client.name ?? "?"}${mcpActivity.client.version ? ` v${mcpActivity.client.version}` : ""}`
-                    : t("mcp.panel.noClient")}
+                  {clientLabel(mcpActivity?.client) ?? t("mcp.panel.noClient")}
                 </span>
               </div>
               <div className="mt-1 text-[11px] text-muted-foreground">
@@ -1783,16 +1781,7 @@ function OrgPanel() {
                   the final button stays disabled until the org name is retyped
                   exactly — two deliberate confirmations before anything dies. */}
               {org.role === "owner" &&
-                (!deletingOpen[org.id] ? (
-                  <button
-                    type="button"
-                    aria-expanded={false}
-                    className="self-start text-[11px] text-muted-foreground underline-offset-2 hover:text-destructive hover:underline"
-                    onClick={() => setDeletingOpen((m) => ({ ...m, [org.id]: true }))}
-                  >
-                    {t("settings.account.org.delete")}
-                  </button>
-                ) : (
+                (deletingOpen[org.id] ? (
                   <div className="flex flex-col gap-1.5 rounded-md border border-destructive/40 bg-destructive/5 p-2">
                     <p className="text-[11px] text-destructive">
                       {t("settings.account.org.deleteWarning")}
@@ -1837,6 +1826,15 @@ function OrgPanel() {
                       </Button>
                     </div>
                   </div>
+                ) : (
+                  <button
+                    type="button"
+                    aria-expanded={false}
+                    className="self-start text-[11px] text-muted-foreground underline-offset-2 hover:text-destructive hover:underline"
+                    onClick={() => setDeletingOpen((m) => ({ ...m, [org.id]: true }))}
+                  >
+                    {t("settings.account.org.delete")}
+                  </button>
                 ))}
             </div>
           ))}

--- a/src/settings/VoiceTypingSettings.tsx
+++ b/src/settings/VoiceTypingSettings.tsx
@@ -124,6 +124,20 @@ export function shortcutCaps(shortcut: string, t: (k: TranslationKey) => string)
   return shortcut;
 }
 
+/** The combo id a recorded keydown selects, or null when the press needs a
+ *  modifier (a bare letter would swallow ordinary typing system-wide). */
+function comboFromEvent(e: KeyboardEvent): VoiceTypingShortcut | null {
+  const mods = [
+    e.metaKey ? "super" : null,
+    e.ctrlKey ? "control" : null,
+    e.altKey ? "alt" : null,
+    e.shiftKey ? "shift" : null,
+  ].filter((m): m is string => m !== null);
+  const isFKey = /^F([1-9]|1\d|2[0-4])$/.test(e.code);
+  if (mods.length === 0 && !isFKey) return null;
+  return `combo:${[...mods, e.code].join("+")}` as VoiceTypingShortcut;
+}
+
 interface AppIdentity {
   bundleIdentifier: string;
   executablePath: string;
@@ -292,20 +306,14 @@ export const VoiceTypingSettings = () => {
       }
       if (MODIFIER_CODES.has(e.code)) return; // still holding — wait for the key
       sawNonModifierRef.current = true; // a combo was attempted
-      const mods = [
-        e.metaKey ? "super" : null,
-        e.ctrlKey ? "control" : null,
-        e.altKey ? "alt" : null,
-        e.shiftKey ? "shift" : null,
-      ].filter((m): m is string => m !== null);
-      const isFKey = /^F([1-9]|1\d|2[0-4])$/.test(e.code);
-      if (mods.length === 0 && !isFKey) {
+      const combo = comboFromEvent(e);
+      if (!combo) {
         setRecordHint("settings.voiceTyping.recorder.needModifier");
         return;
       }
       setRecording(false);
       setRecordHint(null);
-      chooseShortcut(`combo:${[...mods, e.code].join("+")}` as VoiceTypingShortcut).catch((error) =>
+      chooseShortcut(combo).catch((error) =>
         log.error("voice-typing: choose combo shortcut failed", { error: String(error) }),
       );
     };
@@ -335,13 +343,13 @@ export const VoiceTypingSettings = () => {
       setRecording(false);
       setRecordHint(null);
     };
-    window.addEventListener("keydown", onKey, true);
-    window.addEventListener("keyup", onKeyUp, true);
-    window.addEventListener("blur", cancel);
+    globalThis.addEventListener("keydown", onKey, true);
+    globalThis.addEventListener("keyup", onKeyUp, true);
+    globalThis.addEventListener("blur", cancel);
     return () => {
-      window.removeEventListener("keydown", onKey, true);
-      window.removeEventListener("keyup", onKeyUp, true);
-      window.removeEventListener("blur", cancel);
+      globalThis.removeEventListener("keydown", onKey, true);
+      globalThis.removeEventListener("keyup", onKeyUp, true);
+      globalThis.removeEventListener("blur", cancel);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recording]);

--- a/website/index.html
+++ b/website/index.html
@@ -49,6 +49,13 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!--
+      No Subresource Integrity on this one: the Google Fonts CSS2 endpoint serves a
+      different stylesheet per user agent (woff2 vs. legacy formats, varying
+      unicode-range subsets), so a single hash would break the font for most
+      visitors. The response is CSS only — the fonts it points at are separate
+      requests — and it is served over HTTPS from a pinned host.
+    -->
     <link
       href="https://fonts.googleapis.com/css2?family=Geist:wght@300..700&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"

--- a/website/script.js
+++ b/website/script.js
@@ -21,7 +21,7 @@ nav.querySelectorAll(".nav__links a").forEach((a) =>
 
 // Scroll reveal
 const reveals = document.querySelectorAll(".reveal");
-if ("IntersectionObserver" in window) {
+if ("IntersectionObserver" in globalThis) {
   const io = new IntersectionObserver(
     (entries) => {
       entries.forEach((e) => {


### PR DESCRIPTION
## What

Clears 144 of the 161 issues open on [sonar.pathors.com](https://sonar.pathors.com/dashboard?id=pathorsAI_parley) after the migration to self-hosted SonarQube (#298): the 1 reliability issue, and 143 maintainability issues. Behavior-preserving throughout — no public API, Tauri command, or i18n change.

## Highlights

- **`window` → `globalThis`** wherever `window` was used purely as the global object (S7764, 37×). Window-specific uses (`focus` events, `scrollY`) left alone.
- **Cognitive-complexity refactors** (S3776, 34×), all extract-helper style:
  - Rust: `diarize.rs` pipeline (CC 56) split into embed/cluster/carry stages; `audio/mixer.rs` (CC 45) got a `Side` struct owning per-stream bookkeeping; all five streaming transcription providers now share the same `Frame`/`classify`/`read_transcripts` shape; `mcp.rs` search/list share `read_entry_files` as a lazy iterator.
  - TS: `sessionCommands.ts` 275-line RPC switch became 21 named handlers in a `Map` (a `Map` deliberately — action strings come from an on-disk queue, so object-prototype keys like `"constructor"` must not resolve); analysis engine, importTranscript, DeliveryPanel, LibraryScreen similarly decomposed.
  - Kotlin: `AccountSheet` split into three composables.
- **a11y**: `role="button"` divs are now real `<button type="button">` elements (S6819); MoveDialog's scrim became a *sibling* button of the panel instead of wrapping it. Contrast fixes in the iOS readiness doc are now theme-aware tokens passing WCAG AA in both light and dark (S7924).
- **Reliability**: `AnalysisTimeline` no longer uses an object literal as a parameter default (S7737).
- Plus nested-ternary/negated-condition/deep-nesting flattening (S3358/S7735/S2004), regex cleanups, unnecessary assertions, `export…from`, zero fractions.

## Deliberately not fixed (17)

- **16× S1135 TODO comments** — real work markers; deleting them to improve a metric would lose information.
- **1× Web:S5725** (SRI on the Google Fonts stylesheet in `website/index.html`) — `fonts.googleapis.com` content-negotiates on User-Agent; three different UAs produced three different sha384 digests, so any pinned hash would break the font for most visitors. Documented inline; will be marked Accepted in SonarQube.

## Verification

- `bunx tsc --noEmit` — clean
- `bunx vitest run` — 255/255
- `cargo check` / `cargo clippy --lib` / `cargo fmt --check` — clean
- `cargo test --lib` — 42 passed (diarize, mcp, ax_observe, prosody, transcription)
- `./gradlew :parleykit:test` — pass (`:app` unverifiable locally, no Android SDK; CI covers it)