### PR TITLE
[fix] correction watch died when Chromium rebuilt the edited field's AX node

### DIFF
--- a/src-tauri/src/ax_observe.rs
+++ b/src-tauri/src/ax_observe.rs
@@ -249,8 +249,9 @@ mod imp {
     }
 
     /// One tick's reading of the watched field. `Ok(None)` is a tolerable miss
-    /// (transient AX failure — skip this tick); `Err(reason)` ends the
-    /// observation (superseded, or focus moved to another app).
+    /// (transient AX failure, focus briefly elsewhere — skip this tick);
+    /// `Err(reason)` ends the observation (superseded by a newer dictation).
+    /// Persistent misses end it too, via the caller's counter.
     fn read_tick(
         element: &OwnedElement,
         target_pid: i32,
@@ -260,17 +261,27 @@ mod imp {
         if GENERATION.load(Ordering::SeqCst) != generation {
             return Err("superseded by a newer dictation");
         }
-        // Focus must still be inside the app we pasted into. The value is
-        // always read off the ORIGINAL element ref, so a different field of
-        // the same app coming into focus is harmless — that ref's value simply
-        // stops changing. App identity is compared by pid, not CFEqual (see
-        // element_pid).
-        match unsafe { copy_focused_element().and_then(|e| element_pid(e.0)) } {
+        // Reads happen only while focus is inside the app we pasted into
+        // (compared by pid — see element_pid). A mismatch is a MISS, not an
+        // instant stop: Electron apps briefly vend focus under helper pids,
+        // and users peek at other windows mid-correction. A mismatch that
+        // persists past the miss budget ends the observation.
+        let focused = unsafe { copy_focused_element() };
+        match focused.as_ref().and_then(|e| unsafe { element_pid(e.0) }) {
             Some(pid) if pid == target_pid => {}
-            Some(_) => return Err("focus left the app"),
-            None => return Ok(None), // transient: focus query failed
+            _ => return Ok(None),
         }
-        Ok(unsafe { copy_value_string(element.0) })
+        // Prefer the element we armed on, but fall back to the currently
+        // focused one (same app, checked above): Chromium-family apps rebuild
+        // the accessibility node when a contenteditable re-renders, which is
+        // exactly what the user's delete-and-retype does — the armed ref goes
+        // stale at the very moment the correction we're waiting for happens.
+        let value = unsafe { copy_value_string(element.0) }.or_else(|| {
+            focused
+                .as_ref()
+                .and_then(|e| unsafe { copy_value_string(e.0) })
+        });
+        Ok(value)
     }
 
     fn poll(
@@ -298,7 +309,9 @@ mod imp {
                 Ok(None) => {
                     misses += 1;
                     if misses > MAX_MISSES {
-                        log::info!("ax_observe: stopped (field unreadable for {misses} ticks)");
+                        log::info!(
+                            "ax_observe: stopped (no readable value for {misses} ticks — focus moved away or the field went stale)"
+                        );
                         return;
                     }
                     continue;

--- a/src/lib/voiceTyping/host.ts
+++ b/src/lib/voiceTyping/host.ts
@@ -494,7 +494,10 @@ let observation: { insertedText: string; sessionGen: number; rearmsLeft: number 
  * to: a new one starting while the setup is in flight makes this stale.
  */
 async function observePastedField(text: string, sessionGen: number): Promise<void> {
-  observation = { insertedText: text, sessionGen, rearmsLeft: 2 };
+  // 3 re-arms, not fewer: in Chromium-family fields the paste itself lands as
+  // a replace (never matching Rust's splice check), so the first candidate of
+  // EVERY dictation is a rejected paste-landing that costs one re-arm.
+  observation = { insertedText: text, sessionGen, rearmsLeft: 3 };
   await armObservation();
 }
 
@@ -535,6 +538,14 @@ function stopObserving(): void {
 }
 
 async function onCorrectionCandidate(p: CorrectionCandidatePayload): Promise<void> {
+  // A candidate from a dictation the user has already moved past must not
+  // hijack the overlay — it may be showing the NEXT dictation's live text
+  // right now. Rust's generation guard covers most of this, but a candidate
+  // emitted just before the next paste can still arrive after startSession.
+  if (!observation || gen !== observation.sessionGen) {
+    log.info("voice-typing: correction candidate dropped (stale dictation)");
+    return;
+  }
   // The ignore counter (and the write that may follow) only mean something once
   // this window has read the dictionary file.
   await whenDictionaryReady();


### PR DESCRIPTION
## What this changes

Three fixes to the correction observation, all driven by the first real field log (dictating into Claude Desktop, an Electron app):

- **Stale-ref fallback**: Chromium rebuilds the accessibility node when a contenteditable re-renders — exactly what the user's delete-and-retype does — so the element ref we armed on died mid-correction (`stopped (field unreadable for 4 ticks)` in the log). Value reads now fall back to the currently focused element, gated to the same app pid; the privacy boundary (same app, 60 s, diff-and-discard) is unchanged.
- **Focus mismatch is a miss, not a stop**: a single focused-pid mismatch ended the watch (`stopped (focus left the app)` 5 s after arming); it now consumes miss budget instead, ending only when persistent.
- **Re-arm budget 2 → 3 + stale-candidate gate**: in these fields the paste lands as a replace (20 → 86 chars for a 90-char paste in the log), never matching the splice check, so every dictation's first candidate is a rejected paste-landing that costs a re-arm. Also, a candidate arriving after the next dictation has started is now dropped — it would otherwise hijack the overlay while the next dictation's live text is showing.

## Why

v0.24.1's logging did its job: the loop armed correctly, but the correction died in the two Chromium-specific ways above before it could settle. This is the dominant target-app family (Claude Desktop, Slack, VS Code, browsers).

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (255)
- [x] `cargo test` (42) and `cargo clippy --all-targets -- -D warnings` clean
- [ ] Live re-test in Claude Desktop after release — the log lines will confirm

## Screenshots

No UI change.