### PR TITLE
[fix] correction observation died silently in Chromium-family apps

### DIFF
--- a/src-tauri/src/ax_observe.rs
+++ b/src-tauri/src/ax_observe.rs
@@ -59,6 +59,10 @@ mod imp {
     /// Consecutive identical reads before a changed value counts as settled —
     /// so mid-typing snapshots ("Parle", "Parl") don't fire a candidate.
     const SETTLED_TICKS: u32 = 2;
+    /// Consecutive failed reads tolerated before giving up. AX queries fail
+    /// transiently (kAXErrorCannotComplete) while the target app is busy; one
+    /// hiccup must not end a legitimate observation.
+    const MAX_MISSES: u32 = 3;
     /// Values longer than this are not worth diffing (a whole document, a code
     /// editor's buffer): reading them every second is wasteful and the diff
     /// would be meaningless. Counted in CHARS, not bytes.
@@ -76,12 +80,12 @@ mod imp {
             value: *mut CFTypeRef,
         ) -> i32;
         fn AXUIElementGetTypeID() -> usize;
+        fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut i32) -> i32;
     }
 
     #[link(name = "CoreFoundation", kind = "framework")]
     extern "C" {
         fn CFRelease(cf: CFTypeRef);
-        fn CFEqual(a: CFTypeRef, b: CFTypeRef) -> bool;
         fn CFGetTypeID(cf: CFTypeRef) -> usize;
         fn CFStringGetTypeID() -> usize;
     }
@@ -167,10 +171,24 @@ mod imp {
         Some(s)
     }
 
+    /// The pid of the app the element belongs to — the identity that decides
+    /// whether "focus is still where we pasted". Element-ref equality (CFEqual)
+    /// is NOT usable for that: Chromium-family apps (browsers, Electron) mint a
+    /// fresh AX wrapper object per query, so ref equality false-negatives on
+    /// the very apps people dictate into most.
+    unsafe fn element_pid(element: AXUIElementRef) -> Option<i32> {
+        let mut pid: i32 = 0;
+        if AXUIElementGetPid(element, &mut pid) != 0 || pid <= 0 {
+            return None;
+        }
+        Some(pid)
+    }
+
     pub fn observe(app: AppHandle, inserted_text: String) -> bool {
         // Auto-paste and this share the one permission: without Accessibility
         // there is no AX tree to read, so there is nothing to observe.
         if !crate::voice_typing::is_accessibility_trusted() {
+            log::info!("ax_observe: not armed (accessibility not granted)");
             return false;
         }
         // Claim the newest generation before anything else. Even if this call
@@ -178,17 +196,37 @@ mod imp {
         // watcher is now stale and should stop rather than report on it.
         let generation = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
 
-        let (element, baseline) = unsafe {
+        let (element, target_pid, baseline) = unsafe {
             let Some(element) = copy_focused_element() else {
+                log::info!("ax_observe: not armed (no focused element)");
+                return false;
+            };
+            let Some(pid) = element_pid(element.0) else {
+                log::info!("ax_observe: not armed (focused element has no pid)");
                 return false;
             };
             let Some(baseline) = copy_value_string(element.0) else {
+                log::info!("ax_observe: not armed (field value not a readable string)");
                 return false;
             };
-            (element, baseline)
+            (element, pid, baseline)
         };
 
-        std::thread::spawn(move || poll(app, element, baseline, inserted_text, generation));
+        log::info!(
+            "ax_observe: armed (baseline {} chars, target pid {})",
+            baseline.chars().count(),
+            target_pid
+        );
+        std::thread::spawn(move || {
+            poll(
+                app,
+                element,
+                target_pid,
+                baseline,
+                inserted_text,
+                generation,
+            )
+        });
         true
     }
 
@@ -210,33 +248,35 @@ mod imp {
         })
     }
 
-    /// One tick's reading of the watched field, or `None` when polling must
-    /// stop: a newer paste superseded us, focus left the element, or the value
-    /// became unreadable (element went away, stopped being a string, grew past
-    /// the cap).
-    fn read_tick(element: &OwnedElement, generation: u64) -> Option<String> {
+    /// One tick's reading of the watched field. `Ok(None)` is a tolerable miss
+    /// (transient AX failure — skip this tick); `Err(reason)` ends the
+    /// observation (superseded, or focus moved to another app).
+    fn read_tick(
+        element: &OwnedElement,
+        target_pid: i32,
+        generation: u64,
+    ) -> Result<Option<String>, &'static str> {
         // A newer paste owns the field now — stop without a word.
         if GENERATION.load(Ordering::SeqCst) != generation {
-            return None;
+            return Err("superseded by a newer dictation");
         }
-        // Focus must still be on the very element we pasted into. Comparing
-        // the AX refs (rather than, say, the app) is what keeps us from
-        // reporting on a different field that happens to look edited.
-        let still_focused = unsafe {
-            match copy_focused_element() {
-                Some(current) => CFEqual(current.0, element.0),
-                None => false,
-            }
-        };
-        if !still_focused {
-            return None;
+        // Focus must still be inside the app we pasted into. The value is
+        // always read off the ORIGINAL element ref, so a different field of
+        // the same app coming into focus is harmless — that ref's value simply
+        // stops changing. App identity is compared by pid, not CFEqual (see
+        // element_pid).
+        match unsafe { copy_focused_element().and_then(|e| element_pid(e.0)) } {
+            Some(pid) if pid == target_pid => {}
+            Some(_) => return Err("focus left the app"),
+            None => return Ok(None), // transient: focus query failed
         }
-        unsafe { copy_value_string(element.0) }
+        Ok(unsafe { copy_value_string(element.0) })
     }
 
     fn poll(
         app: AppHandle,
         element: OwnedElement,
+        target_pid: i32,
         mut baseline: String,
         inserted_text: String,
         generation: u64,
@@ -246,12 +286,26 @@ mod imp {
         // consecutive ticks it has held.
         let mut candidate: Option<String> = None;
         let mut stable_ticks: u32 = 0;
+        let mut misses: u32 = 0;
 
         for _ in 0..ticks {
             std::thread::sleep(POLL_INTERVAL);
-            let Some(current) = read_tick(&element, generation) else {
-                return;
+            let current = match read_tick(&element, target_pid, generation) {
+                Err(reason) => {
+                    log::info!("ax_observe: stopped ({reason})");
+                    return;
+                }
+                Ok(None) => {
+                    misses += 1;
+                    if misses > MAX_MISSES {
+                        log::info!("ax_observe: stopped (field unreadable for {misses} ticks)");
+                        return;
+                    }
+                    continue;
+                }
+                Ok(Some(current)) => current,
             };
+            misses = 0;
 
             if current == baseline {
                 // Back to what we pasted: whatever edit was in flight was undone.
@@ -296,6 +350,7 @@ mod imp {
             );
             return;
         }
+        log::info!("ax_observe: window expired with no correction");
     }
 
     #[cfg(test)]

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -482,21 +482,41 @@ function scheduleHide() {
 // field, only for a minute — reports the settled value. The diff is computed
 // here, offered once in the overlay, and forgotten unless the user says yes.
 
+/** The observation the current dictation owns. `rearmsLeft` lets a rejected
+ *  candidate re-arm with a fresh baseline — a target app that transforms the
+ *  paste (smart quotes, autocapitalize) or an unrelated multi-word edit would
+ *  otherwise spend the single Rust event and go deaf to the real correction. */
+let observation: { insertedText: string; sessionGen: number; rearmsLeft: number } | null = null;
+
 /**
- * Ask Rust to watch the field we just pasted into, and take AT MOST ONE
- * candidate from it. `sessionGen` pins the dictation this observation belongs
+ * Ask Rust to watch the field we just pasted into. Each armed observation
+ * reports AT MOST ONE candidate; `sessionGen` pins the dictation it belongs
  * to: a new one starting while the setup is in flight makes this stale.
  */
 async function observePastedField(text: string, sessionGen: number): Promise<void> {
+  observation = { insertedText: text, sessionGen, rearmsLeft: 2 };
+  await armObservation();
+}
+
+async function armObservation(): Promise<void> {
   stopObserving();
+  if (!observation || gen !== observation.sessionGen) return;
   let started = false;
   try {
-    started = await invoke<boolean>("observe_pasted_field", { insertedText: text });
+    started = await invoke<boolean>("observe_pasted_field", {
+      insertedText: observation.insertedText,
+    });
   } catch (e) {
     log.warn("voice-typing: observe_pasted_field failed", { error: String(e) });
     return;
   }
-  if (!started || gen !== sessionGen) return;
+  if (!started) {
+    // Rust already logged why (no AX trust, no focused element, value not a
+    // readable string). Note it here too so the TS log tells the whole story.
+    log.info("voice-typing: field observation not armed");
+    return;
+  }
+  if (gen !== observation.sessionGen) return;
   const un = await listen<CorrectionCandidatePayload>(CORRECTION_CANDIDATE_EVENT, (e) => {
     stopObserving(); // one candidate per observation, then we're done listening
     onCorrectionCandidate(e.payload).catch((error) =>
@@ -505,7 +525,7 @@ async function observePastedField(text: string, sessionGen: number): Promise<voi
   });
   // listen() resolves asynchronously — a dictation that started meanwhile owns
   // the overlay now, so drop this subscription instead of leaking it.
-  if (gen === sessionGen) correctionUnlisten = un;
+  if (observation && gen === observation.sessionGen) correctionUnlisten = un;
   else un();
 }
 
@@ -519,9 +539,25 @@ async function onCorrectionCandidate(p: CorrectionCandidatePayload): Promise<voi
   // this window has read the dictionary file.
   await whenDictionaryReady();
   const hit = detectCorrection(p.baseline, p.current, p.insertedText);
-  if (!hit) return;
+  if (!hit) {
+    log.info("voice-typing: correction candidate rejected by diff", {
+      baselineChars: p.baseline.length,
+      currentChars: p.current.length,
+      insertedChars: p.insertedText.length,
+    });
+    // Watch again from the field's CURRENT state — the change we just rejected
+    // becomes part of the new baseline, so a real one-word fix can still land.
+    if (observation && gen === observation.sessionGen && observation.rearmsLeft > 0) {
+      observation.rearmsLeft -= 1;
+      await armObservation();
+    }
+    return;
+  }
   // Declined twice already — the answer isn't going to change.
-  if (isIgnoredTwice(hit.from, hit.to)) return;
+  if (isIgnoredTwice(hit.from, hit.to)) {
+    log.info("voice-typing: correction candidate suppressed (ignored twice)");
+    return;
+  }
   log.info("voice-typing: correction candidate", { chars: hit.from.length });
   await showSuggestion(hit);
 }


### PR DESCRIPTION
## What this changes

Three robustness fixes to the phrase-dictionary field observation (#295), plus logging on every terminal path so a silent failure is diagnosable from the app log:

- Focus liveness is now judged by the focused element's **pid**, not `CFEqual` on element refs — Chromium-family apps (browsers, Slack, VS Code) mint a fresh AX wrapper per query, so ref equality false-negatived on the first tick and the observation ended before the user finished typing the correction. The value is still read off the original element ref only.
- Up to 3 consecutive transient AX failures are tolerated (`kAXErrorCannotComplete` while the target app is busy) instead of giving up on the first.
- A candidate the diff rejects (paste transformed by the target app, unrelated multi-word edit) re-arms the observation with a fresh baseline, up to twice per dictation, instead of spending the single Rust event.

## Why

First field report: the correction loop appeared to do nothing on macOS. The observation had several ways to die silently and zero logging, so it was undiagnosable; the CFEqual false-negative alone plausibly killed it in every Chromium-family target app.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (255)
- [x] `cargo test` (42) and `cargo clippy --all-targets -- -D warnings` clean
- [ ] Live dictation loop — needs a human mic + keyboard; the added logs make the next field test conclusive either way

## Screenshots

No UI change.