### PR TITLE
[feature] a personal dictionary that learns from post-dictation corrections

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -114,6 +114,10 @@ signals (they carry no payload). This is what makes the hand-off robust to the
 keyboard being suspended/killed while the app is foregrounded — whatever it
 missed is still in the downlink when it returns.
 
+`lexicon.json` sits in the same container but is **not** part of this channel:
+it is shared state rather than a mailbox, read at the two moments it matters and
+carrying no notification of its own. See the personal dictionary below.
+
 App Group id: `group.com.pathors.parley.ios` (entitlement on both targets).
 
 ## Not leaving in the first place — the microphone window
@@ -308,6 +312,117 @@ Two things are worth writing down rather than repeating:
 
 Neither is why the reported bug happens, which is worth being clear about: the
 report is that dictation *leaves*, and leaving is what the window fixes.
+
+## Personal dictionary
+
+Dictation types and forgets. A name the STT mishears stays wrong in every future
+dictation, and the user re-fixes it every time — which is the loop the desktop
+closed in #295 with a phrase dictionary learned from post-paste corrections. This
+is the phone's version of it, and the interesting differences are all in what a
+keyboard extension is able to see.
+
+`Lexicon` / `LexiconStore` (ParleyKit) hold correction pairs and hand-added terms
+in `lexicon.json` in the App Group container — same plumbing as
+`DictationChannel`, atomic writes and a tolerant decode, no Darwin note because
+nothing here is live. Every rule lives on the `Lexicon` **value**; the store is
+the same API with a file behind it, which is what lets all of it be unit-tested
+on a machine that has no App Group container.
+
+### What it can see, and what it can't
+
+The desktop reads the field it pasted into through the Accessibility API and
+watches the value settle. The keyboard has no such thing. Its entire view of the
+field is `textDocumentProxy.documentContextBeforeInput`: a run of text ending at
+the cursor, clipped at a length iOS does not promise, with no notification when
+anything changes. So the shape is a snapshot and a comparison — snapshot the
+window when the dictated text has just landed (`state == .done`), compare it
+against the window again at `viewWillDisappear` or at the start of the next
+session, diff, record.
+
+**The scope this buys is narrow, and it is worth stating rather than discovering:
+only edits the user makes while our keyboard is still up in that same field.**
+Dismiss the keyboard, switch apps, or move to another field before fixing the
+word and the correction is never seen. Nothing in the extension API would let it
+be — the field belongs to the host app, and the proxy exists only while we are
+the active input. Two smaller limits sit under it: the window can slide out of
+alignment in a field longer than 200 characters when an edit changes the text's
+length, and `viewWillDisappear` is not a promise on a process iOS kills without
+ceremony. In both cases nothing is learned, which is the intended failure —
+**capturing garbage here becomes a rule that rewrites the user's words from then
+on**, and that is far worse than capturing nothing.
+
+`LexiconCapture.alignable` is the one gate: the two windows have to agree at one
+end or the other, or they are two different pieces of text. It deliberately does
+*not* trim them down to their disagreement first, because a character-level trim
+cuts through the middle of words — "we use pearly" against "we use Parley" shares
+the prefix `we use ` and the suffix `y`, so the trimmed pair is `pearl → Parle`,
+a rule that could never match again since Latin pairs need a whole word. Handing
+both whole windows to a token-level diff is what keeps a learned pair at word
+edges. The anchor is also *weighted* rather than counted — an ideograph is worth
+two — because Chinese packs into five characters what English spends a clause on,
+and a raw count would have refused 在 → 再, the correction this was built for.
+
+`EditDiff` is that token-level diff: Latin runs are words, ideographs are single
+characters, an LCS aligns them, and adjacent changed tokens merge into one span.
+Most of the file is refusals — pure insertions, pure deletions, case,
+punctuation, whitespace, and anything over ten characters on either side. An
+insertion, a deletion, a typo fix and a wholesale rewrite all arrive through the
+same channel; only one of them is vocabulary.
+
+### Why a pair does nothing until it has been seen twice
+
+`Lexicon.autoApplyThreshold` is 2, and the second sighting is the whole point. A
+single edit is as likely to be someone rewording their sentence as it is to be a
+word Parley gets wrong, and the two are indistinguishable from a diff. Acting on
+one sighting would mean that the first time a user changed their mind mid-phrase,
+dictation started silently rewriting that word forever. Twice is cheap for a real
+mishearing — it recurs every time the word is said — and expensive for a
+coincidence. Until then the Settings row says *Learning* rather than showing a
+count, because a list of guesses should not look like a list of rules.
+
+A second, different correction of the same original follows one blunt rule: **the
+newer correction wins unless the standing one has already been confirmed.** Seen
+once is a guess and a fresher guess is better; seen twice is a habit and stays.
+It costs the ability to re-learn a confirmed pair a different way — deleting the
+row in Settings is how that is done, which is a thing the user can see, unlike a
+scoring rule.
+
+### Applied in the app, at the final fold
+
+`DictationCoordinator.applyLexicon` runs once, in `finishUp`, right after the
+last partial is folded in and right before the `done` downlink — the first moment
+the transcript is finished and the last before the keyboard reads it. Mid-session
+is excluded on purpose: the relay is still revising those words, and the keyboard
+has already typed them.
+
+It rewrites **only the tail the keyboard has not typed yet.** The keyboard
+inserts settled text as it arrives and keeps its place with a plain character
+count (`Uplink.insertedCount`); rewriting text already in the user's document
+would move that boundary out from under it and the next insertion would be
+spliced in at the wrong offset — a correction bought at the price of mangling the
+sentence around it. Once insertion becomes one shot at `done` (#309) the boundary
+is zero and the whole transcript goes through the dictionary, which is where this
+wants to end up.
+
+Application itself is three rules, each of them a way of not doing damage: only
+confirmed pairs; longest original first (with both `parley` and `parley cloud` on
+file the longer has to win, or it comes out as neither); and word boundaries with
+case-insensitive matching for an all-ASCII original against a plain substring
+replacement for CJK, which is what makes `api` leave the `api` inside `rapid`
+alone while 在 → 再 works at all. A pair whose replacement properly contains its
+original is never applied — it would grow the text on every pass.
+
+### Known follow-up: recognition context
+
+The dictionary currently only rewrites text after the fact. Biasing recognition
+*at the source* would be better and the terms are ready for it
+(`LexiconStore.recognitionTerms`), but the wire is deliberately untouched:
+Soniox's config frame takes a `context.terms` list and the desktop fills it
+(`src-tauri/src/transcription/soniox.rs`), while `SonioxProtocol.Config` on the
+phone carries no such field. Whether the hosted relay forwards a `context` from
+an iOS client cannot be established from this side, and a config frame the relay
+rejects costs the user dictation altogether — so adding it is a separate change,
+made against a relay whose behaviour has been confirmed.
 
 ## Action Button / Control Center trigger
 

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -641,6 +641,40 @@ final class DictationCoordinator: ObservableObject {
         committed = runs.map(\.text).joined()
     }
 
+    /// Rewrite the finished transcript through the user's personal dictionary,
+    /// so the keyboard types the words they actually use (see `LexiconStore`).
+    ///
+    /// **Once, at the fold, and never mid-session.** While a sentence is still
+    /// arriving the relay keeps revising it, so a correction applied to
+    /// half-settled words would be applied to text that then changes underneath
+    /// it — and the keyboard would have typed the uncorrected version anyway.
+    /// The fold is the first moment the transcript is finished and the last
+    /// moment before the keyboard reads it.
+    ///
+    /// **And only the part the keyboard has not typed yet.** Today the keyboard
+    /// inserts settled text as it arrives and keeps its place with a plain
+    /// character count (`Uplink.insertedCount`). Rewriting text that is already
+    /// in the user's document would move that boundary out from under it, and
+    /// the keyboard's next insertion would be spliced in at the wrong offset —
+    /// a correction bought at the price of mangling the sentence around it. So
+    /// the already-typed prefix is left exactly as it is. Once insertion becomes
+    /// one shot at `done` (#309) the boundary is zero and the whole transcript
+    /// goes through the dictionary, which is where this wants to end up.
+    ///
+    /// This is the last write to `committed`: the relay leg is finished and
+    /// detached by the time `finishUp` runs, so no further segment can rebuild
+    /// it from `runs`.
+    private func applyLexicon() {
+        guard !committed.isEmpty else { return }
+        let typed = DictationChannel.readUplink().map {
+            $0.session == session ? $0.insertedCount : 0
+        } ?? 0
+        let boundary = min(max(typed, 0), committed.count)
+        let tail = String(committed.dropFirst(boundary))
+        guard !tail.isEmpty else { return }
+        committed = String(committed.prefix(boundary)) + LexiconStore.apply(to: tail)
+    }
+
     // MARK: stop / teardown
 
     func stop() async {
@@ -682,6 +716,7 @@ final class DictationCoordinator: ObservableObject {
         // Fold the last partial into the committed text so nothing said right
         // before the endpoint is dropped from what the keyboard inserts.
         foldPartialIn()
+        applyLexicon()
         publish()
         active = false
         // Not `beginLinger()` any more: whether this leaves a ~30 s background

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -224,6 +224,40 @@
         }
       }
     },
+    "Add": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入"
+          }
+        }
+      }
+    },
+    "Add a name or term": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a name or term"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入名字或術語"
+          }
+        }
+      }
+    },
     "Add the Parley keyboard": {
       "extractionState": "manual",
       "localizations": {
@@ -439,6 +473,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消"
+          }
+        }
+      }
+    },
+    "Clear everything": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear everything"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部清空"
+          }
+        }
+      }
+    },
+    "Clear the dictionary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear the dictionary"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空詞庫"
+          }
+        }
+      }
+    },
+    "Clear your personal dictionary?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear your personal dictionary?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要清空個人詞庫嗎？"
           }
         }
       }
@@ -885,6 +970,23 @@
         }
       }
     },
+    "Fix a word right after dictating it and Parley learns how you say it. What it has learned is in the personal dictionary, where you can also add names it should get right.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fix a word right after dictating it and Parley learns how you say it. What it has learned is in the personal dictionary, where you can also add names it should get right."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聽寫完馬上把字改對，Parley 就會記住你的說法。學到的東西都在個人詞庫裡，你也可以在那裡加上該念對的名字。"
+          }
+        }
+      }
+    },
     "Getting ready…": {
       "extractionState": "manual",
       "localizations": {
@@ -1033,6 +1135,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "語言"
+          }
+        }
+      }
+    },
+    "Learned corrections": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Learned corrections"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "學到的更正"
+          }
+        }
+      }
+    },
+    "Learning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Learning"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "學習中"
           }
         }
       }
@@ -1408,6 +1544,23 @@
         }
       }
     },
+    "Names, jargon, and anything else you say often. Parley keeps them so it can prefer your spelling — this list is yours to keep even where transcription can't yet be biased toward it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Names, jargon, and anything else you say often. Parley keeps them so it can prefer your spelling — this list is yours to keep even where transcription can't yet be biased toward it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名字、行話，還有任何你常講的詞。Parley 會留著，好照你的寫法來寫——即使目前還無法讓辨識偏向這份清單，它仍然是你的。"
+          }
+        }
+      }
+    },
     "No matches.": {
       "extractionState": "manual",
       "localizations": {
@@ -1506,6 +1659,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "目前沒有在錄音，也沒有在轉錄。"
+          }
+        }
+      }
+    },
+    "Nothing learned yet.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing learned yet."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還沒學到任何東西。"
           }
         }
       }
@@ -1629,6 +1799,23 @@
         }
       }
     },
+    "Parley forgets every correction it has learned and every term you added. It starts learning again from your next dictation.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley forgets every correction it has learned and every term you added. It starts learning again from your next dictation."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parley 會忘掉學到的每一項更正，以及你加入的每一個詞，並從下一次聽寫重新開始學。"
+          }
+        }
+      }
+    },
     "Parley needs microphone access. Turn it on in Settings › Parley.": {
       "extractionState": "manual",
       "localizations": {
@@ -1710,6 +1897,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "個人"
+          }
+        }
+      }
+    },
+    "Personal dictionary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal dictionary"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人詞庫"
           }
         }
       }
@@ -2813,6 +3017,23 @@
         }
       }
     },
+    "When you fix a word straight after dictating it, Parley notices. It waits until it has seen the same fix twice before using it, so one change of mind doesn't become a rule. Swipe a row away to unlearn it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When you fix a word straight after dictating it, Parley notices. It waits until it has seen the same fix twice before using it, so one change of mind doesn't become a rule. Swipe a row away to unlearn it."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聽寫完馬上改字，Parley 會記下來。同一個改法看到兩次才會真的採用，這樣臨時改個念頭就不會變成規則。往左滑掉某一列就是叫它忘掉。"
+          }
+        }
+      }
+    },
     "Wrapping up…": {
       "extractionState": "manual",
       "localizations": {
@@ -2996,6 +3217,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "登入已過期。按上面的按鈕重新登入，就能繼續錄音。"
+          }
+        }
+      }
+    },
+    "Your terms": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your terms"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的詞"
           }
         }
       }

--- a/ios/App/Parley/PersonalDictionaryView.swift
+++ b/ios/App/Parley/PersonalDictionaryView.swift
@@ -1,0 +1,161 @@
+import ParleyKit
+import SwiftUI
+
+/// The personal dictionary, made visible.
+///
+/// Everything on this screen was learned without being asked for, which is the
+/// reason the screen exists at all: a feature that quietly rewrites what someone
+/// dictates has to be a list they can read and a row they can delete. The
+/// mechanism is `LexiconStore`; this is the only place a person edits it.
+struct PersonalDictionaryView: View {
+    /// Read once per appearance rather than observed. The keyboard writes this
+    /// file from another process, and there is nothing to observe across that
+    /// boundary — but nothing here is live either: a correction learned while
+    /// this screen is open shows up the next time it is opened, which is soon
+    /// enough for a list of words.
+    @State private var lexicon = Lexicon()
+    @State private var newTerm = ""
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        Form {
+            correctionsSection
+            termsSection
+            if !lexicon.pairs.isEmpty || !lexicon.terms.isEmpty {
+                clearSection
+            }
+        }
+        .font(.parley.body)
+        .scrollContentBackground(.hidden)
+        .background(Theme.background)
+        .environment(\.defaultMinListRowHeight, 48)
+        .navigationTitle("Personal dictionary")
+        .onAppear { lexicon = LexiconStore.load() }
+        .confirmationDialog(
+            "Clear your personal dictionary?", isPresented: $showClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear everything", role: .destructive) {
+                LexiconStore.removeAll()
+                lexicon = LexiconStore.load()
+            }
+        } message: {
+            Text("Parley forgets every correction it has learned and every term you added. It starts learning again from your next dictation.")
+        }
+    }
+
+    // MARK: learned corrections
+
+    private var correctionsSection: some View {
+        Section {
+            if lexicon.pairs.isEmpty {
+                Text("Nothing learned yet.")
+                    .font(.parley.subheadline)
+                    .foregroundStyle(Theme.mutedForeground)
+            } else {
+                // Newest first, so a correction just learned sits where the
+                // person who made it will look for it.
+                ForEach(lexicon.pairsByRecency) { pair in
+                    correctionRow(pair)
+                }
+                .onDelete(perform: deletePairs)
+            }
+        } header: {
+            SettingsSection.header("Learned corrections")
+        } footer: {
+            SettingsSection.footer("When you fix a word straight after dictating it, Parley notices. It waits until it has seen the same fix twice before using it, so one change of mind doesn't become a rule. Swipe a row away to unlearn it.")
+        }
+        .listRowBackground(Theme.tintedSurface)
+    }
+
+    /// What was heard, an arrow, what the user meant — and how many times they
+    /// have said so. The count is the honest thing to show: it is what decides
+    /// whether the row is doing anything yet.
+    private func correctionRow(_ pair: LexiconPair) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(verbatim: pair.original)
+                .foregroundStyle(Theme.mutedForeground)
+            Image(systemName: "arrow.right")
+                .font(.parley.caption)
+                .foregroundStyle(Theme.mutedForeground)
+            Text(verbatim: pair.replacement)
+                .font(.parley.bodyEmphasized)
+            Spacer(minLength: 8)
+            if pair.count >= Lexicon.autoApplyThreshold {
+                // Verbatim: a digit and a multiplication sign read the same in
+                // both localizations, and a catalog key for them would be
+                // noise.
+                Text(verbatim: "\(pair.count)×")
+                    .font(.parley.caption.monospacedDigit())
+                    .foregroundStyle(Theme.mutedForeground)
+            } else {
+                // Seen once, so it is not being applied. Saying "learning" is
+                // the difference between a list of rules and a list of guesses.
+                Text("Learning")
+                    .font(.parley.caption)
+                    .foregroundStyle(Theme.warning)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: preferred terms
+
+    private var termsSection: some View {
+        Section {
+            HStack(spacing: 10) {
+                TextField("Add a name or term", text: $newTerm)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .onSubmit(addTerm)
+                Button("Add", action: addTerm)
+                    .font(.parley.subheadlineEmphasized)
+                    .disabled(newTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            ForEach(lexicon.termsByRecency) { term in
+                Text(verbatim: term.text)
+            }
+            .onDelete(perform: deleteTerms)
+        } header: {
+            SettingsSection.header("Your terms")
+        } footer: {
+            SettingsSection.footer("Names, jargon, and anything else you say often. Parley keeps them so it can prefer your spelling — this list is yours to keep even where transcription can't yet be biased toward it.")
+        }
+        .listRowBackground(Theme.tintedSurface)
+    }
+
+    private var clearSection: some View {
+        Section {
+            Button("Clear the dictionary", role: .destructive) {
+                showClearConfirmation = true
+            }
+        }
+        .listRowBackground(Theme.tintedSurface)
+    }
+
+    // MARK: editing
+
+    private func addTerm() {
+        let term = newTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else { return }
+        LexiconStore.addTerm(term)
+        newTerm = ""
+        lexicon = LexiconStore.load()
+    }
+
+    private func deletePairs(_ offsets: IndexSet) {
+        let listed = lexicon.pairsByRecency
+        for index in offsets {
+            LexiconStore.removePair(original: listed[index].original)
+        }
+        lexicon = LexiconStore.load()
+    }
+
+    private func deleteTerms(_ offsets: IndexSet) {
+        let listed = lexicon.termsByRecency
+        for index in offsets {
+            LexiconStore.removeTerm(listed[index].text)
+        }
+        lexicon = LexiconStore.load()
+    }
+}

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -88,26 +88,12 @@ struct SettingsView: View {
 
     private static let keyboardSectionID = "voice-keyboard"
 
-    /// Section headers as the landing site's eyebrow — brand blue and in the
-    /// sentence case they were written in, rather than the system's grey
-    /// all-caps. It is the one place a `Form` lets a brand speak.
-    ///
-    /// `primary` rather than `brand`, because this is small text: brand blue is
-    /// exactly what the dark palette swaps for sky, on the grounds that it
-    /// cannot be read on a navy-black page.
     private func sectionHeader(_ title: LocalizedStringKey) -> some View {
-        Text(title)
-            .font(.parley.footnote.weight(.semibold))
-            .foregroundStyle(Theme.primary)
-            .textCase(nil)
+        SettingsSection.header(title)
     }
 
-    /// Footers are the quiet half of a settings page: same DM Sans, one step
-    /// down, muted.
     private func sectionFooter(_ text: LocalizedStringKey) -> some View {
-        Text(text)
-            .font(.parley.footnote)
-            .foregroundStyle(Theme.mutedForeground)
+        SettingsSection.footer(text)
     }
 
     // MARK: account
@@ -446,8 +432,18 @@ struct SettingsView: View {
             } label: {
                 Text("Set-up steps").font(.parley.subheadlineEmphasized)
             }
+
+            // Below the set-up, because it is only worth anything once the
+            // keyboard is in use: the dictionary fills itself from dictation.
+            NavigationLink {
+                PersonalDictionaryView()
+            } label: {
+                Label("Personal dictionary", systemImage: "text.book.closed")
+            }
         } header: {
             sectionHeader("Voice keyboard")
+        } footer: {
+            sectionFooter("Fix a word right after dictating it and Parley learns how you say it. What it has learned is in the personal dictionary, where you can also add names it should get right.")
         }
         .listRowBackground(Theme.tintedSurface)
     }
@@ -603,6 +599,32 @@ struct SettingsView: View {
             deleteAccountError = String(
                 localized: "Your account was not deleted. Check your connection and try again.")
         }
+    }
+}
+
+/// The settings page's section grammar, shared by `SettingsView` and the screens
+/// it pushes so a pushed screen doesn't quietly fall back to the system's look.
+enum SettingsSection {
+    /// Section headers as the landing site's eyebrow — brand blue and in the
+    /// sentence case they were written in, rather than the system's grey
+    /// all-caps. It is the one place a `Form` lets a brand speak.
+    ///
+    /// `primary` rather than `brand`, because this is small text: brand blue is
+    /// exactly what the dark palette swaps for sky, on the grounds that it
+    /// cannot be read on a navy-black page.
+    static func header(_ title: LocalizedStringKey) -> some View {
+        Text(title)
+            .font(.parley.footnote.weight(.semibold))
+            .foregroundStyle(Theme.primary)
+            .textCase(nil)
+    }
+
+    /// Footers are the quiet half of a settings page: same DM Sans, one step
+    /// down, muted.
+    static func footer(_ text: LocalizedStringKey) -> some View {
+        Text(text)
+            .font(.parley.footnote)
+            .foregroundStyle(Theme.mutedForeground)
     }
 }
 

--- a/ios/Keyboard/KeyboardLexiconWatch.swift
+++ b/ios/Keyboard/KeyboardLexiconWatch.swift
@@ -1,0 +1,72 @@
+import ParleyKit
+import UIKit
+
+/// Watches for the user fixing a word right after dictating it, and teaches the
+/// personal dictionary what they fixed.
+///
+/// The desktop does this with the Accessibility API: it reads the whole field it
+/// pasted into and watches the value settle (`src-tauri/src/ax_observe.rs`). A
+/// keyboard extension has none of that. What it has is
+/// `textDocumentProxy.documentContextBeforeInput` — a clipped run of text ending
+/// at the cursor, with no notification when anything changes and no way to read
+/// past the clip. So the shape here is different: snapshot the window once, when
+/// the dictated text has just landed, and compare it against the window again at
+/// the two moments the editing is over. `LexiconCapture` (in ParleyKit) owns the
+/// comparison and its refusals, and carries the tests for them.
+///
+/// ## What this can and cannot see — the v1 scope, stated plainly
+///
+/// **Only edits the user makes while this keyboard is still up in that same
+/// field.** If they dismiss the keyboard, switch to another app, or move to
+/// another field before fixing the word, the correction is never seen. There is
+/// no API that would let a keyboard extension see it either: the field belongs
+/// to the host app, and the only view of it is the proxy, which exists only
+/// while we are the active input.
+///
+/// Two more limits worth knowing:
+///
+/// - **The window clips.** iOS gives no guarantee about how much text the proxy
+///   returns, and it ends at the cursor rather than at the end of what we
+///   inserted. In a field longer than the window, an edit that changes the
+///   text's length slides the window's own start, and the two snapshots then
+///   describe overlapping-but-offset stretches. The capture refuses whenever it
+///   cannot see enough shared text to believe they are the same field: capturing
+///   nothing beats capturing garbage, because garbage here becomes a rule that
+///   rewrites the user's words from then on.
+/// - **`viewWillDisappear` is not a promise.** iOS kills keyboard extensions
+///   without ceremony. A correction lost to that is simply not learned, and the
+///   next one will be.
+///
+/// Kept in its own file, wired to the controller through two one-line hooks, so
+/// the concurrent change to one-shot-at-`done` insertion (#309) has nothing to
+/// merge here.
+final class KeyboardLexiconWatch {
+    /// The field as it was when the dictated text had just landed. `nil`
+    /// whenever there is nothing to compare against — before a session, and
+    /// after a harvest.
+    private var snapshot: String?
+
+    /// The dictated text has been inserted; remember the field.
+    ///
+    /// Called with `state == .done`, which is after the last delta went in, so
+    /// this is a picture of a finished dictation rather than of a sentence still
+    /// arriving.
+    func noteInserted(context: String?) {
+        snapshot = LexiconCapture.window(context)
+    }
+
+    /// The editing is over: compare, diff, and record whatever the user taught
+    /// us.
+    ///
+    /// Called from `viewWillDisappear` and from the start of the next session —
+    /// the two moments at which the user has stopped fixing this piece of text.
+    /// Clears the snapshot either way: harvesting the same edit twice would
+    /// count one correction as two, and counting to two across two separate
+    /// dictations is precisely what `Lexicon.autoApplyThreshold` is asking for.
+    func harvest(context: String?) {
+        guard let before = snapshot else { return }
+        snapshot = nil
+        LexiconStore.record(
+            LexiconCapture.spans(before: before, after: LexiconCapture.window(context)))
+    }
+}

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -30,6 +30,10 @@ final class KeyboardViewController: UIInputViewController {
     /// session is a leftover from a previous dictation and is ignored.
     private var session = ""
     private var insertedCount = 0
+    /// Learns the user's words from the edits they make right after dictating.
+    /// Everything it does lives in `KeyboardLexiconWatch`; this class only tells
+    /// it when the text landed and when the editing is over.
+    private let lexicon = KeyboardLexiconWatch()
     private var host: UIHostingController<KeyboardRootView>?
     private var heightConstraint: NSLayoutConstraint?
 
@@ -132,6 +136,14 @@ final class KeyboardViewController: UIInputViewController {
         drainDownlink()
     }
 
+    /// The keyboard is going away, which is the end of the user's chance to fix
+    /// the words in this field — so it is the moment to learn from whatever they
+    /// fixed. See `KeyboardLexiconWatch` for what this can and cannot see.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        lexicon.harvest(context: textDocumentProxy.documentContextBeforeInput)
+    }
+
     /// A keyboard follows the appearance of the *field* it is typing into, not
     /// the system's: a dark-themed host app asks for a dark keyboard even while
     /// iOS is in light mode. `textInputMode` changes as the user moves between
@@ -205,6 +217,9 @@ final class KeyboardViewController: UIInputViewController {
     /// URL for the visible round trip.
     func startDictation(completion: @escaping (URL?) -> Void) {
         guard hasFullAccess else { return }
+        // A new session ends the last one's editing window: anything the user
+        // was going to fix, they have finished fixing.
+        lexicon.harvest(context: textDocumentProxy.documentContextBeforeInput)
         session = UUID().uuidString
         insertedCount = 0
         DictationChannel.writeUplink(
@@ -400,6 +415,9 @@ final class KeyboardViewController: UIInputViewController {
             bridge.listening = false
             bridge.reconnecting = false
             bridge.partial = ""
+            // The dictated text is all in the field now, so this is the picture
+            // any later edit gets compared against.
+            lexicon.noteInserted(context: textDocumentProxy.documentContextBeforeInput)
             // The tail stays: the last thing said is worth still being able to
             // read once the button has gone quiet.
         case .error:

--- a/ios/ParleyKit/Sources/ParleyKit/EditDiff.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/EditDiff.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Turn "the user fixed a word right after dictating" into (original,
+/// replacement) pairs.
+///
+/// The phone's counterpart to the desktop's `src/lib/dictionary/diffCorrection.ts`,
+/// and it has the same job with a harder input. The desktop watches one
+/// Accessibility value and gets the whole field; the keyboard only ever sees
+/// `documentContextBeforeInput`, a clipped window ending at the cursor. So this
+/// diff is deliberately token-level and deliberately suspicious: everything
+/// interesting is in refusing the edits that are *not* a misheard word.
+///
+/// An insertion, a deletion, a wholesale rewrite and a typo fix all arrive
+/// through the same channel. Only one of them is vocabulary, and learning any
+/// of the others would poison the lexicon — a dictionary that rewrites text the
+/// user never asked it to rewrite is worse than no dictionary.
+public enum EditDiff {
+    /// One replaced stretch: what was dictated, and what the user made of it.
+    public struct Span: Equatable, Sendable {
+        public let original: String
+        public let replacement: String
+
+        public init(original: String, replacement: String) {
+            self.original = original
+            self.replacement = replacement
+        }
+    }
+
+    /// Longest either side of a span may be. A vocabulary fix is a name or a
+    /// short phrase; past this the user is rewriting their sentence, and the
+    /// two are indistinguishable from here.
+    public static let maxSpanLength = 10
+
+    /// How many tokens either side may carry before this gives up.
+    ///
+    /// The alignment is an O(n·m) table and it runs inside a keyboard
+    /// extension, which iOS gives a hard memory cap and no patience. The
+    /// callers bound their input to a couple of hundred characters already;
+    /// this is the backstop that keeps a surprise from becoming a jetsam.
+    public static let maxTokens = 400
+
+    /// The replaced spans between what was dictated and what is there now.
+    ///
+    /// Empty is the normal answer. It means either nothing changed, or what
+    /// changed was not a word being corrected — and in both cases there is
+    /// nothing to learn.
+    public static func spans(pasted: String, edited: String) -> [Span] {
+        guard pasted != edited else { return [] }
+        let a = tokenize(pasted)
+        let b = tokenize(edited)
+        guard !a.isEmpty, !b.isEmpty, a.count <= maxTokens, b.count <= maxTokens else { return [] }
+
+        var out: [Span] = []
+        for region in regions(a, b) {
+            let original = a[region.a].joined()
+            let replacement = b[region.b].joined()
+            if let span = span(original: original, replacement: replacement) {
+                out.append(span)
+            }
+        }
+        return out
+    }
+
+    /// One changed region, vetted. `nil` for everything that is not a
+    /// vocabulary correction:
+    ///
+    /// - **A pure insertion or deletion.** There is no "this became that" pair
+    ///   in it; the user added or removed words, which says nothing about how
+    ///   any word should be transcribed.
+    /// - **A case, punctuation or whitespace change.** "api" → "API" is the
+    ///   user styling their sentence, and recording it would have the lexicon
+    ///   fighting the host app's own autocapitalisation forever.
+    /// - **Anything too long.** See `maxSpanLength`.
+    private static func span(original: String, replacement: String) -> Span? {
+        let from = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !from.isEmpty, !to.isEmpty, from != to else { return nil }
+        guard from.count <= maxSpanLength, to.count <= maxSpanLength else { return nil }
+        guard significant(from) != significant(to) else { return nil }
+        return Span(original: from, replacement: to)
+    }
+
+    /// What is left of a string once the things a correction may not be about
+    /// — case, punctuation, whitespace — are taken out of it. Two spans that
+    /// reduce to the same thing differ only in styling.
+    private static func significant(_ text: String) -> String {
+        String(text.lowercased().unicodeScalars.filter {
+            !CharacterSet.whitespacesAndNewlines.contains($0)
+                && !CharacterSet.punctuationCharacters.contains($0)
+                && !CharacterSet.symbols.contains($0)
+        }.map(Character.init))
+    }
+
+    // MARK: alignment
+
+    /// The stretches where the two token streams disagree, in order.
+    ///
+    /// Adjacent changed tokens land in the same region by construction — a
+    /// region is simply the gap between two aligned tokens — which is what
+    /// makes "pearly cloud" → "Parley Cloud" one span rather than two halves of
+    /// one.
+    private static func regions(
+        _ a: [String], _ b: [String]
+    ) -> [(a: Range<Int>, b: Range<Int>)] {
+        var out: [(a: Range<Int>, b: Range<Int>)] = []
+        var i = 0
+        var j = 0
+        for (ai, bj) in matches(a, b) {
+            if ai > i || bj > j { out.append((i..<ai, j..<bj)) }
+            i = ai + 1
+            j = bj + 1
+        }
+        if i < a.count || j < b.count { out.append((i..<a.count, j..<b.count)) }
+        return out
+    }
+
+    /// Index pairs of the longest common subsequence, ascending.
+    ///
+    /// A plain LCS table with a deterministic backtrack — ties always step in
+    /// `a` first — because "the same edit always produces the same pair" is the
+    /// property the whole feature is built on. A diff that sometimes learns
+    /// 在 → 再 and sometimes learns 在來 → 再來 would give the user a lexicon
+    /// they cannot predict.
+    private static func matches(_ a: [String], _ b: [String]) -> [(Int, Int)] {
+        var table = [[Int]](repeating: [Int](repeating: 0, count: b.count + 1), count: a.count + 1)
+        for i in stride(from: a.count - 1, through: 0, by: -1) {
+            for j in stride(from: b.count - 1, through: 0, by: -1) {
+                table[i][j] =
+                    a[i] == b[j]
+                    ? table[i + 1][j + 1] + 1
+                    : max(table[i + 1][j], table[i][j + 1])
+            }
+        }
+
+        var out: [(Int, Int)] = []
+        var i = 0
+        var j = 0
+        while i < a.count, j < b.count {
+            if a[i] == b[j] {
+                out.append((i, j))
+                i += 1
+                j += 1
+            } else if table[i + 1][j] >= table[i][j + 1] {
+                i += 1
+            } else {
+                j += 1
+            }
+        }
+        return out
+    }
+
+    // MARK: tokens
+
+    /// Split text into the units a correction can be about.
+    ///
+    /// Latin (and any other spaced script) runs as whole words, because the
+    /// word is what gets misheard. Ideographic scripts one character at a time,
+    /// because they are written without spaces and a character *is* the unit —
+    /// this is what lets 在 → 再 come out as a two-character pair instead of the
+    /// whole sentence. Whitespace runs and single punctuation marks are tokens
+    /// too, so they can align rather than being silently absorbed into a
+    /// neighbour.
+    static func tokenize(_ text: String) -> [String] {
+        var out: [String] = []
+        var run = ""
+        var runIsWord = false
+
+        func flush() {
+            if !run.isEmpty { out.append(run) }
+            run = ""
+        }
+
+        for c in text {
+            if c.isWhitespace {
+                if runIsWord { flush() }
+                runIsWord = false
+                run.append(c)
+            } else if isIdeographic(c) {
+                flush()
+                runIsWord = false
+                out.append(String(c))
+            } else if c.isLetter || c.isNumber || c == "'" || c == "\u{2019}" {
+                if !runIsWord { flush() }
+                runIsWord = true
+                run.append(c)
+            } else {
+                flush()
+                runIsWord = false
+                out.append(String(c))
+            }
+        }
+        flush()
+        return out
+    }
+
+    /// Written without spaces, so one character is one token. CJK ideographs
+    /// (including the extensions and the compatibility block), kana, and Hangul
+    /// syllables.
+    static func isIdeographic(_ c: Character) -> Bool {
+        guard let scalar = c.unicodeScalars.first, c.unicodeScalars.count == 1 else { return false }
+        switch scalar.value {
+        case 0x3040...0x30FF,  // Hiragana, Katakana
+            0x3400...0x4DBF,  // CJK Extension A
+            0x4E00...0x9FFF,  // CJK Unified Ideographs
+            0xAC00...0xD7AF,  // Hangul syllables
+            0xF900...0xFAFF,  // CJK Compatibility Ideographs
+            0x20000...0x2FA1F:  // CJK Extension B and beyond
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/ios/ParleyKit/Sources/ParleyKit/LexiconCapture.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/LexiconCapture.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// The arithmetic behind learning from an edit the keyboard can only half see.
+///
+/// A keyboard extension's whole view of the field is
+/// `textDocumentProxy.documentContextBeforeInput`: a run of text ending at the
+/// cursor, clipped by iOS at a length it does not promise. Comparing two such
+/// windows taken minutes apart is the only way to find out what the user
+/// corrected, and it is a genuinely unreliable comparison — which is why the
+/// decisions live here, next to `EditDiff`, rather than in the extension where
+/// nothing can be run against them.
+///
+/// `KeyboardLexiconWatch` is the stateful, UIKit-facing half; this is the half
+/// worth testing.
+public enum LexiconCapture {
+    /// How much of the field to keep. The proxy's window is bounded by iOS
+    /// anyway; this bounds the diff, which is an O(n·m) table in a process with
+    /// a hard memory cap.
+    public static let windowLimit = 200
+
+    /// How much the two windows must agree, at one end or the other, before they
+    /// are believed to be views of the same field.
+    ///
+    /// Measured in `anchorWeight`, not characters. Below this the agreement is
+    /// coincidence — two unrelated English sentences share a "the " often enough
+    /// — and an edit invented between two unrelated pieces of text becomes a rule
+    /// that rewrites the user's words from then on.
+    public static let minAnchor = 6
+
+    /// The stretch of the field worth remembering.
+    public static func window(_ context: String?) -> String {
+        String((context ?? "").suffix(windowLimit))
+    }
+
+    /// Whether two windows are worth diffing at all.
+    ///
+    /// Both end at the cursor and both begin wherever iOS decided to clip —
+    /// which is *not* the same offset once the text has changed length, so there
+    /// is no index arithmetic that lines them up. What can be checked is whether
+    /// they agree at one end: a run of shared characters at the front or the
+    /// back says these are two views of one field.
+    ///
+    /// That is the only gate. Deciding which parts actually changed is
+    /// `EditDiff`'s job and it is better at it — a shared prefix that has slid
+    /// out of the window comes back as a pure deletion, an over-long rewrite
+    /// comes back as nothing, and both are refusals it already makes.
+    ///
+    /// It is deliberately *not* a trim. Cutting the windows down to their
+    /// disagreement here would cut through the middle of words: "we use pearly"
+    /// against "we use Parley" shares the prefix "we use " and the suffix "y",
+    /// so the trimmed pair is "pearl" → "Parle" — and a Latin pair needs a whole
+    /// word to match, so that rule would then fire on nothing. Handing both
+    /// windows to a token-level diff is what keeps the pair at word edges.
+    public static func alignable(_ before: String, _ after: String) -> Bool {
+        guard !before.isEmpty, !after.isEmpty, before != after else { return false }
+        let a = Array(before)
+        let b = Array(after)
+
+        var prefix = 0
+        var prefixWeight = 0
+        while prefix < a.count, prefix < b.count, a[prefix] == b[prefix] {
+            prefixWeight += anchorWeight(a[prefix])
+            prefix += 1
+        }
+        var suffix = 0
+        var suffixWeight = 0
+        while suffix < a.count - prefix, suffix < b.count - prefix,
+            a[a.count - 1 - suffix] == b[b.count - 1 - suffix]
+        {
+            suffixWeight += anchorWeight(a[a.count - 1 - suffix])
+            suffix += 1
+        }
+        return max(prefixWeight, suffixWeight) >= minAnchor
+    }
+
+    /// What one shared character is worth as evidence: an ideograph counts
+    /// double.
+    ///
+    /// Chinese packs into five characters what English spends a clause on, so
+    /// counting raw characters would demand several times more agreement from a
+    /// Chinese user than from an English one — and would refuse exactly the
+    /// correction this feature was built for. 明天我**在**來一次好嗎 → 再 shares
+    /// eight characters with its corrected form, and a raw count of six would
+    /// have thrown it away for want of a ninth.
+    private static func anchorWeight(_ c: Character) -> Int {
+        EditDiff.isIdeographic(c) ? 2 : 1
+    }
+
+    /// What the user taught us, from two windows on the same field. Empty
+    /// whenever there is nothing worth learning — which is the common case, and
+    /// the safe one.
+    public static func spans(before: String, after: String) -> [EditDiff.Span] {
+        guard alignable(before, after) else { return [] }
+        return EditDiff.spans(pasted: before, edited: after)
+    }
+}

--- a/ios/ParleyKit/Sources/ParleyKit/LexiconStore.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/LexiconStore.swift
@@ -1,0 +1,412 @@
+import Foundation
+
+/// One correction the user has made: what dictation produced, and what they
+/// changed it to.
+///
+/// `count` is the whole reason this is a pair rather than a rule. A single edit
+/// is ambiguous — the user may have been rephrasing, or fixing a name that only
+/// mattered in that one sentence — so a pair does nothing until it has been
+/// seen twice. See `Lexicon.autoApplyThreshold`.
+public struct LexiconPair: Codable, Sendable, Equatable, Identifiable {
+    /// What came back from dictation. Unique within a lexicon: one misheard
+    /// form has exactly one correction, which is what makes this the id.
+    public var original: String
+    /// What the user replaced it with.
+    public var replacement: String
+    /// How many times this exact correction has been seen.
+    public var count: Int
+    /// The last time it was seen. Also the eviction order when the store is
+    /// full.
+    public var updatedAt: Date
+
+    public var id: String { original }
+
+    public init(original: String, replacement: String, count: Int = 1, updatedAt: Date = Date()) {
+        self.original = original
+        self.replacement = replacement
+        self.count = count
+        self.updatedAt = updatedAt
+    }
+
+    /// Tolerant on purpose: the file is shared between two processes and can be
+    /// hand-edited. A pair with no `count` or no stamp is still a usable pair —
+    /// only a missing side makes it meaningless, and that throws so the lossy
+    /// array decode drops just that element.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        original = try c.decode(String.self, forKey: .original)
+        replacement = try c.decode(String.self, forKey: .replacement)
+        count = try c.decodeIfPresent(Int.self, forKey: .count) ?? 1
+        updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .distantPast
+    }
+}
+
+/// A term the user typed in themselves, rather than one Parley worked out.
+///
+/// These are not substitutions — there is nothing to substitute, because
+/// nothing came back wrong yet. They exist to bias recognition toward words the
+/// user knows they are going to say. Until the relay carries a recognition
+/// context (see `LexiconStore.recognitionTerms`) they are a list the user keeps
+/// and Parley cannot yet spend.
+public struct LexiconTerm: Codable, Sendable, Equatable, Identifiable {
+    public var text: String
+    public var updatedAt: Date
+
+    public var id: String { text }
+
+    public init(text: String, updatedAt: Date = Date()) {
+        self.text = text
+        self.updatedAt = updatedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        text = try c.decode(String.self, forKey: .text)
+        updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .distantPast
+    }
+}
+
+/// The user's personal dictionary, as a value.
+///
+/// Every rule lives here rather than on the disk-backed `LexiconStore`, so all
+/// of it can be tested on a machine with no App Group container — which is
+/// every machine that runs `swift test`. `LexiconStore` is the same API with a
+/// file behind it.
+public struct Lexicon: Codable, Sendable, Equatable {
+    public var pairs: [LexiconPair]
+    public var terms: [LexiconTerm]
+
+    /// How many times a correction has to be seen before `apply` will act on
+    /// it.
+    ///
+    /// Two, and the second one is the whole point: a single edit is as likely
+    /// to be the user rewording their sentence as it is to be a word Parley
+    /// gets wrong. Acting on one sighting would mean the first time someone
+    /// changed their mind mid-sentence, dictation started silently rewriting
+    /// that word forever. Twice is cheap for a real mishearing — it happens
+    /// every time the word is said — and expensive for a coincidence.
+    public static let autoApplyThreshold = 2
+
+    /// Caps, so a file two processes append to cannot grow without bound. The
+    /// keyboard reads it on every appearance under a hard memory limit.
+    public static let maxPairs = 500
+    public static let maxTerms = 200
+
+    public init(pairs: [LexiconPair] = [], terms: [LexiconTerm] = []) {
+        self.pairs = pairs
+        self.terms = terms
+    }
+
+    /// Decode what is readable and drop what is not, element by element. A
+    /// single malformed pair must not cost the user the rest of their
+    /// dictionary.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        pairs = (try c.decodeIfPresent([Lossy<LexiconPair>].self, forKey: .pairs) ?? [])
+            .compactMap(\.value)
+        terms = (try c.decodeIfPresent([Lossy<LexiconTerm>].self, forKey: .terms) ?? [])
+            .compactMap(\.value)
+    }
+
+    // MARK: learning
+
+    /// Record a correction.
+    ///
+    /// The rule for a second, different correction of the same original is
+    /// deliberately blunt: **the newer correction wins unless the standing one
+    /// has already been confirmed.** A pair seen twice is a habit and stays; a
+    /// pair seen once is a guess, and a fresher guess is a better guess. There
+    /// is no arithmetic to reason about and no way for two rival corrections to
+    /// trade the slot back and forth.
+    ///
+    /// What it costs: once a pair reaches the threshold, correcting the same
+    /// word a *different* way can no longer displace it. That is what Settings
+    /// is for — deleting the row is how the user changes their mind, and it is
+    /// a thing they can see, unlike a scoring rule.
+    ///
+    /// Refused: empty sides, a no-op, and a replacement that contains its own
+    /// original. The last one is the loop guard — "api" → "api endpoint" would
+    /// grow the text every time it ran — and it is refused here as well as in
+    /// `apply` because a row that can never fire is a row that makes the
+    /// dictionary screen a lie.
+    public mutating func record(original: String, replacement: String, now: Date = Date()) {
+        let from = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !from.isEmpty, !to.isEmpty, from != to, !Lexicon.loops(from: from, to: to) else {
+            return
+        }
+
+        if let i = pairs.firstIndex(where: { $0.original == from }) {
+            if pairs[i].replacement == to {
+                pairs[i].count += 1
+                pairs[i].updatedAt = now
+            } else if pairs[i].count < Lexicon.autoApplyThreshold {
+                pairs[i] = LexiconPair(original: from, replacement: to, count: 1, updatedAt: now)
+            }
+            return
+        }
+
+        pairs.append(LexiconPair(original: from, replacement: to, count: 1, updatedAt: now))
+        evict()
+    }
+
+    /// A term the user added by hand. Re-adding one that is already there just
+    /// freshens its stamp rather than growing a duplicate row.
+    public mutating func addTerm(_ text: String, now: Date = Date()) {
+        let term = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else { return }
+        if let i = terms.firstIndex(where: { $0.text == term }) {
+            terms[i].updatedAt = now
+            return
+        }
+        terms.append(LexiconTerm(text: term, updatedAt: now))
+        evict()
+    }
+
+    public mutating func removePair(original: String) {
+        pairs.removeAll { $0.original == original }
+    }
+
+    public mutating func removeTerm(_ text: String) {
+        terms.removeAll { $0.text == text }
+    }
+
+    public mutating func removeAll() {
+        pairs = []
+        terms = []
+    }
+
+    /// Oldest-updated first, which is the closest thing to "least useful" that
+    /// costs nothing to track: a pair the user keeps re-confirming keeps its
+    /// stamp fresh.
+    private mutating func evict() {
+        if pairs.count > Lexicon.maxPairs {
+            pairs.sort { $0.updatedAt > $1.updatedAt }
+            pairs.removeLast(pairs.count - Lexicon.maxPairs)
+        }
+        if terms.count > Lexicon.maxTerms {
+            terms.sort { $0.updatedAt > $1.updatedAt }
+            terms.removeLast(terms.count - Lexicon.maxTerms)
+        }
+    }
+
+    // MARK: reading
+
+    /// Newest first — the order the dictionary screen lists them in, and the
+    /// order recognition bias would want if it ever gets a wire to ride on.
+    public var pairsByRecency: [LexiconPair] {
+        pairs.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    public var termsByRecency: [LexiconTerm] {
+        terms.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    /// The words the user would rather hear back: everything they typed in, plus
+    /// the right-hand side of every correction. Deduplicated, newest first.
+    public var recognitionTerms: [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for text in termsByRecency.map(\.text) + pairsByRecency.map(\.replacement) {
+            if seen.insert(text).inserted { out.append(text) }
+        }
+        return out
+    }
+
+    // MARK: applying
+
+    /// Rewrite the corrections the user has confirmed.
+    ///
+    /// Three rules, each of them a way of not doing damage:
+    ///
+    /// - **Only confirmed pairs.** `count >= autoApplyThreshold`; see there.
+    /// - **Longest original first.** With both "parley" and "parley cloud" on
+    ///   file the longer one has to win, or it gets half-rewritten by the
+    ///   shorter one and comes out as neither.
+    /// - **Word boundaries for Latin, plain substring for CJK.** An all-ASCII
+    ///   original matches case-insensitively and only as a whole word: dictation
+    ///   capitalises arbitrarily, and "api" must not eat the "api" inside
+    ///   "rapid". Chinese has no word boundaries to assert, so there the match
+    ///   is a plain substring — which is exactly what makes 在 → 再 possible.
+    ///
+    /// Deterministic: the same lexicon and the same text always give the same
+    /// answer, ties in original length broken alphabetically.
+    public func apply(to text: String) -> String {
+        guard !text.isEmpty else { return text }
+        let usable =
+            pairs
+            .filter {
+                $0.count >= Lexicon.autoApplyThreshold && !$0.original.isEmpty
+                    && !$0.replacement.isEmpty
+                    && !Lexicon.loops(from: $0.original, to: $0.replacement)
+            }
+            .sorted {
+                $0.original.count != $1.original.count
+                    ? $0.original.count > $1.original.count
+                    : $0.original < $1.original
+            }
+
+        var out = text
+        for pair in usable {
+            out =
+                pair.original.isLatinWordLike
+                ? Lexicon.replaceWord(pair.original, with: pair.replacement, in: out)
+                : out.replacingOccurrences(of: pair.original, with: pair.replacement)
+        }
+        return out
+    }
+
+    /// The replacement properly contains the original, so substituting would
+    /// grow the text every time it ran — "api" → "api endpoint" reaching "api
+    /// endpoint endpoint" and onward.
+    ///
+    /// *Properly* is the whole subtlety: "api" → "API" also contains its
+    /// original (Latin pairs match case-insensitively), but re-applying it is a
+    /// no-op rather than growth, so the length test is what separates the two.
+    static func loops(from: String, to: String) -> Bool {
+        guard to.count > from.count else { return false }
+        return from.isLatinWordLike
+            ? to.range(of: from, options: [.caseInsensitive]) != nil
+            : to.contains(from)
+    }
+
+    /// Case-insensitive whole-word replacement, mirroring the desktop's
+    /// `asciiVariantRe`: the boundary is asserted only on the sides that
+    /// actually begin or end with a word character, so a pair like "sql," still
+    /// matches at the end of a clause.
+    static func replaceWord(_ original: String, with replacement: String, in text: String) -> String
+    {
+        let escaped = NSRegularExpression.escapedPattern(for: original)
+        let before = original.first.map(isWordScalar) == true ? "(?<![A-Za-z0-9_])" : ""
+        let after = original.last.map(isWordScalar) == true ? "(?![A-Za-z0-9_])" : ""
+        guard
+            let re = try? NSRegularExpression(
+                pattern: before + escaped + after, options: [.caseInsensitive])
+        else { return text }
+        return re.stringByReplacingMatches(
+            in: text, range: NSRange(text.startIndex..., in: text),
+            withTemplate: NSRegularExpression.escapedTemplate(for: replacement))
+    }
+
+    private static func isWordScalar(_ c: Character) -> Bool {
+        c.isLetter || c.isNumber || c == "_"
+    }
+}
+
+extension String {
+    /// All-ASCII, and carrying at least one letter or digit — the shape that has
+    /// word boundaries worth asserting. Anything else (Chinese, kana, an emoji)
+    /// takes the substring path.
+    var isLatinWordLike: Bool {
+        unicodeScalars.allSatisfy { $0.isASCII } && contains { $0.isLetter || $0.isNumber }
+    }
+}
+
+/// Decodes an element or shrugs. Used for the lexicon's arrays so one bad row
+/// costs one row rather than the file.
+struct Lossy<T: Decodable>: Decodable {
+    let value: T?
+
+    init(from decoder: Decoder) throws {
+        value = try? T(from: decoder)
+    }
+}
+
+/// The user's personal dictionary on disk.
+///
+/// `lexicon.json` in the App Group container, so both processes see the same
+/// file: the keyboard writes what it learned from an edit, the app reads it when
+/// it folds the final transcript, and the Settings screen is the only place
+/// either of them is edited by hand. Same plumbing as `DictationChannel` —
+/// atomic writes, a tolerant decode, no schema migration to get wrong.
+///
+/// Unlike `DictationChannel` there is no Darwin note. Nothing here is live: a
+/// lexicon is read at the two moments it matters (before a fold, before a
+/// screen draws) and a change that lands a second later is simply picked up the
+/// next time. A notification would buy nothing and would have to be listened
+/// for in a process that is trying to hold no state at all.
+public enum LexiconStore {
+    public static let fileName = "lexicon.json"
+
+    public static func load() -> Lexicon {
+        guard let url = url, let data = try? Data(contentsOf: url) else { return Lexicon() }
+        return (try? decoder.decode(Lexicon.self, from: data)) ?? Lexicon()
+    }
+
+    public static func save(_ lexicon: Lexicon) {
+        guard let url = url, let data = try? encoder.encode(lexicon) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Read, change, write. Not atomic across processes, and deliberately not
+    /// defended against: the two writers are a keyboard learning a word and a
+    /// person editing Settings, which are never the same second, and the worst
+    /// case is one lost correction the next edit will teach again.
+    private static func mutate(_ change: (inout Lexicon) -> Void) {
+        var lexicon = load()
+        change(&lexicon)
+        save(lexicon)
+    }
+
+    public static func record(original: String, replacement: String) {
+        mutate { $0.record(original: original, replacement: replacement) }
+    }
+
+    /// Record a whole edit's worth of spans in one read-modify-write, which is
+    /// what the keyboard has (see `KeyboardLexiconWatch`).
+    public static func record(_ spans: [EditDiff.Span]) {
+        guard !spans.isEmpty else { return }
+        mutate { lexicon in
+            for span in spans {
+                lexicon.record(original: span.original, replacement: span.replacement)
+            }
+        }
+    }
+
+    public static func addTerm(_ text: String) {
+        mutate { $0.addTerm(text) }
+    }
+
+    public static func removePair(original: String) {
+        mutate { $0.removePair(original: original) }
+    }
+
+    public static func removeTerm(_ text: String) {
+        mutate { $0.removeTerm(text) }
+    }
+
+    public static func removeAll() {
+        mutate { $0.removeAll() }
+    }
+
+    public static func pairs() -> [LexiconPair] { load().pairsByRecency }
+    public static func terms() -> [LexiconTerm] { load().termsByRecency }
+
+    /// The terms recognition should be biased toward.
+    ///
+    /// Nothing spends these yet. Soniox's config frame has a `context.terms`
+    /// field and the desktop already fills it (`transcription/soniox.rs`), but
+    /// `SonioxProtocol.Config` on the phone carries no such field and whether
+    /// the hosted relay forwards one from an iOS client is not something this
+    /// side can establish — so the wire is deliberately left alone and this is
+    /// the seam the follow-up plugs into. See `docs/design/ios-voice-keyboard.md`.
+    public static func recognitionTerms() -> [String] { load().recognitionTerms }
+
+    public static func apply(to text: String) -> String { load().apply(to: text) }
+
+    // MARK: file plumbing
+
+    private static var url: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: DictationChannel.appGroup)?
+            .appendingPathComponent(fileName)
+    }
+
+    private static var encoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }
+
+    private static var decoder: JSONDecoder { JSONDecoder() }
+}

--- a/ios/ParleyKit/Sources/ParleyKit/SonioxProtocol.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/SonioxProtocol.swift
@@ -24,6 +24,16 @@ public enum SonioxProtocol {
     /// First frame on the socket. In relay mode `apiKey` stays nil — the relay
     /// injects the master key server-side and forces the model, so neither
     /// secret nor model choice rides in the client frame.
+    ///
+    /// **No recognition context here, deliberately.** Soniox's config frame
+    /// takes a `context.terms` list to bias vocabulary, and the desktop fills it
+    /// from the phrase dictionary (`src-tauri/src/transcription/soniox.rs`). The
+    /// phone's personal dictionary has the terms ready
+    /// (`LexiconStore.recognitionTerms`) and does not send them: whether the
+    /// hosted relay forwards a `context` from an iOS client is not something
+    /// this side can establish, and a config frame the relay rejects costs the
+    /// user dictation altogether. Adding the field is the known follow-up —
+    /// see `docs/design/ios-voice-keyboard.md`.
     public struct Config: Encodable {
         public var apiKey: String?
         public var model: String

--- a/ios/ParleyKit/Tests/ParleyKitTests/EditDiffTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/EditDiffTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// What the keyboard is allowed to learn from an edit.
+///
+/// Most of these assert a *refusal*. That is the point of the file: the diff
+/// sees every edit the user makes in the field, and all but one shape of them
+/// would teach the lexicon something false.
+final class EditDiffTests: XCTestCase {
+
+    // MARK: what a correction looks like
+
+    func testLatinWordSwap() {
+        XCTAssertEqual(
+            EditDiff.spans(pasted: "we use pearly for that", edited: "we use Parley for that"),
+            [EditDiff.Span(original: "pearly", replacement: "Parley")])
+    }
+
+    func testCJKHomophoneFix() {
+        // The case this feature exists for: one character, one tone apart, and
+        // the sentence around it untouched.
+        XCTAssertEqual(
+            EditDiff.spans(pasted: "我在來一次", edited: "我再來一次"),
+            [EditDiff.Span(original: "在", replacement: "再")])
+    }
+
+    func testAdjacentChangedTokensBecomeOneSpan() {
+        // Two characters fixed side by side are one vocabulary item, not two —
+        // merging is what `regions` does by construction, because a region is
+        // the whole gap between two aligned tokens.
+        XCTAssertEqual(
+            EditDiff.spans(pasted: "我在萊一次", edited: "我再來一次"),
+            [EditDiff.Span(original: "在萊", replacement: "再來")])
+    }
+
+    func testChangedTokensSeparatedByMatchingTextStaySeparate() {
+        // The mirror of the test above, and the reason merging is bounded: two
+        // misheard words with an intact space between them are two things the
+        // user cares about, and learning them as one phrase would only fire
+        // when both were misheard together again.
+        XCTAssertEqual(
+            EditDiff.spans(pasted: "ship it on pearly clod", edited: "ship it on Parley Cloud"),
+            [
+                EditDiff.Span(original: "pearly", replacement: "Parley"),
+                EditDiff.Span(original: "clod", replacement: "Cloud"),
+            ])
+    }
+
+    func testMultipleSpans() {
+        let spans = EditDiff.spans(
+            pasted: "我在來一次 with pearly", edited: "我再來一次 with Parley")
+        XCTAssertEqual(
+            spans,
+            [
+                EditDiff.Span(original: "在", replacement: "再"),
+                EditDiff.Span(original: "pearly", replacement: "Parley"),
+            ])
+    }
+
+    func testSpansComeBackInDocumentOrder() {
+        let spans = EditDiff.spans(pasted: "alfa bravo charlie", edited: "alpha bravo charley")
+        XCTAssertEqual(spans.map(\.original), ["alfa", "charlie"])
+        XCTAssertEqual(spans.map(\.replacement), ["alpha", "charley"])
+    }
+
+    // MARK: what it refuses
+
+    func testIdenticalTextsProduceNothing() {
+        XCTAssertTrue(EditDiff.spans(pasted: "nothing changed", edited: "nothing changed").isEmpty)
+    }
+
+    func testEmptyInputProducesNothing() {
+        XCTAssertTrue(EditDiff.spans(pasted: "", edited: "something").isEmpty)
+        XCTAssertTrue(EditDiff.spans(pasted: "something", edited: "").isEmpty)
+    }
+
+    func testInsertionOnlyProducesNothing() {
+        // The user added a word. That says nothing about how any word should be
+        // transcribed.
+        XCTAssertTrue(EditDiff.spans(pasted: "hello world", edited: "hello there world").isEmpty)
+        XCTAssertTrue(EditDiff.spans(pasted: "我來一次", edited: "我再來一次").isEmpty)
+    }
+
+    func testDeletionOnlyProducesNothing() {
+        XCTAssertTrue(EditDiff.spans(pasted: "hello there world", edited: "hello world").isEmpty)
+        XCTAssertTrue(EditDiff.spans(pasted: "我再來一次", edited: "我來一次").isEmpty)
+    }
+
+    func testTrailingInsertionProducesNothing() {
+        // The commonest edit of all: the user keeps typing after dictating.
+        XCTAssertTrue(
+            EditDiff.spans(pasted: "send it today", edited: "send it today please").isEmpty)
+    }
+
+    func testCaseOnlyChangeProducesNothing() {
+        // Autocapitalisation, or the user styling their own sentence. Learning
+        // it would have the lexicon fighting the host app forever.
+        XCTAssertTrue(EditDiff.spans(pasted: "the api call", edited: "the API call").isEmpty)
+        XCTAssertTrue(EditDiff.spans(pasted: "parley", edited: "Parley").isEmpty)
+    }
+
+    func testPunctuationOnlyChangeProducesNothing() {
+        XCTAssertTrue(EditDiff.spans(pasted: "done, thanks", edited: "done. thanks").isEmpty)
+        XCTAssertTrue(EditDiff.spans(pasted: "ok?", edited: "ok!").isEmpty)
+    }
+
+    func testWhitespaceOnlyChangeProducesNothing() {
+        XCTAssertTrue(EditDiff.spans(pasted: "a  b", edited: "a b").isEmpty)
+    }
+
+    func testSpansLongerThanTheCapAreDropped() {
+        // A whole clause replaced is the user rewriting, and there is no way to
+        // tell that from a very long name being fixed — so neither is learned.
+        XCTAssertTrue(
+            EditDiff.spans(
+                pasted: "prefix internationalization suffix",
+                edited: "prefix globalizationalization suffix"
+            ).isEmpty)
+    }
+
+    func testALongSideDropsThePairEvenWhenTheOtherIsShort() {
+        XCTAssertTrue(
+            EditDiff.spans(pasted: "call sql today", edited: "call structuredquery today").isEmpty)
+    }
+
+    func testAnAbsurdlyLongEditIsRefusedOutright() {
+        // The alignment table is O(n·m) and this runs in a keyboard extension.
+        let pasted = String(repeating: "word ", count: 300)
+        let edited = String(repeating: "other ", count: 300)
+        XCTAssertTrue(EditDiff.spans(pasted: pasted, edited: edited).isEmpty)
+    }
+
+    // MARK: tokens
+
+    func testLatinRunsAreWholeWordsAndCJKIsPerCharacter() {
+        XCTAssertEqual(EditDiff.tokenize("hi 你好"), ["hi", " ", "你", "好"])
+    }
+
+    func testPunctuationIsItsOwnToken() {
+        XCTAssertEqual(EditDiff.tokenize("a, b."), ["a", ",", " ", "b", "."])
+    }
+
+    func testAnApostropheStaysInsideItsWord() {
+        XCTAssertEqual(EditDiff.tokenize("don't stop"), ["don't", " ", "stop"])
+    }
+
+    func testAccentedLatinIsAWordNotIdeographic() {
+        XCTAssertEqual(EditDiff.tokenize("café au lait"), ["café", " ", "au", " ", "lait"])
+        XCTAssertFalse(EditDiff.isIdeographic("é"))
+        XCTAssertTrue(EditDiff.isIdeographic("再"))
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/LexiconCaptureTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/LexiconCaptureTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// The half of the keyboard's capture that can be run without a keyboard.
+///
+/// Everything here is about the same question: given two clipped views of a
+/// field taken at different times, is there anything here worth learning? The
+/// answer is usually no, and being confidently wrong is the expensive failure —
+/// a bogus pair becomes a rule that rewrites the user's words from then on.
+final class LexiconCaptureTests: XCTestCase {
+
+    // MARK: the window
+
+    func testTheWindowKeepsTheTail() {
+        let long = String(repeating: "a", count: LexiconCapture.windowLimit + 50) + "end"
+        let window = LexiconCapture.window(long)
+        XCTAssertEqual(window.count, LexiconCapture.windowLimit)
+        XCTAssertTrue(window.hasSuffix("end"))
+    }
+
+    func testNoContextIsAnEmptyWindow() {
+        XCTAssertEqual(LexiconCapture.window(nil), "")
+    }
+
+    // MARK: the alignment gate
+
+    func testTwoViewsOfOneFieldAlign() {
+        XCTAssertTrue(LexiconCapture.alignable("we use pearly today", "we use Parley today"))
+    }
+
+    func testASharedTailAloneIsEnough() {
+        // The window slid at the front — the field grew — but the text up to the
+        // cursor still matches, which is all the gate needs.
+        XCTAssertTrue(LexiconCapture.alignable("xyz and the pearly report", "the Parley report"))
+    }
+
+    func testUnrelatedTextDoesNotAlign() {
+        XCTAssertFalse(LexiconCapture.alignable("we use pearly today", "totally different"))
+    }
+
+    func testAShortCoincidenceDoesNotAlign() {
+        // "the " in common is not evidence of anything.
+        XCTAssertFalse(LexiconCapture.alignable("the quick brown fox", "the lazy dog sleeps"))
+    }
+
+    func testAShortCJKAnchorIsStillEnough() {
+        // The anchor is weighted, not counted. Five shared ideographs are a
+        // clause; five shared Latin characters are half a word.
+        // Three shared ideographs clear the bar; five shared Latin characters
+        // do not.
+        XCTAssertTrue(LexiconCapture.alignable("我在來一次好嗎", "我再來一次好嗎"))
+        XCTAssertFalse(LexiconCapture.alignable("abcd fox", "abcd dog"))
+    }
+
+    func testIdenticalOrEmptyWindowsDoNotAlign() {
+        XCTAssertFalse(LexiconCapture.alignable("same text here", "same text here"))
+        XCTAssertFalse(LexiconCapture.alignable("", "anything at all"))
+        XCTAssertFalse(LexiconCapture.alignable("anything at all", ""))
+    }
+
+    // MARK: end to end
+
+    func testACorrectionInAFieldIsCaptured() {
+        XCTAssertEqual(
+            LexiconCapture.spans(before: "let's use pearly", after: "let's use Parley"),
+            [EditDiff.Span(original: "pearly", replacement: "Parley")])
+    }
+
+    func testAWordIsCapturedWholeRatherThanCutAtTheSharedEdges() {
+        // The regression this file exists for: a character-level trim would hand
+        // the diff "pearl" against "Parle" — a pair that can never match,
+        // because a Latin original only applies on a word boundary.
+        let spans = LexiconCapture.spans(before: "we use pearly", after: "we use Parley")
+        XCTAssertEqual(spans.map(\.original), ["pearly"])
+        XCTAssertEqual(spans.map(\.replacement), ["Parley"])
+    }
+
+    func testACJKCorrectionIsCaptured() {
+        XCTAssertEqual(
+            LexiconCapture.spans(before: "明天我在來一次好嗎", after: "明天我再來一次好嗎"),
+            [EditDiff.Span(original: "在", replacement: "再")])
+    }
+
+    func testTypingOnAfterDictatingTeachesNothing() {
+        XCTAssertTrue(
+            LexiconCapture.spans(
+                before: "meeting at three", after: "meeting at three tomorrow"
+            ).isEmpty)
+    }
+
+    func testAFieldTheUserRetypedTeachesNothing() {
+        XCTAssertTrue(
+            LexiconCapture.spans(before: "meeting at three", after: "never mind").isEmpty)
+    }
+
+    func testAWindowThatSlidOutOfAlignmentTeachesNothing() {
+        // Two windows on two different parts of a long document. There is a
+        // shared "ipsum " in there; there is no edit.
+        let before = String(repeating: "lorem ipsum ", count: 5) + "alpha"
+        let after = String(repeating: "ipsum lorem ", count: 5) + "omega"
+        XCTAssertTrue(LexiconCapture.spans(before: before, after: after).isEmpty)
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/LexiconTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/LexiconTests.swift
@@ -1,0 +1,260 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// The personal dictionary's rules, exercised as a value.
+///
+/// `LexiconStore` is the same API with a file behind it, and the file lives in
+/// an App Group container that does not exist on a machine running `swift test`
+/// — which is exactly why every rule is on `Lexicon` and none of them is on the
+/// store.
+final class LexiconTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    private func t(_ offset: TimeInterval) -> Date { t0.addingTimeInterval(offset) }
+
+    /// A pair confirmed enough times to be worth applying.
+    private func confirmed(_ original: String, _ replacement: String) -> LexiconPair {
+        LexiconPair(
+            original: original, replacement: replacement,
+            count: Lexicon.autoApplyThreshold, updatedAt: t0)
+    }
+
+    // MARK: recording
+
+    func testFirstSightingIsRecordedOnce() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        XCTAssertEqual(lexicon.pairs.count, 1)
+        XCTAssertEqual(lexicon.pairs[0].count, 1)
+        XCTAssertEqual(lexicon.pairs[0].updatedAt, t0)
+    }
+
+    func testTheSameCorrectionAgainIncrementsAndRestamps() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.record(original: "pearly", replacement: "Parley", now: t(60))
+        XCTAssertEqual(lexicon.pairs.count, 1)
+        XCTAssertEqual(lexicon.pairs[0].count, 2)
+        XCTAssertEqual(lexicon.pairs[0].updatedAt, t(60))
+    }
+
+    func testAFresherCorrectionDisplacesAnUnconfirmedOne() {
+        // Seen once is a guess; a newer guess is a better guess.
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.record(original: "pearly", replacement: "Purley", now: t(60))
+        XCTAssertEqual(lexicon.pairs.count, 1)
+        XCTAssertEqual(lexicon.pairs[0].replacement, "Purley")
+        XCTAssertEqual(lexicon.pairs[0].count, 1)
+    }
+
+    func testAConfirmedCorrectionKeepsItsSlot() {
+        // Twice is a habit. Deleting the row in Settings is how the user changes
+        // their mind — deliberately, and visibly.
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.record(original: "pearly", replacement: "Parley", now: t(60))
+        lexicon.record(original: "pearly", replacement: "Purley", now: t(120))
+        XCTAssertEqual(lexicon.pairs.count, 1)
+        XCTAssertEqual(lexicon.pairs[0].replacement, "Parley")
+        XCTAssertEqual(lexicon.pairs[0].count, 2)
+    }
+
+    func testNonsensePairsAreRefused() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "", replacement: "Parley", now: t0)
+        lexicon.record(original: "pearly", replacement: "   ", now: t0)
+        lexicon.record(original: "same", replacement: "same", now: t0)
+        XCTAssertTrue(lexicon.pairs.isEmpty)
+    }
+
+    func testBothSidesAreTrimmed() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "  pearly ", replacement: " Parley\n", now: t0)
+        XCTAssertEqual(lexicon.pairs[0].original, "pearly")
+        XCTAssertEqual(lexicon.pairs[0].replacement, "Parley")
+    }
+
+    func testAPairThatWouldGrowTheTextIsRefused() {
+        // "api" → "api endpoint" applied to its own output forever.
+        var lexicon = Lexicon()
+        lexicon.record(original: "api", replacement: "the API endpoint", now: t0)
+        lexicon.record(original: "在", replacement: "在再", now: t0)
+        XCTAssertTrue(lexicon.pairs.isEmpty)
+    }
+
+    func testSpansFromADiffFeedStraightIn() {
+        var lexicon = Lexicon()
+        for span in EditDiff.spans(pasted: "我在來一次", edited: "我再來一次") {
+            lexicon.record(original: span.original, replacement: span.replacement, now: t0)
+        }
+        XCTAssertEqual(lexicon.pairs.map(\.original), ["在"])
+    }
+
+    // MARK: terms
+
+    func testTermsAreAddedTrimmedAndDeduplicated() {
+        var lexicon = Lexicon()
+        lexicon.addTerm(" Pathors ", now: t0)
+        lexicon.addTerm("Pathors", now: t(60))
+        lexicon.addTerm("", now: t(60))
+        XCTAssertEqual(lexicon.terms.map(\.text), ["Pathors"])
+        XCTAssertEqual(lexicon.terms[0].updatedAt, t(60))
+    }
+
+    func testRecognitionTermsAreManualTermsThenReplacements() {
+        var lexicon = Lexicon()
+        lexicon.addTerm("Pathors", now: t(10))
+        lexicon.record(original: "pearly", replacement: "Parley", now: t(20))
+        lexicon.record(original: "sonyox", replacement: "Soniox", now: t(30))
+        XCTAssertEqual(lexicon.recognitionTerms, ["Pathors", "Soniox", "Parley"])
+    }
+
+    func testRecognitionTermsDeduplicate() {
+        var lexicon = Lexicon()
+        lexicon.addTerm("Parley", now: t(10))
+        lexicon.record(original: "pearly", replacement: "Parley", now: t(20))
+        XCTAssertEqual(lexicon.recognitionTerms, ["Parley"])
+    }
+
+    // MARK: removal
+
+    func testRemoval() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.addTerm("Pathors", now: t0)
+        lexicon.removePair(original: "pearly")
+        lexicon.removeTerm("Pathors")
+        XCTAssertTrue(lexicon.pairs.isEmpty)
+        XCTAssertTrue(lexicon.terms.isEmpty)
+
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.addTerm("Pathors", now: t0)
+        lexicon.removeAll()
+        XCTAssertEqual(lexicon, Lexicon())
+    }
+
+    // MARK: caps
+
+    func testThePairCapEvictsTheOldestUpdated() {
+        var lexicon = Lexicon()
+        for i in 0...Lexicon.maxPairs {
+            lexicon.record(original: "w\(i)", replacement: "W\(i)", now: t(Double(i)))
+        }
+        XCTAssertEqual(lexicon.pairs.count, Lexicon.maxPairs)
+        XCTAssertNil(lexicon.pairs.first { $0.original == "w0" })
+        XCTAssertNotNil(lexicon.pairs.first { $0.original == "w\(Lexicon.maxPairs)" })
+    }
+
+    func testTheTermCapEvictsTheOldestUpdated() {
+        var lexicon = Lexicon()
+        for i in 0...Lexicon.maxTerms {
+            lexicon.addTerm("t\(i)", now: t(Double(i)))
+        }
+        XCTAssertEqual(lexicon.terms.count, Lexicon.maxTerms)
+        XCTAssertNil(lexicon.terms.first { $0.text == "t0" })
+    }
+
+    // MARK: applying
+
+    func testASinglySeenPairIsNotApplied() {
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        XCTAssertEqual(lexicon.apply(to: "we use pearly"), "we use pearly")
+    }
+
+    func testAConfirmedPairIsApplied() {
+        let lexicon = Lexicon(pairs: [confirmed("pearly", "Parley")])
+        XCTAssertEqual(lexicon.apply(to: "we use pearly today"), "we use Parley today")
+    }
+
+    func testLatinPairsNeedWordBoundaries() {
+        let lexicon = Lexicon(pairs: [confirmed("api", "API")])
+        // "rapid" contains "api" and must be left alone.
+        XCTAssertEqual(lexicon.apply(to: "a rapid api call"), "a rapid API call")
+    }
+
+    func testLatinPairsMatchRegardlessOfCase() {
+        // Dictation capitalises arbitrarily; the pair is about the word.
+        let lexicon = Lexicon(pairs: [confirmed("pearly", "Parley")])
+        XCTAssertEqual(lexicon.apply(to: "Pearly and pearly"), "Parley and Parley")
+    }
+
+    func testCJKPairsAreAPlainSubstringReplacement() {
+        let lexicon = Lexicon(pairs: [confirmed("在來", "再來")])
+        XCTAssertEqual(lexicon.apply(to: "我在來一次"), "我再來一次")
+    }
+
+    func testTheLongestOriginalWins() {
+        // With both on file, "parley cloud" must not be half-rewritten by
+        // "parley" and come out as neither.
+        let lexicon = Lexicon(pairs: [
+            confirmed("pearly", "Parley"),
+            confirmed("pearly clod", "Parley Cloud"),
+        ])
+        XCTAssertEqual(lexicon.apply(to: "ship on pearly clod"), "ship on Parley Cloud")
+    }
+
+    func testALoopingPairIsNeverAppliedEvenIfItIsOnFile() {
+        // `record` refuses these, but the file is shared and hand-editable.
+        let lexicon = Lexicon(pairs: [confirmed("api", "api endpoint")])
+        XCTAssertEqual(lexicon.apply(to: "the api"), "the api")
+    }
+
+    func testApplyIsDeterministicAndLeavesUnknownTextAlone() {
+        let lexicon = Lexicon(pairs: [
+            confirmed("pearly", "Parley"), confirmed("在", "再"),
+        ])
+        let text = "我在說 pearly 的事"
+        let once = lexicon.apply(to: text)
+        XCTAssertEqual(once, "我再說 Parley 的事")
+        XCTAssertEqual(lexicon.apply(to: text), once)
+    }
+
+    func testApplyOnEmptyLexiconAndEmptyText() {
+        XCTAssertEqual(Lexicon().apply(to: "untouched"), "untouched")
+        XCTAssertEqual(Lexicon(pairs: [confirmed("a", "b")]).apply(to: ""), "")
+    }
+
+    func testARegexMetacharacterInAPairIsALiteral() {
+        let lexicon = Lexicon(pairs: [confirmed("c++", "C++")])
+        XCTAssertEqual(lexicon.apply(to: "wrote c++ today"), "wrote C++ today")
+    }
+
+    func testADollarInAReplacementIsALiteral() {
+        let lexicon = Lexicon(pairs: [confirmed("usd", "$")])
+        XCTAssertEqual(lexicon.apply(to: "10 usd"), "10 $")
+    }
+
+    // MARK: coding
+
+    func testRoundTrip() throws {
+        var lexicon = Lexicon()
+        lexicon.record(original: "pearly", replacement: "Parley", now: t0)
+        lexicon.addTerm("Pathors", now: t0)
+        let data = try JSONEncoder().encode(lexicon)
+        XCTAssertEqual(try JSONDecoder().decode(Lexicon.self, from: data), lexicon)
+    }
+
+    func testDecodeToleratesMissingFieldsAndDropsOnlyTheUnreadableRows() throws {
+        let json = """
+            {
+              "pairs": [
+                {"original": "pearly", "replacement": "Parley"},
+                {"replacement": "no original here"},
+                {"original": "在", "replacement": "再", "count": 7}
+              ],
+              "terms": [{"text": "Pathors"}, {"nope": true}]
+            }
+            """
+        let lexicon = try JSONDecoder().decode(Lexicon.self, from: Data(json.utf8))
+        XCTAssertEqual(lexicon.pairs.map(\.original), ["pearly", "在"])
+        XCTAssertEqual(lexicon.pairs[0].count, 1)
+        XCTAssertEqual(lexicon.pairs[1].count, 7)
+        XCTAssertEqual(lexicon.terms.map(\.text), ["Pathors"])
+    }
+
+    func testDecodeOfAnEmptyObjectIsAnEmptyLexicon() throws {
+        XCTAssertEqual(try JSONDecoder().decode(Lexicon.self, from: Data("{}".utf8)), Lexicon())
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,6 +9,7 @@ Lives in the main repo as `ios/` alongside the desktop app, `android/`, and `web
 - `SegmentBuilder` — speaker-run accumulation, stable segment ids, partial/final tail semantics (port of `src-tauri/src/transcription/common.rs`)
 - `SonioxProtocol` + `SonioxStreamParser` — the Soniox realtime wire protocol as spoken through Parley's hosted STT relay (`wss://api.parley.tw/stt/stream`): config frame without vendor key, `keepalive`/`finalize` control frames, `<end>`/`<fin>` endpoint markers, error frames
 - `SttRelayClient` — `URLSessionWebSocketTask` relay session honoring the drain rule (never close the socket after `finalize`; the relay flushes the tail first)
+- `EditDiff` + `Lexicon`/`LexiconStore` + `LexiconCapture` — the personal dictionary the voice keyboard learns from post-dictation corrections (the phone's counterpart to the desktop's `src/lib/dictionary/`). See [`../docs/design/ios-voice-keyboard.md`](../docs/design/ios-voice-keyboard.md)
 
 Design doc: [`../docs/design/ios-app.md`](../docs/design/ios-app.md). Cloud prerequisites are tracked in parley-internal (Phase 0 epic).
 


### PR DESCRIPTION
Closes #311. Best reviewed after #312 (one-shot insertion) — it works against current main too, but the capture window is cleanest once insertion happens in one piece.

When the user fixes a word right after dictating it, that correction is signal. This PR saves it and prefers the user's words from then on.

- **`EditDiff` + `LexiconStore` + `LexiconCapture` (ParleyKit, 64 new tests).** Token-level LCS diff (Latin runs as words, ideographs as characters) that returns replacement spans only — insertions, deletions, case/punctuation-only changes, and oversized spans are refused. The store persists to `lexicon.json` in the App Group (500 pairs / 200 terms, oldest-evicted); a pair auto-applies only once seen twice, so a one-off edit never becomes a rule.
- **Keyboard capture (`KeyboardLexiconWatch`).** Snapshots the proxy's context window when the dictated text lands, diffs it when the keyboard leaves the field or the next session starts. Alignment-gated: capturing nothing beats capturing garbage. v1 scope stated plainly in the file: only edits made while our keyboard stays up in that field.
- **App-side apply.** `DictationCoordinator` rewrites the finished transcript through the lexicon at the final fold — never mid-session, and (until #312 lands) never the already-typed prefix, so the keyboard's insertion offset can't be moved out from under it.
- **Settings › Personal dictionary.** Learned corrections with counts, swipe-to-delete; preferred terms with an add field; clear-all with confirmation. en + zh-Hant throughout.

Known follow-up: Soniox `context.terms` recognition biasing — the desktop already sends it and claims the relay forwards it, but the iOS protocol file doesn't carry the field yet; `LexiconStore.recognitionTerms()` is the ready seam.

Verified: `swift test` 121/121; `xcodebuild` iPhone 17 Pro simulator clean build SUCCEEDED.