### PR TITLE
[fix] two Sonar issues the sweep itself introduced

### DIFF
--- a/src/components/library/LibraryCards.tsx
+++ b/src/components/library/LibraryCards.tsx
@@ -115,7 +115,11 @@ function MenuShell({
           }
         }}
       />
+      {/* stopPropagation: the popover floats inside a clickable card — menu
+          interactions must not bubble into the card's own open handler. */}
       <div
+        role="menu"
+        aria-label={title}
         className="absolute right-0 top-7 z-40 max-h-64 min-w-40 overflow-y-auto rounded-md border bg-popover p-1 shadow-md"
         onClick={(ev) => ev.stopPropagation()}
         onKeyDown={(ev) => ev.stopPropagation()}

--- a/src/settings/VoiceTypingSettings.tsx
+++ b/src/settings/VoiceTypingSettings.tsx
@@ -138,6 +138,39 @@ function comboFromEvent(e: KeyboardEvent): VoiceTypingShortcut | null {
   return `combo:${[...mods, e.code].join("+")}` as VoiceTypingShortcut;
 }
 
+/**
+ * Register `shortcut` with the backend and return the resulting status (null
+ * when the apply itself failed). A single-key trigger needs Input Monitoring —
+ * request it right when the user picks one (the permission follows the
+ * feature), then re-apply so the tap arms immediately if macOS granted
+ * without a relaunch.
+ */
+async function applyShortcut(shortcut: VoiceTypingShortcut): Promise<HotkeyStatus | null> {
+  const s = await invoke<HotkeyStatus>("set_voice_typing_shortcut", { shortcut }).catch(
+    (error) => {
+      log.warn("voice typing settings: shortcut apply failed", {
+        shortcut,
+        error: String(error),
+      });
+      return null;
+    },
+  );
+  if (!s || !isModifierId(shortcut) || s.authorized) return s;
+  await invoke("request_input_monitoring").catch((error) =>
+    log.warn("voice typing settings: input monitoring request failed", {
+      shortcut,
+      error: String(error),
+    }),
+  );
+  return invoke<HotkeyStatus>("set_voice_typing_shortcut", { shortcut }).catch((error) => {
+    log.warn("voice typing settings: shortcut reapply failed", {
+      shortcut,
+      error: String(error),
+    });
+    return s;
+  });
+}
+
 interface AppIdentity {
   bundleIdentifier: string;
   executablePath: string;
@@ -221,35 +254,7 @@ export const VoiceTypingSettings = () => {
       broadcastSettings({ ...useStore.getState().settings }).catch((error) =>
         log.warn("voice typing settings: broadcast failed", { error: String(error) }),
       );
-      let s = await invoke<HotkeyStatus>("set_voice_typing_shortcut", { shortcut }).catch(
-        (error) => {
-          log.warn("voice typing settings: shortcut apply failed", {
-            shortcut,
-            error: String(error),
-          });
-          return null;
-        },
-      );
-      // A single-key trigger needs Input Monitoring — request it right when the
-      // user picks one (the permission follows the feature), then re-apply so the
-      // tap arms immediately if macOS granted without a relaunch.
-      if (s && isModifierId(shortcut) && !s.authorized) {
-        await invoke("request_input_monitoring").catch((error) =>
-          log.warn("voice typing settings: input monitoring request failed", {
-            shortcut,
-            error: String(error),
-          }),
-        );
-        s = await invoke<HotkeyStatus>("set_voice_typing_shortcut", { shortcut }).catch(
-          (error) => {
-            log.warn("voice typing settings: shortcut reapply failed", {
-              shortcut,
-              error: String(error),
-            });
-            return s;
-          },
-        );
-      }
+      const s = await applyShortcut(shortcut);
       if (s) setStatus(s);
     } finally {
       setSaving(false);


### PR DESCRIPTION
Follow-up to #300: the main-branch scan after merge surfaced 2 new issues introduced by the sweep's own refactors (gate failed on new_violations = 1).

- **LibraryCards** (S6848): the MenuShell popover lost `role="presentation"` in the a11y pass, leaving a plain div with `stopPropagation` handlers. It's semantically a menu → `role="menu"` + `aria-label`, with a comment explaining why the handlers must stay (the popover floats inside a clickable card).
- **VoiceTypingSettings** (S3776, CC 16): extracted the apply-shortcut-with-Input-Monitoring-retry flow to a module-level `applyShortcut()`; behavior identical.

After this, main should be down to the 16 deliberately-kept S1135 TODO markers and a green gate.

Verified: `bunx tsc --noEmit` clean, `bunx vitest run` 255/255.