### PR TITLE
[feature] dictation polishes the transcript before the keyboard pastes it

### DIFF
--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -141,10 +141,39 @@ final class DictationCoordinator: ObservableObject {
     /// answer in the background, long after any view is gone.
     nonisolated static let windowLengthKey = "micWindowLength"
 
+    /// Where the "Polish with AI" switch lives. Read straight out of
+    /// `UserDefaults` for the same reason `windowLengthKey` is: a session can
+    /// end with the app in the background and no view alive to have bound it.
+    nonisolated static let polishKey = "dictationPolishEnabled"
+
     var windowLength: MicWindowLength {
         MicWindowLength(
             rawValue: UserDefaults.standard.string(forKey: Self.windowLengthKey) ?? "") ?? .off
     }
+
+    /// On unless the user turned it off. "Never touched" is not "off": the
+    /// pass is what makes dictated text read like writing instead of like
+    /// speech, and its every failure mode is "keep the raw words" — so the
+    /// absent key defaults to true rather than to the `bool(forKey:)` false.
+    var polishEnabled: Bool {
+        guard UserDefaults.standard.object(forKey: Self.polishKey) != nil else { return true }
+        return UserDefaults.standard.bool(forKey: Self.polishKey)
+    }
+
+    /// The coordinator's own cloud client. `AppState`'s is not reachable from
+    /// here — a session can end in the background, long after any view that
+    /// held one — and both read the same Keychain token, so a second client
+    /// costs nothing and owns nothing.
+    private lazy var cloud = CloudClient { KeychainStore.get(AppState.tokenKey) }
+
+    /// How long the cleanup pass may hold the finished transcript.
+    ///
+    /// This is the user's foreground wait: they have stopped speaking and are
+    /// watching the field where the words are about to land. The raw words are
+    /// ready the whole time, so everything past this budget is time spent on a
+    /// nicety nobody asked to wait for — short enough to read as a beat, not as
+    /// a hang, and the raw transcript is what ships when it runs out.
+    private nonisolated static let polishBudget = Duration.seconds(6)
 
     private init() {
         window = .closed(length: MicWindowLength(
@@ -651,15 +680,15 @@ final class DictationCoordinator: ObservableObject {
     /// The fold is the first moment the transcript is finished and the last
     /// moment before the keyboard reads it.
     ///
-    /// **And only the part the keyboard has not typed yet.** Today the keyboard
-    /// inserts settled text as it arrives and keeps its place with a plain
-    /// character count (`Uplink.insertedCount`). Rewriting text that is already
-    /// in the user's document would move that boundary out from under it, and
-    /// the keyboard's next insertion would be spliced in at the wrong offset —
-    /// a correction bought at the price of mangling the sentence around it. So
-    /// the already-typed prefix is left exactly as it is. Once insertion becomes
-    /// one shot at `done` (#309) the boundary is zero and the whole transcript
-    /// goes through the dictionary, which is where this wants to end up.
+    /// **And only the part the keyboard has not typed yet.** The boundary is
+    /// `Uplink.insertedCount`, the plain character count the keyboard keeps of
+    /// what it has already put in the document. Rewriting text that is already
+    /// there would move that count out from under it and splice the next
+    /// insertion in at the wrong offset — a correction bought at the price of
+    /// mangling the sentence around it. Since #312 the keyboard inserts once,
+    /// at `done`, so in practice the count is zero and the whole transcript
+    /// goes through the dictionary; the boundary stays because it is what makes
+    /// that safe rather than merely true right now.
     ///
     /// This is the last write to `committed`: the relay leg is finished and
     /// detached by the time `finishUp` runs, so no further segment can rebuild
@@ -707,23 +736,118 @@ final class DictationCoordinator: ObservableObject {
     }
 
     private func finishUp() {
+        // One session ends once. The relay signing off lands here while `stop`
+        // is still awaiting the drain that provoked it, and then `stop`'s own
+        // tail arrives — everything below used to be idempotent enough not to
+        // care, but a network round trip is not, and the second caller must not
+        // start a second one.
+        guard active else { return }
         relay = nil
         reconnectTask?.cancel()
         reconnectTask = nil
         audio.discard()
         reportsLevel.set(false)
-        state = .done
         // Fold the last partial into the committed text so nothing said right
         // before the endpoint is dropped from what the keyboard inserts.
         foldPartialIn()
+
+        guard wantsPolish() else {
+            settle()
+            // Not `beginLinger()` any more: whether this leaves a ~30 s
+            // background task or an open microphone window is
+            // `releaseMicrophone`'s decision, and the two must never both be in
+            // flight. Reached from the relay signing off as well as from
+            // `stop`, hence the Task.
+            Task { await releaseMicrophone() }
+            return
+        }
+
+        // The cleanup pass runs *before* `done`, not after it, because `done`
+        // is the keyboard's one and only cue to insert: it stopped typing
+        // deltas in 1.5 and now pastes the whole transcript once, when this
+        // state arrives. So the session simply stays `finishing` a moment
+        // longer, and the text that eventually ships with `done` already is the
+        // final text — no second insertion, no swap under the cursor, and not a
+        // byte of the wire protocol changes. Publishing here keeps `updatedAt`
+        // fresh so the keyboard's adoption window cannot age out mid-request.
+        publish()
+        // The session is over as far as this app's own UI is concerned, and
+        // `releaseMicrophone` declines to act while it thinks otherwise. It
+        // goes first on purpose: an HTTP call needs no microphone, and what
+        // releasing arms — the window, or the ~30 s linger — is exactly what
+        // keeps this process resident long enough to finish one.
+        active = false
+        Task { await releaseMicrophone() }
+
+        let raw = committed
+        let target = session
+        let client = cloud
+        // The dictionary rides along so the model cannot "fix" the corrections
+        // the user made by hand; `applyLexicon` then has the last word anyway.
+        let terms = LexiconStore.recognitionTerms()
+        Task {
+            let polished = await Self.polished(raw: raw, cloud: client, terms: terms)
+            // A new session, or a `fail`, may have landed while the request was
+            // out. Either way this is no longer the transcript the keyboard is
+            // waiting for, and publishing it now would be publishing over
+            // somebody else's.
+            guard self.session == target, self.state == .finishing else { return }
+            self.committed = polished ?? raw
+            self.settle()
+        }
+    }
+
+    /// Whether the finished transcript is worth a trip to the cloud.
+    private func wantsPolish() -> Bool {
+        #if DEBUG
+            // ScreenshotDemo runs with no account and no network by design —
+            // the whole flow has to be capturable without either — so its
+            // sessions keep the plain synchronous ending.
+            if ScreenshotDemo.isActive { return false }
+        #endif
+        guard polishEnabled else { return false }
+        // The keyboard only reaches a signed-in app, but a session can have
+        // expired mid-dictation. No token, no request; the raw words stand.
+        guard KeychainStore.get(AppState.tokenKey) != nil else { return false }
+        return TranscriptPolisher.shouldPolish(committed)
+    }
+
+    /// The last beat of a session: hand the finished text to the keyboard as
+    /// `done`, which is its cue to insert.
+    private func settle() {
+        state = .done
+        // After the polish, never before. The dictionary holds corrections the
+        // user made by hand, and a model that undid one of them has to lose to
+        // the person who typed it.
         applyLexicon()
         publish()
         active = false
-        // Not `beginLinger()` any more: whether this leaves a ~30 s background
-        // task or an open microphone window is `releaseMicrophone`'s decision,
-        // and the two must never both be in flight. Reached from the relay
-        // signing off as well as from `stop`, hence the Task.
-        Task { await releaseMicrophone() }
+    }
+
+    /// The cleanup pass with a deadline on it. Every way this can go wrong — a
+    /// timeout, no network, an HTTP error, a reply that failed `accept` — comes
+    /// back as `nil`, which the caller reads as "keep the raw transcript". None
+    /// of them is ever news the user has to be told.
+    ///
+    /// `nonisolated` so the waiting happens off the main actor: the coordinator
+    /// is the main actor, and holding it for six seconds to be polite about
+    /// punctuation would be a strange trade.
+    private nonisolated static func polished(
+        raw: String, cloud: CloudClient, terms: [String]
+    ) async -> String? {
+        let outcome = try? await withThrowingTaskGroup(of: String?.self) { group -> String? in
+            group.addTask {
+                try await TranscriptPolisher.polish(
+                    raw: raw, cloud: cloud, protectedTerms: terms)
+            }
+            group.addTask {
+                try await Task.sleep(for: polishBudget)
+                throw PolishTimedOut()
+            }
+            defer { group.cancelAll() }
+            return try await group.next() ?? nil
+        }
+        return outcome ?? nil
     }
 
     private func fail(_ message: String) {
@@ -1042,6 +1166,10 @@ final class DictationCoordinator: ObservableObject {
         }
     #endif
 }
+
+/// The polish budget ran out. Never surfaced: it exists only to lose the race
+/// inside `polished`, where losing means the raw transcript ships.
+private struct PolishTimedOut: Error {}
 
 /// A boolean the audio thread may read on every chunk.
 ///

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -308,6 +308,23 @@
         }
       }
     },
+    "After dictation ends, AI tidies the wording and punctuation before the text is inserted. The original language is preserved.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After dictation ends, AI tidies the wording and punctuation before the text is inserted. The original language is preserved."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聽寫結束後，AI 會先整理用詞與標點再貼上文字，並維持原本的語言。"
+          }
+        }
+      }
+    },
     "After you dictate, Parley can hold the microphone open for a while, so the next tap on the keyboard's mic types where you already are instead of opening Parley.\n\niOS shows the orange microphone dot for the whole time, because Parley really is holding the microphone. It is not listening through it: nothing is recorded, transcribed, or sent until you tap the mic, and sound that arrives before then is thrown away as it comes in. The window ends on its own, and you can end it early here or from the keyboard.": {
       "extractionState": "manual",
       "localizations": {
@@ -2016,6 +2033,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "請再試一次。"
+          }
+        }
+      }
+    },
+    "Polish with AI": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polish with AI"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 潤飾"
           }
         }
       }

--- a/ios/App/Parley/SettingsView.swift
+++ b/ios/App/Parley/SettingsView.swift
@@ -15,6 +15,10 @@ struct SettingsView: View {
     /// to the App Group's defaults, which is where the extension looks for them
     /// on every appearance — there is no live binding across a process boundary.
     @State private var enabled = TypingKeyboards.enabled()
+    /// The cleanup pass after dictation. Bound here, read raw by the
+    /// coordinator: both sides are `UserDefaults.standard`, and the coordinator
+    /// has to be able to answer this in the background with no view alive.
+    @AppStorage(DictationCoordinator.polishKey) private var polishEnabled = true
     @State private var personalFolders: [CloudFolder] = []
     @State private var orgFolders: [String: [CloudFolder]] = [:]
     @State private var showDeleteConfirmation = false
@@ -437,6 +441,18 @@ struct SettingsView: View {
             } label: {
                 Text("Set-up steps").font(.parley.subheadlineEmphasized)
             }
+
+            // Directly above the dictionary, because the two are about the same
+            // text and run in this order: the model tidies what was said, then
+            // the dictionary has the last word over what it did.
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle("Polish with AI", isOn: $polishEnabled)
+                Text("After dictation ends, AI tidies the wording and punctuation before the text is inserted. The original language is preserved.")
+                    .font(.parley.caption)
+                    .foregroundStyle(Theme.mutedForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 2)
 
             // Below the set-up, because it is only worth anything once the
             // keyboard is in use: the dictionary fills itself from dictation.

--- a/ios/ParleyKit/Sources/ParleyKit/CloudClient.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/CloudClient.swift
@@ -195,6 +195,16 @@ public actor CloudClient {
             body: body, contentType: "application/json")
     }
 
+    // MARK: generic JSON POST
+
+    /// `POST` a JSON body and hand back the raw response body, for callers that
+    /// own their own request/response shapes — the OpenAI-compatible
+    /// `v1/chat/completions` endpoint the dictation polish pass uses. Same
+    /// auth header and same 2xx-or-`CloudError` discipline as every call above.
+    public func postJSON(_ path: String, body: Data) async throws -> Data {
+        try await request(path, method: "POST", body: body, contentType: "application/json")
+    }
+
     // MARK: plumbing
 
     private func get<T: Decodable>(_ path: String, as type: T.Type) async throws -> T {

--- a/ios/ParleyKit/Sources/ParleyKit/TranscriptPolisher.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/TranscriptPolisher.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// The best-effort cleanup pass that runs after dictation ends: the raw
+/// transcript goes to the cloud's OpenAI-compatible chat endpoint and comes
+/// back with the filler words gone, the punctuation fixed and the paragraphs
+/// broken where a writer would break them.
+///
+/// Everything here is written around one rule: **this must never make dictation
+/// worse.** The raw text is already in the user's document before the first
+/// byte of this request leaves the phone, and every failure mode — no network,
+/// a slow model, a refusal, a model that answered the transcript instead of
+/// cleaning it — resolves to "keep the raw text". That is why `polish` returns
+/// an optional rather than throwing something the caller has to interpret, and
+/// why `accept` is deliberately suspicious of what comes back.
+public enum TranscriptPolisher {
+    /// The cloud's OpenAI-compatible chat endpoint.
+    static let path = "v1/chat/completions"
+    /// The cloud's alias for the small, fast, Groq-hosted model. Dictation is
+    /// capped at 120 s, so the transcripts are short and latency is the only
+    /// thing that matters here.
+    static let model = "parley-fast"
+
+    static let systemPrompt = """
+        You clean up voice-dictation transcripts. Rewrite the user's transcript \
+        into polished written text: remove filler words and false starts, fix \
+        punctuation, add paragraph breaks where natural. Keep the meaning and \
+        the speaker's own wording as much as possible. Preserve the original \
+        language and script EXACTLY: Traditional Chinese input must stay \
+        Traditional Chinese (Taiwan conventions); never convert to Simplified \
+        Chinese; never translate. Do not answer questions in the transcript, do \
+        not add content, do not add commentary. Output ONLY the cleaned text.
+        """
+
+    /// Below this the round trip costs more (in latency, and in the risk of the
+    /// model "helping") than the tidy-up is worth: a single short phrase has no
+    /// filler to remove and no paragraphs to break.
+    static let minimumCharacters = 8
+
+    /// How many of the user's dictionary terms travel with the request. The
+    /// dictionary grows for as long as someone keeps dictating, and a prompt
+    /// that grows with it would eventually cost more latency than the polish is
+    /// worth — the terms are ordered by recency, so the ones that matter to the
+    /// sentence just spoken are at the front anyway.
+    static let maximumProtectedTerms = 30
+
+    public static func shouldPolish(_ raw: String) -> Bool {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).count >= minimumCharacters
+    }
+
+    /// The system message for one request: the standing prompt, plus a line
+    /// naming the user's own vocabulary when there is any. Empty in, unchanged
+    /// out — a user with no dictionary sends exactly what shipped before.
+    static func systemPrompt(protecting terms: [String]) -> String {
+        let kept = terms.prefix(maximumProtectedTerms)
+        guard !kept.isEmpty else { return systemPrompt }
+        return systemPrompt + "\nPreserve these user-dictionary terms exactly as written: "
+            + kept.joined(separator: "、")
+    }
+
+    // MARK: the call
+
+    /// Send `raw` to be cleaned up. Returns the polished text, or `nil` when
+    /// what came back failed `accept` — the caller keeps the raw transcript
+    /// either way. Throws only on transport/HTTP failure, which means the same
+    /// thing to the caller.
+    ///
+    /// `protectedTerms` is the user's personal dictionary. Those are words they
+    /// have already corrected by hand, so the model must not "fix" them back:
+    /// a cleanup pass that undoes a name the user spelled out themselves is
+    /// exactly the kind of help nobody asked for.
+    public static func polish(
+        raw: String, cloud: CloudClient, protectedTerms: [String] = []
+    ) async throws -> String? {
+        let body = try JSONEncoder().encode(
+            ChatRequest(
+                model: model,
+                temperature: 0.2,
+                maxTokens: 2048,
+                messages: [
+                    .init(role: "system", content: systemPrompt(protecting: protectedTerms)),
+                    .init(role: "user", content: raw),
+                ]))
+        let data = try await cloud.postJSON(path, body: body)
+        guard let content = content(fromChatCompletion: data) else { return nil }
+        let polished = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard accept(raw: raw, polished: polished) else { return nil }
+        return polished
+    }
+
+    static func content(fromChatCompletion data: Data) -> String? {
+        guard let response = try? JSONDecoder().decode(ChatResponse.self, from: data) else {
+            return nil
+        }
+        return response.choices.first?.message.content
+    }
+
+    // MARK: what we are willing to swap in
+
+    /// Whether `polished` is a plausible cleanup of `raw`. The model is not
+    /// trusted to have followed the prompt: this is the last gate before text
+    /// the user did not type replaces text they did say.
+    public static func accept(raw: String, polished: String) -> Bool {
+        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = polished.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmedRaw.isEmpty else { return false }
+
+        // A cleanup shortens a little and lengthens a little. Anything outside
+        // this band is a different kind of output: an answer to a question in
+        // the transcript, a summary, a translation, or a truncation.
+        let ratio = Double(trimmed.count) / Double(trimmedRaw.count)
+        guard ratio >= 0.3, ratio <= 2.0 else { return false }
+
+        // Simplified drift: the model rewriting Traditional Chinese into
+        // Simplified is the one failure that looks like success. Only a
+        // *newly introduced* simplified character counts — a user who dictated
+        // simplified text in the first place gets their script back untouched.
+        if !containsSimplifiedChinese(trimmedRaw), containsSimplifiedChinese(trimmed) {
+            return false
+        }
+        return true
+    }
+
+    /// A heuristic drift detector, not a converter: a membership test against
+    /// high-frequency characters whose Traditional counterpart is a different
+    /// character (说/說, 时/時, 开/開…). It answers "did Simplified Chinese
+    /// appear here", nothing more — it cannot tell you a text is Traditional,
+    /// and it is not a script classifier. Over-rejecting is the safe direction:
+    /// a rejected polish just leaves the user with the raw transcript.
+    public static func containsSimplifiedChinese(_ s: String) -> Bool {
+        s.contains { simplifiedOnly.contains($0) }
+    }
+
+    /// Simplified-only characters. Characters that are also written this way in
+    /// Traditional Chinese (別, 份, 氣, 目, 內, 那…) are deliberately absent:
+    /// they would fire on perfectly good Traditional output.
+    private static let simplifiedOnly: Set<Character> = Set(
+        """
+        说时后对开门问间东发经过还进远运动会员实处体验声记忆费术语议论证据坚决卖买风飞马鸟龙单双击战胜负责务际线联网络继续读书写听讲词汇报诉\
+        应该脑头们几个从来没错误导师长辈坛贴质价钱财产业习惯题标号码现场适当选择优点败义愤骂\
+        汉简传输车电话张欢乐学觉视观见亲让认识请谢谁边铁银钟页顺须顾预领频颜类显
+        """)
+
+    // MARK: wire shapes (OpenAI chat completions)
+
+    struct ChatRequest: Encodable {
+        struct Message: Encodable {
+            let role: String
+            let content: String
+        }
+        let model: String
+        let temperature: Double
+        let maxTokens: Int
+        let messages: [Message]
+
+        enum CodingKeys: String, CodingKey {
+            case model, temperature, messages
+            case maxTokens = "max_tokens"
+        }
+    }
+
+    struct ChatResponse: Decodable {
+        struct Choice: Decodable {
+            struct Message: Decodable { let content: String }
+            let message: Message
+        }
+        let choices: [Choice]
+    }
+}

--- a/ios/ParleyKit/Tests/ParleyKitTests/TranscriptPolisherTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/TranscriptPolisherTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+
+@testable import ParleyKit
+
+/// The gates around the cleanup pass. Every one of them exists to make the same
+/// promise keepable: a polish that is not obviously a polish must be dropped,
+/// because the raw transcript is already correct in the user's document.
+final class TranscriptPolisherTests: XCTestCase {
+
+    // MARK: shouldPolish
+
+    func testShouldPolishSkipsShortPhrases() {
+        XCTAssertFalse(TranscriptPolisher.shouldPolish(""))
+        XCTAssertFalse(TranscriptPolisher.shouldPolish("thanks"))
+        XCTAssertFalse(TranscriptPolisher.shouldPolish("   ok    "), "whitespace doesn't count")
+    }
+
+    func testShouldPolishAcceptsFromEightCharacters() {
+        XCTAssertTrue(TranscriptPolisher.shouldPolish("12345678"))
+        XCTAssertTrue(TranscriptPolisher.shouldPolish("um so I was thinking we could ship it"))
+        XCTAssertTrue(TranscriptPolisher.shouldPolish("我們明天早上再確認一次"))
+    }
+
+    // MARK: accept
+
+    func testAcceptsAPlausibleCleanup() {
+        XCTAssertTrue(
+            TranscriptPolisher.accept(
+                raw: "um so I was thinking like we could maybe ship it tomorrow",
+                polished: "I was thinking we could ship it tomorrow."))
+    }
+
+    func testRejectsEmptyPolish() {
+        XCTAssertFalse(
+            TranscriptPolisher.accept(raw: "um so I was thinking about it", polished: ""))
+        XCTAssertFalse(
+            TranscriptPolisher.accept(raw: "um so I was thinking about it", polished: "   \n "))
+    }
+
+    func testRejectsWhenTooMuchWasCutAway() {
+        // The shape of a model that summarised instead of cleaning up.
+        XCTAssertFalse(
+            TranscriptPolisher.accept(
+                raw: String(repeating: "the quick brown fox jumped over it. ", count: 4),
+                polished: "A fox jumped."))
+    }
+
+    func testRejectsWhenTheModelAnsweredInsteadOfCleaning() {
+        XCTAssertFalse(
+            TranscriptPolisher.accept(
+                raw: "what is the capital of France",
+                polished:
+                    "The capital of France is Paris, a city on the Seine in the north of the "
+                    + "country, and it has been the seat of government since the tenth century."))
+    }
+
+    func testRejectsSimplifiedDrift() {
+        XCTAssertFalse(
+            TranscriptPolisher.accept(
+                raw: "我們說好的時間到了", polished: "我们说好的时间到了。"),
+            "Traditional in, Simplified out is the failure that looks like success")
+    }
+
+    func testSimplifiedInputKeepsItsOwnScript() {
+        XCTAssertTrue(
+            TranscriptPolisher.accept(
+                raw: "我们说好的时间到了嗯就是这样",
+                polished: "我们说好的时间到了，就是这样。"),
+            "the guard is about drift, not about preferring one script")
+    }
+
+    func testEnglishIsUntouchedByTheScriptGuard() {
+        XCTAssertTrue(
+            TranscriptPolisher.accept(
+                raw: "so uh we should probably call them back on monday",
+                polished: "We should call them back on Monday."))
+    }
+
+    // MARK: containsSimplifiedChinese
+
+    func testDetectsSimplifiedOnlyCharacters() {
+        XCTAssertTrue(TranscriptPolisher.containsSimplifiedChinese("说"))
+        XCTAssertTrue(TranscriptPolisher.containsSimplifiedChinese("对"))
+        XCTAssertTrue(TranscriptPolisher.containsSimplifiedChinese("开"))
+        XCTAssertTrue(TranscriptPolisher.containsSimplifiedChinese("先開門再说"))
+    }
+
+    func testTraditionalAndNonChineseAreNotFlagged() {
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese("說"))
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese("對"))
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese("開"))
+        XCTAssertFalse(
+            TranscriptPolisher.containsSimplifiedChinese("我們說好的時間到了，明天早上再確認。"))
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese("Nothing Chinese in here."))
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese("ありがとうございます"))
+        XCTAssertFalse(TranscriptPolisher.containsSimplifiedChinese(""))
+    }
+
+    // MARK: wire shapes
+
+    func testDecodesChatCompletionContent() {
+        let json = Data(
+            """
+            {
+              "id": "chatcmpl-1",
+              "object": "chat.completion",
+              "model": "parley-fast",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": { "role": "assistant", "content": "We should ship it tomorrow." },
+                  "finish_reason": "stop"
+                }
+              ],
+              "usage": { "prompt_tokens": 90, "completion_tokens": 8, "total_tokens": 98 }
+            }
+            """.utf8)
+
+        XCTAssertEqual(
+            TranscriptPolisher.content(fromChatCompletion: json), "We should ship it tomorrow.")
+    }
+
+    func testChoicelessOrUnparsableResponseIsNil() {
+        XCTAssertNil(TranscriptPolisher.content(fromChatCompletion: Data(#"{"choices":[]}"#.utf8)))
+        XCTAssertNil(TranscriptPolisher.content(fromChatCompletion: Data("not json".utf8)))
+    }
+
+    func testRequestBodyUsesTheFastModelAndOpenAIKeys() throws {
+        let body = try JSONEncoder().encode(
+            TranscriptPolisher.ChatRequest(
+                model: TranscriptPolisher.model, temperature: 0.2, maxTokens: 2048,
+                messages: [
+                    .init(role: "system", content: TranscriptPolisher.systemPrompt),
+                    .init(role: "user", content: "hello there"),
+                ]))
+        let obj = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(obj["model"] as? String, "parley-fast")
+        XCTAssertEqual(obj["max_tokens"] as? Int, 2048, "snake_case, as the OpenAI shape wants")
+        let messages = try XCTUnwrap(obj["messages"] as? [[String: String]])
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0]["role"], "system")
+        XCTAssertEqual(messages[1]["content"], "hello there")
+    }
+
+    // MARK: the personal dictionary rides along
+
+    func testNoTermsLeavesTheStandingPromptAlone() {
+        XCTAssertEqual(
+            TranscriptPolisher.systemPrompt(protecting: []), TranscriptPolisher.systemPrompt)
+    }
+
+    func testTermsAreNamedInTheSystemPrompt() {
+        let prompt = TranscriptPolisher.systemPrompt(protecting: ["Cerana", "派斯科技"])
+        XCTAssertTrue(prompt.hasPrefix(TranscriptPolisher.systemPrompt), "the standing rules stay")
+        XCTAssertTrue(prompt.contains("Cerana、派斯科技"))
+    }
+
+    func testOnlyTheFirstThirtyTermsTravel() {
+        let terms = (1...40).map { "term\($0)" }
+        let prompt = TranscriptPolisher.systemPrompt(protecting: terms)
+        XCTAssertTrue(prompt.contains("term30"))
+        XCTAssertFalse(prompt.contains("term31"), "the dictionary grows; the prompt must not")
+    }
+}


### PR DESCRIPTION
## What

iOS dictation gains an optional LLM cleanup pass (Typeless-style): when a session ends, the raw transcript goes to Parley Cloud's OpenAI-compatible endpoint (`parley-fast`, Groq-hosted) to drop filler words, fix punctuation, and break paragraphs. The session stays in `.finishing` for the round trip (6 s hard budget), and `.done` — the keyboard's single insertion cue since #312 — already carries the final text. The keyboard and the App Group wire protocol are untouched.

Toggle: Settings → Voice keyboard → **Polish with AI** (default on, `en` + `zh-Hant` strings).

## Why this shape

- **Never worse than raw.** Every failure mode — timeout, no network, signed out, HTTP error, rejected reply — ships the raw transcript, silently.
- **Acceptance gates over trust.** `TranscriptPolisher.accept` rejects empty output, implausible length ratios (a model that answered the transcript instead of cleaning it), and Simplified-Chinese drift: a zh-Hant transcript that comes back with simplified-only characters is discarded wholesale.
- **The personal dictionary (#313) wins both ways.** Confirmed terms ride in the prompt as protected vocabulary, and `applyLexicon` runs *after* the polish so a hand-made correction always beats the model. Polishing before the one-shot paste (instead of swapping text afterwards) also keeps the keyboard's lexicon watch from harvesting the model's rewrites as user corrections.
- `finishUp` now refuses re-entry; this de-dupes the polish request and closes a pre-existing race where the relay signing off after `fail()` could overwrite `.error` with `.done`.

## Verification

- `swift test --package-path ios/ParleyKit`: 182 tests, 0 failures (17 new for the polisher, incl. the simplified-drift detector and prompt/term capping).
- `xcodegen` + `xcodebuild` (iOS Simulator): build succeeded, no warnings in touched files.
- `bunx tsc --noEmit` and `bunx vitest run` (269 tests): clean.

Not yet exercised end-to-end on a device — the polish leg needs a signed-in account and a live relay; worth one real dictation on TestFlight before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)