### PR TITLE
[chore] resolve sonar findings: review-seed token, TODO false positives, ReDoS verdicts

### DIFF
--- a/ios/AppStore/seed-demo.mjs
+++ b/ios/AppStore/seed-demo.mjs
@@ -2,9 +2,22 @@
 // Content is fictional but written the way real B2B meetings actually sound —
 // screenshots should show the product doing its job, not a placeholder.
 // No real companies, people, or customer data appear anywhere.
-import { readFileSync } from "node:fs";
+//
+// Usage: PARLEY_REVIEW_TOKEN=<reviewer account API token> node seed-demo.mjs
+//
+// The token comes from the environment rather than a file under /tmp: that
+// directory is world-writable, so any local process could swap the token out
+// from under this script. Pull the value from the approved secret manager at
+// call time (see README step 6) and never write it into the repository.
 
-const TOKEN = readFileSync("/tmp/review-token.txt", "utf8").trim();
+const TOKEN = process.env.PARLEY_REVIEW_TOKEN?.trim();
+if (!TOKEN) {
+  console.error(
+    "PARLEY_REVIEW_TOKEN is not set — export the reviewer account's API token before running this script."
+  );
+  process.exit(1);
+}
+
 const API = "https://api.parley.tw";
 
 const seg = (i, speaker, text, startMs, endMs) => ({


### PR DESCRIPTION
Sweep of the 16 `typescript:S1135` issues and 4 security hotspots on `sonar.pathors.com`. One real fix; everything else is a documented verdict.

## Code change

**`javascript:S5443` — `ios/AppStore/seed-demo.mjs:7` — FIXED.** The App Review seeding script read its bearer token from `/tmp/review-token.txt`. `/tmp` is world-writable, so any local process could swap the file between the operator writing it and the script reading it, and the secret was left sitting on disk afterwards. It now reads `PARLEY_REVIEW_TOKEN` from the environment and exits with a clear message when unset. `AppStore/README.md` step 6 already asked for reviewer credentials to live in the approved secret manager, so this brings the script in line with the documented posture.

## TODO comments — no change, all 16 are false positives

Parley ships a user-facing feature called **TODO**: the TODO agenda rail, TODO templates in Settings, and `"todo"` as a literal usage category. `S1135` matches the word in comments, so every mention of the feature trips it. None of these 16 comments describes outstanding work — they all document behaviour that is already shipped. Rewording them to dodge a word match would make the comments describe the product *less* accurately, which is why the file is untouched.

Classified against the sweep's a/b/c scheme, all 16 are **(b)** — prose explaining current behaviour, not a task — but with the caveat that the standard (b) remedy (strip the word "TODO") does not apply, because here "TODO" is the correct product noun.

| Location | Comment refers to |
|---|---|
| `src/components/sidebar/TodosPanel.tsx:13` | items added "from a TODO template" |
| `src/components/sidebar/TodosPanel.tsx:89` | "TODO agenda auto-check is LIVE-only" |
| `src/lib/analysis/engine.ts:204` | "auto-check the TODO agenda checklist" |
| `src/lib/analysis/engine.ts:205` | "the TODO auto-check is preserved here" |
| `src/lib/analysis/engine.ts:279` | "Auto-check the TODO agenda every ~45s" |
| `src/lib/usage/log.ts:17` | the literal union `"ask" \| "eval" \| "todo"` |
| `src/lib/usage/log.ts:52` | the same `category` values |
| `src/components/live/CoachFeed.tsx:148` | "Replaces the tabbed Ask/TODO WorkPanel" |
| `src/i18n/messages.ts:841` | "eval template sets, and TODO …" (dictionary section header) |
| `src/lib/store.ts:43` | "eval templates, TODO templates, and …" |
| `src/lib/store.ts:547` | "Mark the given todo ids as done" |
| `src/lib/sessionCommands.ts:11` | "add/check/remove todo" MCP commands |
| `src/lib/todoTemplates.ts:8` | "Built-in TODO/agenda templates" |
| `src/lib/templatesSync.ts:11` | "Sync eval/TODO templates" |
| `src/lib/types.ts:328` | "Library of TODO/agenda templates" |
| `src/lib/ai/todos.ts:17` | "Returns the set of todo ids it considers done" |

In several of these the word is pinned by an identifier (`todoTemplates`, `todoIds`) or by a literal string value that cannot change without changing behaviour.

## Remaining hotspot verdicts

**`typescript:S5852` — `src/lib/replay/importTranscript.ts:61` — SAFE.** `/^\[(?:(\d{1,2}):)?(\d{1,2}):(\d{2})(?:[.,](\d{1,3}))?\]\s*(.*)$/`. Every quantifier before the closing `\]` is bounded to at most three digits, so the prefix is effectively deterministic and its backtracking is constant-factor. The only unbounded parts, `\s*(.*)$`, are reached solely after `\]` has matched, and `(.*)$` succeeds unconditionally on the remainder, so the whitespace loop is never forced to retry. There is no nested ambiguous quantifier and therefore no super-linear backtracking.

**`typescript:S5852` — `src/lib/replay/importTranscript.ts:86` — SAFE.** `/^(.+?)[:：]\s+(.+)$/`. The pattern is anchored, so there is a single start position and the lazy `(.+?)` expands at most *n* times, each expansion costing one character-class test. After a colon matches, `\s+` scans one whitespace run and `(.+)$` succeeds whenever any character remains, so it gives back at most one position. The whitespace runs are disjoint, making total work linear in line length. The lazy quantifier is also load-bearing: it lets a label contain a colon that is not followed by whitespace (`a:b: c` → label `a:b`), which the obvious "linear rewrite" `([^:：]+)` would break, so leaving it alone is both safe and correct.

Verified empirically as well as by inspection — both regexes were run against adversarial inputs (no-colon runs, `a:` repetitions, long trailing-whitespace tails) from 1k to 16k characters, and cost scales linearly, staying under 0.25 ms at 16k. Real input is far smaller still: `parse()` splits on newlines first, so each call sees a single line.

**`xml:S5604` — `android/app/src/main/AndroidManifest.xml:5` — SAFE.** `RECORD_AUDIO` on a meeting-recording app is the core function, not incidental access. The manifest already pairs it with `FOREGROUND_SERVICE_MICROPHONE`, so capture is bound to a user-visible foreground service, and Android gates the permission behind a runtime prompt. Removing it would remove the product.

## Verification

`bunx tsc --noEmit` and `bunx vitest run` (25 files, 255 tests) both pass. The changed script is not imported by the app — it is an operator tool run by hand — and was smoke-tested for the unset-token path.
