### PR TITLE
[feature] voice pane says what a tap will do, and pastes once at the end

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -38,25 +38,51 @@ hand-off, and the in-app dictation session are new.
    *uplink* file to the App Group, and opens `parley://dictate?session=…` with
    SwiftUI's `openURL` action (the responder-chain `openURL:` walk was disabled
    for keyboards in iOS 18; `openURL` is the public path that still works, with
-   the walk kept only as an older-system fallback).
+   the walk kept only as an older-system fallback). Only when there is
+   something to start: a keyboard whose readiness mailbox says the app has no
+   account or no microphone permission mints no session and opens the bare
+   `parley://` instead — see *Four states* below.
 2. **App records.** `onOpenURL` routes to `DictationCoordinator`, which starts
    the mic + relay and mirrors the growing transcript into a *downlink* file,
    posting a Darwin notification on each update.
 3. **Return to the host app** — or, far better, never leave it. See the
    microphone window below.
-4. **Keyboard inserts.** On the Darwin note (and on every `viewWillAppear`, in
-   case it was suspended through the notification), the keyboard reads the
-   downlink and inserts whatever is new past its high-water mark
-   (`insertedCount`), so a keyboard that was killed and relaunched mid-session
-   never double-inserts. The tentative tail is shown above the keys, never
-   inserted.
-5. **Stop.** The keyboard's ⏹ writes `stopRequested` and posts the uplink note;
-   the app finishes the relay, drains the last utterance, folds the final tail
-   into the committed text, and marks the session done.
+4. **Keyboard watches, and inserts nothing yet.** On the Darwin note (and on
+   every `viewWillAppear`, in case it was suspended through the notification)
+   the keyboard reads the downlink and shows the settled tail followed by the
+   tentative partial above the keys. Nothing reaches the host's document while
+   the session is `starting`, `listening`, `reconnecting` or `finishing`.
+5. **Stop, then one insertion.** The keyboard's ⏹ writes `stopRequested` and
+   posts the uplink note; the app finishes the relay, drains the last utterance,
+   folds the final tail into the committed text, and marks the session `done`.
+   That state is the keyboard's cue: it inserts the whole committed text in a
+   single `insertText`, then writes the character count back to the uplink as
+   its high-water mark (`insertedCount`), so a keyboard killed mid-session and
+   relaunched after the session ended still pastes exactly once. `error` inserts
+   nothing at all.
+
+#### Why one insertion rather than a stream
+
+The keyboard used to insert each delta as the relay settled it, which read as
+the more live design and was the worse one. Settled is not final: the relay
+revises runs it has already emitted, so a document collected the churn, and
+`insertText` cannot take anything back. Worse, every way a session can end
+badly — a lost socket, quota, the user walking away — left a half sentence in
+someone's field, punctuated wherever the relay happened to have got to. One
+insertion at `done` makes the transaction the whole utterance: either the
+sentence lands, or the field is exactly as it was and the error says so. This is
+also what the copy on the failure paths now says (it used to promise that what
+was already said "has been typed").
+
+The price is that the keyboard's own text slot stops being a nicety and becomes
+the only place the words are visible while they are being spoken — see *The live
+transcript* below — and that the transcript now depends on the keyboard coming
+back within the downlink's adoption window (150 s) rather than on it having been
+alive at the right moments.
 
 ### App Group channel
 
-`DictationChannel` (in ParleyKit, so both targets share it) is four
+`DictationChannel` (in ParleyKit, so both targets share it) is five
 single-writer mailboxes, each with its own Darwin notification, so the two
 processes never contend on a file:
 
@@ -67,9 +93,21 @@ processes never contend on a file:
   updatedAt}`, the microphone window and its heartbeat.
 - `dictation-window-control.json` — keyboard → app: `{closeRequestedAt}`, the
   keyboard's "end the window now".
+- `dictation-ready.json` — app → keyboard: `{signedIn, micGranted, updatedAt}`,
+  whether a tap could dictate at all.
 
 The window pair is separate from the session pair because a window outlives any
 one dictation, and most of what it has to say happens when no session exists.
+
+**Readiness is the one mailbox with no staleness rule**, and that is a
+difference in kind rather than an omission. A window is a claim about a live
+process, so a file nobody is re-stamping is a lie (hence the heartbeat). An
+account and a microphone grant are facts about the *installation*: they are
+still true when the app is dead, so the newest file is always right. A missing
+file is not an unknown either — it means Parley has never run here, which is
+exactly the state the pane needs to describe. The app republishes on launch, on
+every foregrounding, on sign-in and sign-out, and the moment the microphone
+prompt is answered.
 
 The files are the source of truth; the Darwin notes are pure "go re-read"
 signals (they carry no payload). This is what makes the hand-off robust to the
@@ -169,10 +207,14 @@ the point where adding an element moves the record button. It is hidden during a
 session — the record button already says the microphone is live, and the chip is
 about the *next* tap.
 
-The negative signal cannot be the mere absence of the chip, so the idle slot
-gains a second line — *This tap opens Parley first* — but **only for someone who
-has turned a window on**. Without the setting, every tap has always opened
-Parley; saying so on every keyboard would be noise rather than information.
+The negative signal cannot be the mere absence of the chip. It used to be a
+second line under *Tap to speak* — *This tap opens Parley first* — shown only to
+someone who had turned a window on, on the grounds that without the setting
+every tap had always opened Parley and saying so would be noise. That reasoning
+was wrong in the one way that mattered: the headline still said *Tap to speak*,
+which is a promise about this keyboard, and the button still drew a microphone.
+The fix is in the state list below — the promise now lives in the headline and on
+the button's own glyph, so the caption has nothing left to add and is gone.
 
 ### Bounded on purpose: there is no "until I turn it off"
 
@@ -398,18 +440,54 @@ never needs a second element saying "Listening…" beside it. The other is the
 wordmark (`#1469D4` light, `#2DB6F3` dark). Nothing else on the pane carries a
 colour, including `⏎` when the host has asked for an action.
 
+#### Four states, and only one of them is a microphone
+
+The pane used to draw the mic button and *Tap to speak* in every state, so a
+keyboard that could not transcribe a word looked identical to one that could —
+which is how a feature that was merely not set up got reported as broken. The
+glyph is what changed: the colour stays (the button is still the thing to press)
+but a **microphone is only drawn when speaking here would actually work.**
+
+| state | button | text slot |
+|---|---|---|
+| no Full Access | dimmed, mic | *Voice typing needs Full Access* + the Settings path |
+| not set up (`!ready`) | gradient, `arrow.up.forward.app` | *Set up voice typing in Parley* / *Tap to open the app* |
+| set up, no open window | gradient, `arrow.up.forward.app` | *Dictation starts in Parley* |
+| microphone window open | gradient, `mic.fill` | *Tap to speak* |
+
+These are the *idle* states. A live session takes the slot ahead of all four
+(the transcript, or the reconnecting line), and so does an error from the last
+one — an error names the actual problem, where this table can only name a
+destination.
+
+`ready` is the readiness mailbox saying both `signedIn` and `micGranted`; a
+missing file counts as not ready. The not-set-up tap **mints no session** — it
+opens `parley://` and nothing else, because a start request in that state can
+only be answered with a failure, and a pane that flipped to "listening" to show
+it would be the same lie in a new state.
+
+The third row is the interesting one, because it describes a tap whose outcome
+is not yet known: it goes through the ordinary `startDictation` path, so if the
+app is still resident it acks over the Darwin channel within milliseconds and
+the pane flips to listening *in place*. Promising the jump and then not making it
+is the right way round — the reverse is the bug this whole section is about — and
+in practice the user reads the glyph after the button has already become ⏹.
+
 **Return is a glyph, not a word.** The host decides what the key is *called* —
 Go, Send, Search — and a 44pt disc has no room for "Search"; `returnKeyGlyph`
 maps the type to a symbol instead. What the key *does* is unchanged: it types a
 line break, because a keyboard extension cannot fire the host's return action.
 
 **The live transcript.** The settled tail is echoed above the button in a softer
-ink, followed by the words not yet settled. Settled text has already been
-inserted into the document — but the document is usually behind the keyboard, so
-without the echo dictation reads as words that appear and then vanish. The
-window is capped at 140 characters and cleared with the session: a few hundred
-bytes, not the transcript history a keyboard extension must not hold. The slot's
-height is fixed so beginning to speak never resizes the keyboard.
+ink, followed by the words not yet settled. This began as an echo — settled text
+was already in the document, which is usually hidden behind the keyboard — and
+since insertion moved to the end of the session it is the *only* place the words
+are visible while they are being spoken. The window is still capped at 140
+characters and cleared with the session: a few hundred bytes, not the transcript
+history a keyboard extension must not hold. Raising the cap would not show more,
+because three lines at this size hold fewer characters than that — it would only
+push more of the newest words past the truncation. The slot's height is fixed so
+beginning to speak never resizes the keyboard.
 
 ### No Bopomofo engine — 注音 is the system's job
 

--- a/ios/App/Parley/AppState.swift
+++ b/ios/App/Parley/AppState.swift
@@ -56,6 +56,25 @@ final class AppState: NSObject, ObservableObject {
     /// `signedIn`, so being offline is never mistaken for being signed out.
     var hasAccount: Bool { user != nil || hasStoredSession }
 
+    /// Tell the keyboard whether tapping its mic could transcribe anything.
+    ///
+    /// The keyboard cannot read the Keychain or ask about the microphone, so
+    /// without this it could only find out by starting a session and reading
+    /// back the failure — which is why it used to offer a mic button that could
+    /// not record. Both facts outlive this process, so the keyboard reads them
+    /// with no staleness rule; see `DictationChannel.KeyboardReadiness`.
+    ///
+    /// `static` because the microphone prompt resolves inside
+    /// `DictationCoordinator`, which has no `AppState` to ask. The Keychain is
+    /// the same source `hasStoredSession` mirrors, and `user != nil` always
+    /// implies a stored token, so the two readings cannot disagree.
+    static func publishKeyboardReadiness() {
+        DictationChannel.writeReadiness(
+            .init(
+                signedIn: KeychainStore.get(tokenKey) != nil,
+                micGranted: AudioCapture.permission == .granted))
+    }
+
     private(set) lazy var cloud = CloudClient {
         KeychainStore.get(AppState.tokenKey)
     }
@@ -90,6 +109,10 @@ final class AppState: NSObject, ObservableObject {
         let token = KeychainStore.get(Self.tokenKey)
         hasStoredSession = token != nil
         bootstrapped = true
+        // Launch is the one beat that has to republish unconditionally: iOS
+        // restarts the app when microphone permission is changed in Settings,
+        // so the grant may have flipped while nothing was running to notice.
+        Self.publishKeyboardReadiness()
         guard token != nil else { return }
 
         do {
@@ -227,11 +250,13 @@ final class AppState: NSObject, ObservableObject {
     private func storeToken(_ token: String) {
         KeychainStore.set(token, for: Self.tokenKey)
         hasStoredSession = true
+        Self.publishKeyboardReadiness()
     }
 
     private func clearStoredToken() {
         KeychainStore.delete(Self.tokenKey)
         hasStoredSession = false
+        Self.publishKeyboardReadiness()
     }
 
     #if DEBUG

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -262,6 +262,10 @@ final class DictationCoordinator: ObservableObject {
             awaitingMicPermission = true
             let granted = await AudioCapture.requestPermission()
             awaitingMicPermission = false
+            // The prompt is the moment the keyboard's pane can stop saying
+            // "set up voice typing" — or must start saying it. Published
+            // either way, since a refusal is news too.
+            AppState.publishKeyboardReadiness()
             guard granted else {
                 // Re-read to name the actual situation: a refusal in the
                 // prompt is a Settings trip; a prompt that never got answered
@@ -607,14 +611,19 @@ final class DictationCoordinator: ObservableObject {
     }
 
     /// Out of redials. End the session rather than leave a microphone running
-    /// into nothing — but keep every word already settled, which the keyboard
-    /// has already typed into the user's document.
+    /// into nothing.
+    ///
+    /// The copy used to say the settled words had already been typed. They had,
+    /// when the keyboard inserted every delta as it arrived; it now inserts once
+    /// at `.done`, and an error is not `.done` — so an ended session leaves the
+    /// user's field untouched, and saying otherwise would send them looking for
+    /// text that is not there.
     private func endAfterLostConnection() {
         audio.discard()
         fail(
             String(
                 localized:
-                    "Lost the connection. What you already said has been typed — tap the mic to carry on."
+                    "Lost the connection before anything could be typed. Tap the mic to try again."
             ))
     }
 
@@ -863,7 +872,9 @@ final class DictationCoordinator: ObservableObject {
                 publishWindow()
                 return
             default:
-                guard await AudioCapture.requestPermission() else {
+                let granted = await AudioCapture.requestPermission()
+                AppState.publishKeyboardReadiness()
+                guard granted else {
                     windowProblem = String(
                         localized: "Microphone access wasn't granted, so there is no window to keep open.")
                     window = .closed(length: length)

--- a/ios/App/Parley/DictationView.swift
+++ b/ios/App/Parley/DictationView.swift
@@ -136,7 +136,7 @@ struct DictationView: View {
         if needsManualReturn {
             return String(
                 localized:
-                    "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen."
+                    "Your words show up on the Parley keyboard as you talk, and land at the cursor when you stop — nothing happens on this screen."
             )
         }
         return String(localized: "You're back in your app — just talk.")

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -1189,19 +1189,18 @@
         }
       }
     },
-    "Lost the connection. What you already said has been typed — tap the mic to carry on.": {
-      "extractionState": "manual",
+    "Lost the connection before anything could be typed. Tap the mic to try again.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lost the connection. What you already said has been typed — tap the mic to carry on."
+            "value": "Lost the connection before anything could be typed. Tap the mic to try again."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "連線中斷了。剛才說過的內容已經打出來，點一下麥克風就能接著說。"
+            "value": "連線中斷，還沒來得及打出任何文字。點一下麥克風再試一次。"
           }
         }
       }
@@ -2419,7 +2418,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 Parley 鍵盤上點麥克風，說的話就會即時打進游標處。"
+            "value": "在 Parley 鍵盤上點麥克風，說的話就會打進游標處。"
           }
         }
       }
@@ -3001,18 +3000,18 @@
         }
       }
     },
-    "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen.": {
+    "Your words show up on the Parley keyboard as you talk, and land at the cursor when you stop — nothing happens on this screen.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Your words show up on the Parley keyboard and land at the cursor as you talk — nothing happens on this screen."
+            "value": "Your words show up on the Parley keyboard as you talk, and land at the cursor when you stop — nothing happens on this screen."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "說話的內容會直接顯示在 Parley 鍵盤上、即時打進游標處——這個畫面不會顯示任何東西。"
+            "value": "說話的內容會顯示在 Parley 鍵盤上，停止後整段話會打進游標處——這個畫面不會顯示任何東西。"
           }
         }
       }

--- a/ios/App/Parley/ParleyApp.swift
+++ b/ios/App/Parley/ParleyApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ParleyApp: App {
     @StateObject private var app = AppState()
     @StateObject private var dictation = DictationCoordinator.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     /// The navigation and tab bars are drawn by UIKit and never see a SwiftUI
     /// `.font()`, so their appearance proxies are configured once here, before
@@ -36,6 +37,14 @@ struct ParleyApp: App {
                 // in the background — the cover is ready when it next appears).
                 .fullScreenCover(isPresented: dictationPresented) {
                     DictationView(coordinator: dictation)
+                }
+                // Every foregrounding, not only launch: a trip to Settings to
+                // grant the microphone brings the app back here rather than
+                // through `init`, and the keyboard's pane is only honest for as
+                // long as this file is.
+                .onChange(of: scenePhase) { _, phase in
+                    guard phase == .active else { return }
+                    AppState.publishKeyboardReadiness()
                 }
         }
     }

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -1,3 +1,4 @@
+import ParleyKit
 import SwiftUI
 
 /// The Parley keyboard's face.
@@ -277,6 +278,12 @@ struct KeyboardRootView: View {
     /// gradient, listening it goes flat recording red inside a breathing ring,
     /// so "armed" is never something you have to read out of a gradient — and
     /// never needs a second element saying "Listening…" beside it.
+    ///
+    /// The **glyph** is where the button stops promising more than it can do. A
+    /// microphone means "speak now and the words appear here", and that is only
+    /// true when the app is set up and holding an open microphone window;
+    /// otherwise the tap goes to Parley, and the button says so. The colour
+    /// stays either way — the button is still the thing to press.
     private var recordButton: some View {
         PressableButton(action: toggle) { pressed in
             ZStack {
@@ -287,15 +294,31 @@ struct KeyboardRootView: View {
                     .fill(recordFill)
                     .frame(width: KBMetrics.recordSize, height: KBMetrics.recordSize)
                     .brightness(pressed ? -0.06 : 0)
-                Image(systemName: bridge.listening ? "stop.fill" : "mic.fill")
-                    .font(.system(size: bridge.listening ? 24 : 28, weight: .medium))
+                Image(systemName: recordGlyph)
+                    .font(.system(size: bridge.listening ? 24 : 27, weight: .medium))
                     .foregroundStyle(recordInk)
             }
             .frame(width: KBMetrics.deckHeight, height: KBMetrics.deckHeight)
         }
         .disabled(!bridge.hasFullAccess)
-        .accessibilityLabel(
-            bridge.listening ? Text("Stop dictation") : Text("Start dictation"))
+        .accessibilityLabel(recordLabel)
+    }
+
+    private var recordGlyph: String {
+        if bridge.listening { return "stop.fill" }
+        return bridge.opensApp ? "arrow.up.forward.app" : "mic.fill"
+    }
+
+    /// The label says what the tap does, not what the button is called — the
+    /// three idle states are three different actions.
+    private var recordLabel: Text {
+        if bridge.listening { return Text("Stop dictation") }
+        // Without Full Access the button is dimmed and the slot explains why;
+        // the label stays what it was so nothing about that state changes.
+        guard bridge.hasFullAccess else { return Text("Start dictation") }
+        if !bridge.ready { return Text("Open Parley to set up voice typing") }
+        if !bridge.windowIsOpen { return Text("Start dictation, which opens Parley first") }
+        return Text("Start dictation")
     }
 
     /// Disabled (no Full Access) reads inert rather than inviting: the button
@@ -313,17 +336,29 @@ struct KeyboardRootView: View {
     private func toggle() {
         if bridge.listening {
             bridge.stop()
+        } else if !bridge.ready {
+            // Nothing to start. Without an account or microphone permission the
+            // app can only answer a session request with a failure, and minting
+            // one would flip this pane into a listening state that never
+            // listens — so the tap does the one thing that helps and opens
+            // Parley, where both can be fixed.
+            open(DictationChannel.appURL)
         } else {
             // The bridge tries the no-jump start first; the completion only
-            // fires when the app really has to come forward. SwiftUI's openURL
-            // is the path that still opens the container app from a keyboard
-            // on iOS 18+; the responder-chain walk covers older releases.
+            // fires when the app really has to come forward.
             bridge.start { url in
                 guard let url else { return }
-                openURL(url) { accepted in
-                    if !accepted { bridge.fallbackOpen(url) }
-                }
+                open(url)
             }
+        }
+    }
+
+    /// Open the container app. SwiftUI's `openURL` is the path that still works
+    /// from a keyboard on iOS 18+; the responder-chain walk covers older
+    /// releases.
+    private func open(_ url: URL) {
+        openURL(url) { accepted in
+            if !accepted { bridge.fallbackOpen(url) }
         }
     }
 
@@ -331,13 +366,17 @@ struct KeyboardRootView: View {
 
     /// One fixed-height slot above the button, so the keyboard never changes
     /// shape between states: the Full Access explainer, an error, the live
-    /// transcript, or the idle prompt.
+    /// transcript, the set-up notice, or the idle prompt.
     ///
     /// The live case shows the settled tail in a softer ink followed by the
-    /// words not yet settled. Settled text has already been inserted into the
-    /// document, but the document is usually behind the keyboard — echoing a
-    /// short tail is what makes dictation read as continuous instead of as
-    /// words that appear and then vanish.
+    /// words not yet settled. The transcript only reaches the document when the
+    /// session is done, so until then this slot is where the words are — which
+    /// is also why the fixed height matters more than it looks: beginning to
+    /// speak must not resize the keyboard.
+    ///
+    /// The set-up notice sits *below* the error, not above it: an error names
+    /// the actual problem ("turn the microphone on in Settings"), and the
+    /// generic invitation to open the app is only better than saying nothing.
     private var textSlot: some View {
         Group {
             if !bridge.hasFullAccess {
@@ -353,6 +392,8 @@ struct KeyboardRootView: View {
                 reconnectingText
             } else if bridge.listening || !bridge.tail.isEmpty {
                 liveText
+            } else if !bridge.ready {
+                setUpNotice
             } else {
                 idleText
             }
@@ -365,9 +406,9 @@ struct KeyboardRootView: View {
     }
 
     /// The connection dropped mid-sentence. The transcript stays exactly where
-    /// it was — nothing typed is taken back — with one line above it saying
-    /// why it stopped growing. Amber rather than the error red: the session is
-    /// still alive and the words are being kept.
+    /// it was — nothing already said is thrown away — with one line above it
+    /// saying why it stopped growing. Amber rather than the error red: the
+    /// session is still alive and the words are being kept.
     private var reconnectingText: some View {
         VStack(alignment: .leading, spacing: 2) {
             Spacer(minLength: 0)
@@ -384,26 +425,46 @@ struct KeyboardRootView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Idle, and — for someone who has turned the microphone window on — what
-    /// this particular tap is going to do.
+    /// Parley has never been set up far enough to dictate: no account on this
+    /// device, or no microphone permission.
     ///
-    /// The second line only appears while the feature is *on but closed*.
-    /// Without a window every tap opens Parley, always has, and saying so on a
-    /// keyboard someone is about to type on is noise. With one, it is the
-    /// difference the setting exists to make, and it must not be legible only
-    /// as the absence of a chip.
-    private var idleText: some View {
+    /// Which of the two it is deliberately isn't said here. The keyboard knows,
+    /// but neither can be fixed from a keyboard, the slot is three lines, and
+    /// both end in the same place — so the copy names the destination instead of
+    /// the diagnosis.
+    private var setUpNotice: some View {
         centered {
             VStack(spacing: 3) {
-                Text("Tap to speak")
-                    .font(.subheadline)
-                    .foregroundStyle(KBTheme.inkSoft(dark))
-                if bridge.windowIsChosen && !bridge.windowIsOpen {
-                    Text("This tap opens Parley first")
-                        .font(.caption2)
-                        .foregroundStyle(KBTheme.inkSoft(dark).opacity(0.8))
+                Text("Set up voice typing in Parley")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(KBTheme.ink(dark))
+                Text("Tap to open the app")
+                    .font(.caption2)
+                    .foregroundStyle(KBTheme.inkSoft(dark).opacity(0.8))
+            }
+            .multilineTextAlignment(.center)
+        }
+    }
+
+    /// Idle and set up: what this particular tap is going to do.
+    ///
+    /// "Tap to speak" is only true while a microphone window is open. It used to
+    /// be the headline in both cases, with a caption underneath — *This tap
+    /// opens Parley first* — for the people who had turned a window on. That was
+    /// backwards: the common case is the one that leaves, and the caption said
+    /// exactly what this line now says. So the promise moved into the headline,
+    /// where it matches the glyph on the button.
+    private var idleText: some View {
+        centered {
+            Group {
+                if bridge.windowIsOpen {
+                    Text("Tap to speak")
+                } else {
+                    Text("Dictation starts in Parley")
                 }
             }
+            .font(.subheadline)
+            .foregroundStyle(KBTheme.inkSoft(dark))
         }
     }
 

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -7,9 +7,9 @@ import UIKit
 /// A keyboard extension is forbidden from opening the microphone, so this
 /// keyboard doesn't try. Its mic button opens `parley://dictate`; the container
 /// app records and streams the transcript back through the App Group; this
-/// keyboard inserts the settled text with `textDocumentProxy.insertText`. The
-/// design and its constraints are written up in
-/// `docs/design/ios-voice-keyboard.md`.
+/// keyboard shows it live above the keys and, when the session is done, inserts
+/// the finished text in one `textDocumentProxy.insertText`. The design and its
+/// constraints are written up in `docs/design/ios-voice-keyboard.md`.
 ///
 /// Everything expensive (audio, the relay, any model) stays in the app. This
 /// process only shuttles text, which keeps it well under the tight jetsam limit
@@ -21,6 +21,9 @@ final class KeyboardViewController: UIInputViewController {
     /// It is what lets a tap that will stay put look different from a tap that
     /// will jump — see `MicWindowState`.
     private var windowNote: DarwinObserver?
+    /// The app announcing that the answer to "could a tap dictate at all"
+    /// changed — a sign-in, a sign-out, or the microphone prompt being answered.
+    private var readyNote: DarwinObserver?
 
     /// The keyboard's view of the current session. It mints the id, so it owns
     /// the truth about which downlink is "ours"; a downlink for any other
@@ -101,6 +104,13 @@ final class KeyboardViewController: UIInputViewController {
             windowNote = DarwinObserver(DictationChannel.windowNote) { [weak self] in
                 DispatchQueue.main.async { self?.readWindow() }
             }
+            // Rare compared to the others — signing in and answering the
+            // microphone prompt happen once — but it is the note that turns a
+            // "set up voice typing" pane into a working one without the user
+            // having to dismiss the keyboard and bring it back.
+            readyNote = DarwinObserver(DictationChannel.readyNote) { [weak self] in
+                DispatchQueue.main.async { self?.readReadiness() }
+            }
         }
     }
 
@@ -117,6 +127,7 @@ final class KeyboardViewController: UIInputViewController {
         if !bridge.listening { bridge.tail = "" }
         refreshAppearance()
         refreshReturnKey()
+        readReadiness()
         readWindow()
         drainDownlink()
     }
@@ -222,6 +233,23 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
+    // MARK: readiness
+
+    /// Read whether the app is in a state where a tap could transcribe at all.
+    ///
+    /// Deliberately without the staleness rule the window gets: an account and a
+    /// microphone grant are facts about the installation, not about a process
+    /// that may have died, so the newest file is always the truth. A *missing*
+    /// file is not an unknown either — it means Parley has never run here, which
+    /// is exactly the state this pane needs to describe.
+    private func readReadiness() {
+        guard hasFullAccess else {
+            bridge.ready = false
+            return
+        }
+        bridge.ready = DictationChannel.readReadiness()?.canDictate ?? false
+    }
+
     // MARK: the microphone window (called from SwiftUI)
 
     /// Read what the app says about the microphone window.
@@ -233,11 +261,13 @@ final class KeyboardViewController: UIInputViewController {
     private func readWindow() {
         guard hasFullAccess else {
             bridge.windowIsOpen = false
-            bridge.windowIsChosen = false
             return
         }
+        // Only whether it is open now. Whether the user has *chosen* a length
+        // used to be mirrored too, to decide whether the idle slot should warn
+        // that the tap would leave — the pane now says so unconditionally, in
+        // the headline and on the button, so there is nothing left to decide.
         let window = DictationChannel.readWindow()
-        bridge.windowIsChosen = (window?.length ?? .off) != .off
         bridge.windowIsOpen = window?.isOpen() ?? false
         // Rounded up, so "1m" never means "already gone": the number is there
         // to say roughly how much room is left, and rounding down would let the
@@ -279,15 +309,27 @@ final class KeyboardViewController: UIInputViewController {
     /// or a long-finished transcript that would land in the wrong field.
     private static let adoptionWindow: TimeInterval = 150
 
-    /// How much settled text the keyboard echoes above the record button. Long
-    /// enough to read as a continuing sentence in the three lines the slot has,
-    /// short enough that this is a window rather than the transcript history a
-    /// keyboard extension must not hold.
+    /// How much settled text the keyboard echoes above the record button.
+    ///
+    /// Since nothing is inserted until the session is done, this echo is the
+    /// only place the words are visible while they are being spoken — but it is
+    /// still a window, not a transcript. Three lines at this size hold rather
+    /// fewer than 140 characters, so the cap is already past what the slot can
+    /// show; raising it would only push more of the newest words out of view.
     private static let tailLimit = 140
 
-    /// Read the transcript the app has published and insert whatever is new.
-    /// Idempotent: `insertedCount` is the high-water mark, so a keyboard that
-    /// was killed and relaunched mid-session never re-inserts settled text.
+    /// Read the transcript the app has published, and insert it once the app
+    /// says the session is done.
+    ///
+    /// Nothing is inserted while the session runs. Streaming each delta into the
+    /// host field as it settled meant the relay's revisions landed as visible
+    /// churn in someone's document, and a dictation abandoned halfway left a
+    /// half-sentence behind; the live view above the record button is where the
+    /// words belong until they are final.
+    ///
+    /// Idempotent either way: `insertedCount` is the high-water mark, persisted
+    /// through the uplink, so a keyboard killed and relaunched after the session
+    /// finished still inserts the transcript exactly once.
     private func drainDownlink() {
         guard hasFullAccess, let d = DictationChannel.readDownlink() else { return }
 
@@ -319,10 +361,16 @@ final class KeyboardViewController: UIInputViewController {
             insertedCount = up.insertedCount
         }
 
+        // One insertion, at the end. `.done` is the only state that has the
+        // whole transcript — `finishing` is still waiting on the relay's last
+        // utterance — and `.error` deliberately inserts nothing at all: a
+        // session that failed leaves the user's field exactly as they left it.
+        // The high-water mark is still what makes this safe, because `.done`
+        // republishes on every drain and the keyboard drains on every
+        // appearance.
         let committed = Array(d.committed)
-        if committed.count > insertedCount {
-            let delta = String(committed[insertedCount...])
-            textDocumentProxy.insertText(delta)
+        if d.state == .done, committed.count > insertedCount {
+            textDocumentProxy.insertText(String(committed[insertedCount...]))
             insertedCount = committed.count
             var up = DictationChannel.readUplink() ?? .init(session: session)
             up.insertedCount = insertedCount
@@ -445,11 +493,11 @@ final class KeyboardBridge: ObservableObject {
     /// The last stretch of settled text for the running session, shown above
     /// the record button in a softer ink so dictation reads as continuous.
     ///
-    /// It is a short window, not history: settled text is already in the host's
-    /// document, and this only exists because the document is usually behind
-    /// the keyboard. Capped at `tailLimit` characters, cleared with the
-    /// session — a few hundred bytes, nowhere near the transcript store the
-    /// extension deliberately doesn't keep.
+    /// It is a short window, not history: the transcript lands in the host's
+    /// document in one piece when the session is done, and until then this is
+    /// where the words are visible. Capped at `tailLimit` characters, cleared
+    /// with the session — a few hundred bytes, nowhere near the transcript
+    /// store the extension deliberately doesn't keep.
     @Published var tail = ""
     /// Whether the system wants *us* to draw a next-keyboard key. False from
     /// iPhone X onwards, where iOS draws its own beneath the keyboard and the
@@ -459,17 +507,33 @@ final class KeyboardBridge: ObservableObject {
     /// connection), shown in the caption slot until the next start.
     @Published var errorText: String?
 
+    /// Parley is set up far enough for a tap to actually transcribe: an account
+    /// on this device, and microphone permission granted. False when the
+    /// readiness file is missing too, which is what "Parley has never run here"
+    /// looks like from inside the extension.
+    ///
+    /// The pane used to offer a mic button in every state, so someone who had
+    /// never opened the app tapped a button that could only fail — the bug this
+    /// exists to close. See `DictationChannel.KeyboardReadiness`.
+    @Published var ready = false
+
     /// The microphone window is open: the next tap will be served where the
     /// user already is, with no trip through Parley.
     @Published var windowIsOpen = false
-    /// The user has chosen a window length at all. Distinct from
-    /// `windowIsOpen`, and the distinction is the whole point: someone who has
-    /// not turned the feature on is told nothing, while someone who has needs
-    /// to know that *this* tap falls outside it.
-    @Published var windowIsChosen = false
     /// Roughly how long the open window has left, in whole minutes. Refreshed
     /// by the app's heartbeat rather than by a timer in this process.
     @Published var windowMinutesLeft: Int?
+
+    /// This tap leaves for Parley rather than recording here: the app is not set
+    /// up, or there is no open microphone window to borrow.
+    ///
+    /// It is what the record button draws instead of a microphone. A mic glyph
+    /// that cannot open a mic is the whole bug — and even in the merely
+    /// windowless case the honest promise is "this opens Parley", because
+    /// staying put depends on a process that may already be gone. When it
+    /// happens to still be there, the pane flips to listening in place and the
+    /// button becomes ⏹ before the user has read the glyph.
+    var opensApp: Bool { hasFullAccess && (!ready || !windowIsOpen) }
 
     /// Which pane is showing. Changing it also has to change the keyboard's
     /// height, which only the controller can do — hence `setMode` rather than a

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -68,6 +68,22 @@
         }
       }
     },
+    "Dictation starts in Parley": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictation starts in Parley"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音輸入從 Parley 開始"
+          }
+        }
+      }
+    },
     "Done": {
       "extractionState": "manual",
       "localizations": {
@@ -187,6 +203,22 @@
         }
       }
     },
+    "Open Parley to set up voice typing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Parley to set up voice typing"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟 Parley 設定語音輸入"
+          }
+        }
+      }
+    },
     "Reconnecting… keep talking": {
       "extractionState": "manual",
       "localizations": {
@@ -234,6 +266,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "傳送"
+          }
+        }
+      }
+    },
+    "Set up voice typing in Parley": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set up voice typing in Parley"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到 Parley 完成語音輸入設定"
           }
         }
       }
@@ -299,6 +347,22 @@
         }
       }
     },
+    "Start dictation, which opens Parley first": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start dictation, which opens Parley first"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始語音輸入，會先開啟 Parley"
+          }
+        }
+      }
+    },
     "Stop dictation": {
       "localizations": {
         "en": {
@@ -311,6 +375,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "停止語音輸入"
+          }
+        }
+      }
+    },
+    "Tap to open the app": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to open the app"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點一下開啟 Parley"
           }
         }
       }
@@ -344,23 +424,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "麥克風待命中，點一下即可關閉。"
-          }
-        }
-      }
-    },
-    "This tap opens Parley first": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This tap opens Parley first"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "這次會先開啟 Parley"
           }
         }
       }

--- a/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
@@ -5,17 +5,21 @@ import Foundation
 /// iOS 8, Full Access included), so dictation runs in the app and the transcript
 /// is handed back through the App Group container.
 ///
-/// Four single-writer mailboxes, each with its own Darwin notification, so the
+/// Five single-writer mailboxes, each with its own Darwin notification, so the
 /// two processes never contend on the same file:
 ///   - `downlink` (app → keyboard): the growing transcript + session state.
 ///   - `uplink`   (keyboard → app): the session request, host bundle id, stop.
 ///   - `window`   (app → keyboard): the microphone window — whether the next
 ///     tap will be served where the user is, or has to open Parley.
 ///   - `window control` (keyboard → app): end the window now.
+///   - `readiness` (app → keyboard): whether dictation could work at all —
+///     an account on this device, and microphone permission.
 ///
 /// The window pair is separate from the session pair on purpose: a window
 /// outlives any one dictation and most of what it has to say happens when no
-/// session exists at all.
+/// session exists at all. Readiness is separate from both for the opposite
+/// reason: it is not about a moment but about the installation, and it is the
+/// one thing here that has to be readable before anything has ever happened.
 ///
 /// Darwin notifications carry no payload — they are pure "go re-read" signals.
 /// The files are the source of truth, which is what makes this robust to the
@@ -39,6 +43,9 @@ public enum DictationChannel {
     public static let windowNote = "com.pathors.parley.dictation.window"
     /// keyboard → app: end the microphone window now.
     public static let windowControlNote = "com.pathors.parley.dictation.window-control"
+    /// app → keyboard: the answer to "could a tap dictate at all" changed —
+    /// someone signed in or out, or the microphone prompt was answered.
+    public static let readyNote = "com.pathors.parley.dictation.ready"
 
     /// The URL the keyboard opens to start a session. The app routes this in
     /// `onOpenURL`. The session id round-trips so a stale downlink from a prior
@@ -46,6 +53,12 @@ public enum DictationChannel {
     public static func startURL(session: String) -> URL {
         URL(string: "parley://dictate?session=\(session)")!
     }
+
+    /// Just open the app, with nothing asked of it. The keyboard uses this when
+    /// there is no session worth minting — no account, or no microphone
+    /// permission — because a start request in that state can only be answered
+    /// with a failure the user has to leave for the app to fix anyway.
+    public static let appURL = URL(string: "parley://")!
 
     public static func session(fromStart url: URL) -> String? {
         guard url.scheme == "parley", url.host == "dictate",
@@ -165,10 +178,57 @@ public enum DictationChannel {
         read("dictation-window-control.json")
     }
 
+    // MARK: readiness (app writes, keyboard reads)
+
+    /// Whether tapping the keyboard's mic could transcribe anything at all.
+    ///
+    /// The keyboard has no Keychain of its own and no microphone to ask about,
+    /// so without this it could only find out by minting a session and reading
+    /// back the app's failure — which is why its mic button used to invite a tap
+    /// it could not honour. Both facts belong to the *installation* rather than
+    /// to a moment: they outlive the app's process, so unlike `MicWindowState`
+    /// this needs no heartbeat and no staleness rule. A missing file is not a
+    /// stale answer, it is the honest one — Parley has never been set up here.
+    public struct KeyboardReadiness: Codable, Sendable, Equatable {
+        /// This device holds a Parley session. The app's own gate uses the same
+        /// notion, so an offline user who is signed in still counts.
+        public var signedIn: Bool
+        /// `AVAudioApplication` record permission is granted. Anything else —
+        /// denied, or never asked — means the app cannot open the microphone
+        /// without the user answering something first.
+        public var micGranted: Bool
+        /// When the app last wrote this file (stamped by `writeReadiness`).
+        /// Optional so files written before the field existed still decode. It
+        /// is diagnostic only: nothing reads it to decide whether to believe
+        /// the rest, because these facts do not go stale.
+        public var updatedAt: Date?
+
+        public init(signedIn: Bool = false, micGranted: Bool = false, updatedAt: Date? = nil) {
+            self.signedIn = signedIn
+            self.micGranted = micGranted
+            self.updatedAt = updatedAt
+        }
+
+        /// Both halves are in place, so a tap can actually record.
+        public var canDictate: Bool { signedIn && micGranted }
+    }
+
+    public static func writeReadiness(_ value: KeyboardReadiness) {
+        var stamped = value
+        stamped.updatedAt = Date()
+        write(stamped, to: "dictation-ready.json")
+        post(readyNote)
+    }
+
+    public static func readReadiness() -> KeyboardReadiness? {
+        read("dictation-ready.json")
+    }
+
     public static func clear() {
         for name in [
             "dictation-down.json", "dictation-up.json",
             "dictation-window.json", "dictation-window-control.json",
+            "dictation-ready.json",
         ] {
             if let url = container?.appendingPathComponent(name) {
                 try? FileManager.default.removeItem(at: url)

--- a/ios/ParleyKit/Tests/ParleyKitTests/DictationChannelTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/DictationChannelTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+
+@testable import ParleyKit
+
+/// The App Group mailboxes' wire format. The container itself needs two signed
+/// processes and a phone, so what is testable here is the encoding — which is
+/// exactly where a change breaks the other side of the channel silently, since
+/// a mailbox that fails to decode reads as "nothing there".
+final class DictationChannelTests: XCTestCase {
+    private func roundTrip<T: Codable>(_ value: T) throws -> T {
+        try JSONDecoder().decode(T.self, from: try JSONEncoder().encode(value))
+    }
+
+    // MARK: readiness
+
+    func testReadinessRoundTrips() throws {
+        let stamped = Date(timeIntervalSince1970: 1_700_000_000)
+        let value = DictationChannel.KeyboardReadiness(
+            signedIn: true, micGranted: true, updatedAt: stamped)
+        let back = try roundTrip(value)
+        XCTAssertEqual(back, value)
+        XCTAssertTrue(back.canDictate)
+        XCTAssertEqual(back.updatedAt, stamped)
+    }
+
+    func testReadinessNeedsBothHalves() {
+        XCTAssertFalse(
+            DictationChannel.KeyboardReadiness(signedIn: true, micGranted: false).canDictate)
+        XCTAssertFalse(
+            DictationChannel.KeyboardReadiness(signedIn: false, micGranted: true).canDictate)
+        XCTAssertFalse(DictationChannel.KeyboardReadiness().canDictate)
+    }
+
+    func testReadinessDecodesWithoutAStamp() throws {
+        // `updatedAt` is optional so a file written by an older build still
+        // decodes. It is diagnostic only — unlike the microphone window, these
+        // facts outlive the process that wrote them, so nothing reads the stamp
+        // to decide whether to believe the rest.
+        let json = Data(#"{"signedIn":true,"micGranted":true}"#.utf8)
+        let value = try JSONDecoder().decode(DictationChannel.KeyboardReadiness.self, from: json)
+        XCTAssertNil(value.updatedAt)
+        XCTAssertTrue(value.canDictate)
+    }
+
+    // MARK: session mailboxes
+
+    func testDownlinkRoundTripsEveryState() throws {
+        for state in [
+            DictationChannel.Downlink.State.starting, .listening, .reconnecting, .finishing,
+            .done, .error,
+        ] {
+            let back = try roundTrip(
+                DictationChannel.Downlink(
+                    session: "s", committed: "hello ", partial: "world", state: state))
+            XCTAssertEqual(back.state, state)
+            XCTAssertEqual(back.committed, "hello ")
+            XCTAssertEqual(back.partial, "world")
+        }
+    }
+
+    func testUplinkCarriesTheInsertionHighWaterMark() throws {
+        let back = try roundTrip(
+            DictationChannel.Uplink(
+                session: "s", hostBundleID: "com.example.app", stopRequested: true,
+                insertedCount: 42))
+        XCTAssertEqual(back.insertedCount, 42)
+        XCTAssertEqual(back.hostBundleID, "com.example.app")
+        XCTAssertTrue(back.stopRequested)
+    }
+
+    // MARK: URLs
+
+    func testStartURLRoundTripsTheSession() {
+        let id = UUID().uuidString
+        XCTAssertEqual(DictationChannel.session(fromStart: .init(string: "parley://x")!), nil)
+        XCTAssertEqual(
+            DictationChannel.session(fromStart: DictationChannel.startURL(session: id)), id)
+    }
+
+    func testAppURLAsksForNothing() {
+        // The keyboard opens this when there is no session worth minting; it
+        // must not look like a start request to the app's `onOpenURL`.
+        XCTAssertNil(DictationChannel.session(fromStart: DictationChannel.appURL))
+    }
+}


### PR DESCRIPTION
Closes #309.

**Honest voice-pane states.** The pane used to offer a mic button in every state, so someone who had never opened Parley (or had no mic window open) tapped a button that read "Tap to speak" and nothing transcribed where they were.

- New fifth App Group mailbox `dictation-ready.json` (`KeyboardReadiness {signedIn, micGranted}`), published by the app on launch, on foreground, on sign-in/out, and after the mic prompt resolves. No staleness rule on purpose: these are facts about the installation, not about a live process.
- Not set up → the big button keeps the brand gradient but shows `arrow.up.forward.app`; the slot says **"Set up voice typing in Parley — tap to open the app"**; the tap opens `parley://` and mints no session.
- Set up but no open mic window → same open-app glyph, slot says dictation opens Parley first; the tap still takes the silent Darwin-ack fast path when the app happens to be awake.
- Mic window open → the mic button and "Tap to speak", as before.

**One-shot insertion.** Nothing is inserted while a session runs — the live transcript stays in the keyboard's echo slot — and the whole committed text lands in one `insertText` when the session reaches `.done`. `.error` inserts nothing. The `insertedCount` high-water idempotency and the foreign-session adoption rules are unchanged, so a keyboard killed and relaunched after `done` still inserts exactly once.

Design doc updated (five mailboxes, new state table, insertion rationale). All new strings localized en + zh-Hant.

Verified: `swift test` 65/65; `xcodebuild` iPhone 17 Pro simulator BUILD SUCCEEDED.