### PR TITLE
[feature] the keyboard answers the finger, and switching stops being a swipe

### DIFF
--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -822,6 +822,16 @@ final class DictationCoordinator: ObservableObject {
         applyLexicon()
         publish()
         active = false
+        // No haptic here, deliberately. `done` is not delivery — it is this
+        // process saying the text is *ready* — and the transcript is only ever
+        // handed to anyone by the keyboard's one `insertText` (see
+        // `KeyboardViewController.drainDownlink`). That holds for both entry
+        // points: `DictationView` is a hand-off screen that shows no transcript
+        // and has no stop control, and `StartDictationIntent` is delivered by
+        // "whatever Parley keyboard is frontmost" too. So the success pattern
+        // belongs to the keyboard process, which is also the one the user is
+        // actually holding — this one is usually in the background by now, and
+        // iOS drops haptics from a background app.
     }
 
     /// The cleanup pass with a deadline on it. Every way this can go wrong — a

--- a/ios/Keyboard/Haptics.swift
+++ b/ios/Keyboard/Haptics.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+/// The two beats a dictation has, in one place so they cannot drift apart.
+///
+/// They are deliberately different patterns rather than two of the same thump:
+/// the start is a single solid impact under the finger that just pressed, and
+/// the finish is the system's two-beat success pattern, arriving when the words
+/// land in the field. If both ends of a session felt identical the second one
+/// would read as a stray tap.
+///
+/// This lives in the keyboard target because both beats happen there — the tap
+/// that starts a dictation, and the one `insertText` that delivers it. The app
+/// records in between and hands over nothing, so it has nothing to confirm; if
+/// that ever changes, move this to a shared source directory rather than
+/// copying it.
+///
+/// **Full Access.** Inside a keyboard extension the system silently drops
+/// haptics unless the user has granted it, so the keyboard's call sites sit
+/// behind `UIInputViewController.hasFullAccess` to keep that fact in the code
+/// rather than in a bug report. Nothing here is ever load-bearing: a haptic that
+/// does not play costs the user nothing, which is what lets the keyboard stay
+/// fully usable without Full Access (App Review 4.4.1).
+///
+/// There is no setting for any of this. A device with haptics turned off in
+/// Settings already plays nothing, and a second switch would only be a way to
+/// disagree with the system.
+enum Haptics {
+    /// Held rather than made per call: `prepare()` only helps the generator it
+    /// was called on, and a generator created at the moment of the event is
+    /// exactly the late one it exists to avoid.
+    ///
+    /// `nonisolated(unsafe)` because every call site is already on the main
+    /// thread — a SwiftUI body and a `UIInputViewController` — which is also
+    /// what UIKit requires of feedback generators.
+    nonisolated(unsafe) private static let start = UIImpactFeedbackGenerator(style: .medium)
+    nonisolated(unsafe) private static let finish = UINotificationFeedbackGenerator()
+
+    /// Warm the engine up before the press that will need it.
+    static func prepareForDictation() { start.prepare() }
+
+    /// The microphone is opening: one solid thump, on the press rather than on
+    /// the release.
+    static func dictationStarted() { start.impactOccurred() }
+
+    /// Warm the engine up for the end of a session that is already finishing.
+    static func prepareForDelivery() { finish.prepare() }
+
+    /// The transcript is finished and handed over — fired by whichever process
+    /// actually inserts it, which is always the keyboard. Once per session, and
+    /// never on the failure path: a session that ended in an error delivered
+    /// nothing, and saying "done" with the body would be the wrong news.
+    static func dictationDelivered() { finish.notificationOccurred(.success) }
+}

--- a/ios/Keyboard/KeyboardKeys.swift
+++ b/ios/Keyboard/KeyboardKeys.swift
@@ -18,6 +18,15 @@ enum KeyTint {
     case accent
 }
 
+/// What a cap is cut to. Characters keep UIKit's rounded rectangle; the
+/// function keys around them — shift, delete, `123`, the globe, space, return
+/// and the mode key — are pills, which is how the two families stay tellable
+/// apart at a glance when both carry the same soft shadow.
+enum KeyShape {
+    case cap
+    case pill
+}
+
 /// Every width on a key row, derived from the widest row's key count: one key is
 /// the unit and every wide key is expressed in units, so the rows line up on a
 /// 320pt SE and a 440pt Pro Max alike.
@@ -40,18 +49,39 @@ struct KeyRowMetrics {
     /// The half-key iOS insets the QWERTY home row by — and exactly what centres
     /// a ten-key 注音 row under the eleven-key one above it.
     var halfKey: CGFloat { (unit + KBMetrics.keyGap) / 2 }
+
+    /// The mode key. A `wide` key on a 320pt SE comes out at 42pt, under the
+    /// 44pt minimum target — so this one key takes its floor from the metrics
+    /// table and the difference comes out of the space bar, which is the only
+    /// key in the row with slack to give.
+    var mode: CGFloat { max(wide, KBMetrics.modeKeyWidth) }
 }
 
-/// A key cap. 5pt corners and a 1pt hard shadow, which is what UIKit draws.
+/// A key cap: 7pt corners on a character, a pill on a function key, over two
+/// stacked soft shadows in both appearances.
+///
+/// It used to be 5pt corners and a single hard 1pt shadow that was switched off
+/// entirely in dark mode — the copy of UIKit's own cap. The softer pair reads as
+/// Parley's rather than as a slightly-wrong system keyboard, and dark mode gets
+/// a shadow at all, which it did not before.
 struct KeyCap: View {
     let dark: Bool
     let tint: KeyTint
+    var shape: KeyShape = .cap
     let pressed: Bool
 
     var body: some View {
-        RoundedRectangle(cornerRadius: 5, style: .continuous)
-            .fill(fill)
-            .shadow(color: .black.opacity(dark ? 0 : 0.28), radius: 0, x: 0, y: 1)
+        Group {
+            switch shape {
+            case .cap:
+                RoundedRectangle(cornerRadius: KBMetrics.keyRadius, style: .continuous)
+                    .fill(fill)
+            case .pill:
+                Capsule().fill(fill)
+            }
+        }
+        .shadow(color: KBTheme.capShadowNear(dark), radius: 1, x: 0, y: 1)
+        .shadow(color: KBTheme.capShadowFar(dark), radius: 3, x: 0, y: 2)
     }
 
     private var fill: Color {
@@ -79,22 +109,42 @@ struct ControlDisc: View {
 }
 
 /// A button that reports its own pressed state, so keys and the mic control can
-/// darken under the finger the way system keys do. `.buttonStyle(.plain)` alone
-/// gives no feedback at all, which is what made the keys feel dead.
+/// darken and shrink under the finger the way system keys do.
+/// `.buttonStyle(.plain)` alone gives no feedback at all, which is what made the
+/// keys feel dead.
+///
+/// `onPressDown` fires the moment the finger lands, which `action` — a button's
+/// touch-*up* — cannot: the record button's haptic has to arrive with the press,
+/// not after it. It never changes when a character is typed; only `action` does
+/// that.
 struct PressableButton<Content: View>: View {
     let action: () -> Void
+    var onPressDown: (() -> Void)?
     @ViewBuilder var content: (Bool) -> Content
 
     var body: some View {
         Button(action: action) { EmptyView() }
-            .buttonStyle(PressStyle(content: content))
+            .buttonStyle(PressStyle(content: content, onPressDown: onPressDown))
     }
 
     private struct PressStyle<C: View>: ButtonStyle {
         @ViewBuilder var content: (Bool) -> C
+        var onPressDown: (() -> Void)?
+
         func makeBody(configuration: Configuration) -> some View {
+            // Two animation scopes, not one: the inner keeps the fill swap on
+            // exactly the ease it always had, the outer gives the scale its
+            // spring on the way back up.
             content(configuration.isPressed)
-                .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+                .animation(KBMetrics.pressDown, value: configuration.isPressed)
+                .scaleEffect(configuration.isPressed ? KBMetrics.pressScale : 1)
+                .animation(
+                    configuration.isPressed ? KBMetrics.pressDown : KBMetrics.pressUp,
+                    value: configuration.isPressed
+                )
+                .onChange(of: configuration.isPressed) { _, isPressed in
+                    if isPressed { onPressDown?() }
+                }
         }
     }
 }
@@ -147,7 +197,12 @@ struct RepeatingKey<Content: View>: View {
     var body: some View {
         content(pressed)
             .contentShape(Rectangle())
-            .animation(.easeOut(duration: 0.08), value: pressed)
+            // The same two scopes as `PressableButton`: these keys never go
+            // through the button style, so the press feedback has to be spelled
+            // out here too or delete would be the one dead key on the board.
+            .animation(KBMetrics.pressDown, value: pressed)
+            .scaleEffect(pressed ? KBMetrics.pressScale : 1)
+            .animation(pressed ? KBMetrics.pressDown : KBMetrics.pressUp, value: pressed)
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { _ in
@@ -174,6 +229,8 @@ struct RepeatingKey<Content: View>: View {
 struct KeyButton<Label: View>: View {
     let dark: Bool
     var tint: KeyTint = .letter
+    /// Characters keep the rounded cap; every function key is a pill.
+    var shape: KeyShape = .cap
     var width: CGFloat?
     var height: CGFloat = KBMetrics.keyHeight
     var ink: Color?
@@ -183,7 +240,7 @@ struct KeyButton<Label: View>: View {
     var body: some View {
         PressableButton(action: action) { pressed in
             ZStack {
-                KeyCap(dark: dark, tint: tint, pressed: pressed)
+                KeyCap(dark: dark, tint: tint, shape: shape, pressed: pressed)
                 label().foregroundStyle(ink ?? KBTheme.ink(dark))
             }
             .frame(width: width, height: height)
@@ -203,7 +260,7 @@ struct DeleteKey: View {
     var body: some View {
         RepeatingKey(action: action) { pressed in
             ZStack {
-                KeyCap(dark: dark, tint: .alt, pressed: pressed)
+                KeyCap(dark: dark, tint: .alt, shape: .pill, pressed: pressed)
                 Image(systemName: "delete.left")
                     .font(.system(size: 19, weight: .regular))
                     .foregroundStyle(KBTheme.ink(dark))
@@ -245,7 +302,7 @@ struct GlobeKey: View {
             if round {
                 ControlDisc(dark: dark, pressed: pressed)
             } else {
-                KeyCap(dark: dark, tint: .alt, pressed: pressed)
+                KeyCap(dark: dark, tint: .alt, shape: .pill, pressed: pressed)
             }
             Image(systemName: "globe")
                 .font(.system(size: round ? 16 : 17, weight: .regular))
@@ -253,7 +310,12 @@ struct GlobeKey: View {
                 .accessibilityHidden(true)
             InputModeSwitchButton(controller: controller, pressed: $pressed)
         }
-        .animation(.easeOut(duration: 0.08), value: pressed)
+        // Its own press feedback, for the same reason `RepeatingKey` has one:
+        // the touches belong to a UIKit button, so the cap would otherwise be
+        // the only key on the row that doesn't move.
+        .animation(KBMetrics.pressDown, value: pressed)
+        .scaleEffect(pressed ? KBMetrics.pressScale : 1)
+        .animation(pressed ? KBMetrics.pressDown : KBMetrics.pressUp, value: pressed)
     }
 }
 
@@ -306,5 +368,116 @@ private struct InputModeSwitchButton: UIViewRepresentable {
         var report: (Bool) -> Void = { _ in }
         @objc func down() { report(true) }
         @objc func up() { report(false) }
+    }
+}
+
+/// What a pane is called, in one place: the strip names the pane you are on,
+/// the mode key names the one you are going to, and the menu names all of them.
+///
+/// 注音 keeps its own name in both localizations — the keys on that pane *are*
+/// 注音, and nothing an English word could say would identify it faster.
+extension KeyboardPane {
+    /// The short name, as it goes on a key cap.
+    var name: Text {
+        switch self {
+        case .voice: return Text("Voice")
+        case .english: return Text("English")
+        case .zhuyin: return Text(verbatim: "注音")
+        }
+    }
+
+    /// The long name, for VoiceOver and for the mode key's menu, where there is
+    /// room to say which of the three kinds of thing this is.
+    var label: Text {
+        switch self {
+        case .voice: return Text("Voice dictation")
+        case .english: return Text("English keyboard")
+        case .zhuyin: return Text("Bopomofo keyboard")
+        }
+    }
+}
+
+/// The key that changes pane — the headline of the bottom row.
+///
+/// Before it, the only way across was a full-width swipe nobody found and a row
+/// of 5pt dots far under the 44pt minimum target. This is the ordinary answer:
+/// a key that says where it goes, in the same corner of every pane so the hand
+/// can learn it.
+///
+/// **Tap advances, hold picks.** `primaryAction` is the tap — one pane along,
+/// wrapping at the end so the key is never a dead one — and the menu is the long
+/// press, listing every pane with the current one ticked, for jumping straight
+/// across a three-pane track. It is the same pairing the system's own globe has,
+/// which is why it needs no explaining.
+///
+/// It is labelled with the pane it will take you to, like the system's
+/// `123`/`ABC` key: a key captioned with what you are already looking at is the
+/// one caption that tells you nothing.
+struct ModeKey: View {
+    @ObservedObject var bridge: KeyboardBridge
+    let dark: Bool
+    var width: CGFloat?
+    var height: CGFloat = KBMetrics.keyHeight
+    /// The voice pane draws its controls as discs, the typing panes as caps.
+    var round = false
+
+    /// A `Menu` reports no pressed state of its own, so the one genuinely new
+    /// key would have been the only dead key on a keyboard whose point is that
+    /// pressing things feels like something. A zero-distance drag alongside the
+    /// menu's own recognizer supplies it.
+    ///
+    /// `@GestureState` rather than `@State` because it resets itself when the
+    /// gesture ends *or is cancelled* — and the menu opening under the finger is
+    /// exactly the cancellation that would otherwise leave the cap stuck down.
+    @GestureState private var pressed = false
+
+    var body: some View {
+        Menu {
+            ForEach(bridge.panes, id: \.self) { pane in
+                Button(action: { bridge.setPane(pane) }) {
+                    if pane == bridge.pane {
+                        Label { pane.label } icon: { Image(systemName: "checkmark") }
+                    } else {
+                        pane.label
+                    }
+                }
+            }
+        } label: {
+            ZStack {
+                if round {
+                    ControlDisc(dark: dark, pressed: pressed)
+                } else {
+                    KeyCap(dark: dark, tint: .alt, shape: .pill, pressed: pressed)
+                }
+                bridge.nextPane.name
+                    .font(.system(size: round ? 13 : 15))
+                    // "English" is wider than a 44pt key on a 320pt SE. It
+                    // shrinks rather than truncating: half a pane name is worse
+                    // than a small one.
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                    .padding(.horizontal, 4)
+                    .foregroundStyle(round ? KBTheme.inkSoft(dark) : KBTheme.ink(dark))
+            }
+            .frame(width: width, height: height)
+            .frame(maxWidth: width == nil ? .infinity : nil)
+            .contentShape(Rectangle())
+            // The same two scopes every other key uses: the fill on the ease it
+            // has always had, the scale springing back on release.
+            .animation(KBMetrics.pressDown, value: pressed)
+            .scaleEffect(pressed ? KBMetrics.pressScale : 1)
+            .animation(pressed ? KBMetrics.pressDown : KBMetrics.pressUp, value: pressed)
+            // Simultaneous, so it only *observes* the touch: the tap still
+            // reaches `primaryAction` and the hold still opens the menu.
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .updating($pressed) { _, state, _ in state = true }
+            )
+        } primaryAction: {
+            bridge.advancePane()
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text("Switch input mode"))
+        .accessibilityValue(bridge.nextPane.name)
     }
 }

--- a/ios/Keyboard/KeyboardLetterPane.swift
+++ b/ios/Keyboard/KeyboardLetterPane.swift
@@ -61,13 +61,22 @@ struct LetterPane: View {
         }
     }
 
-    /// `123`, the globe when the system asks for one, `@`, the space bar, and
-    /// return. Space takes whatever the fixed keys leave, which lands it at
-    /// roughly the five-key width iOS gives it — and a little wider on the
-    /// devices that draw their own globe below the keyboard.
+    /// The mode key, `123`, the globe when the system asks for one, `@`, the
+    /// space bar, and return. Space takes whatever the fixed keys leave, which
+    /// lands it at roughly the five-key width iOS gives it — and a little wider
+    /// on the devices that draw their own globe below the keyboard.
+    ///
+    /// The mode key holds the bottom-left corner on every pane, which is what
+    /// pushes `123` one key along. That corner is the price of the swipe no
+    /// longer being the only way across: a key that moves between panes has to
+    /// be in the same place on all of them, and this is the only slot the voice
+    /// pane can also offer.
     private func bottomRow(_ m: KeyRowMetrics) -> some View {
         row {
-            KeyButton(dark: dark, tint: .alt, width: m.wide, action: openSymbols) {
+            ModeKey(bridge: bridge, dark: dark, width: m.mode)
+            KeyButton(
+                dark: dark, tint: .alt, shape: .pill, width: m.wide, action: openSymbols
+            ) {
                 Text(verbatim: "123").font(.system(size: 16, weight: .regular))
             }
             .accessibilityLabel(Text(verbatim: "123"))
@@ -79,7 +88,7 @@ struct LetterPane: View {
                 Text(verbatim: "@").font(.system(size: 22))
             }
             .accessibilityLabel(Text("At sign"))
-            KeyButton(dark: dark, width: nil, action: tapSpace) {
+            KeyButton(dark: dark, shape: .pill, width: nil, action: tapSpace) {
                 Text("Space").font(.system(size: 15))
             }
             .accessibilityLabel(Text("Space"))
@@ -107,7 +116,8 @@ struct LetterPane: View {
         KeyButton(
             // An engaged shift borrows the light letter cap, which is how iOS
             // shows that it is armed without adding a second colour.
-            dark: dark, tint: shift.isOn ? .letter : .alt, width: width, action: tapShift
+            dark: dark, tint: shift.isOn ? .letter : .alt, shape: .pill, width: width,
+            action: tapShift
         ) {
             Image(systemName: shiftGlyph).font(.system(size: 19, weight: .regular))
         }

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -64,11 +64,26 @@ struct KeyboardRootView: View {
                             state = rubberBanded(value.translation.width, width: width)
                         }
                         .onEnded { value in
-                            let dx = value.translation.width
-                            guard abs(dx) > KBMetrics.swipeThreshold,
-                                abs(dx) > abs(value.translation.height) * 1.5
-                            else { return }
-                            bridge.stepPane(by: dx < 0 ? 1 : -1)
+                            // Either measure may commit it: how far the finger
+                            // actually went, or where its velocity says it was
+                            // going. Reading only the first is what made a fast
+                            // flick — the gesture everybody actually uses — do
+                            // nothing, because the finger leaves the glass long
+                            // before it has travelled 56pt.
+                            let move: CGSize
+                            if abs(value.translation.width) > KBMetrics.swipeThreshold {
+                                move = value.translation
+                            } else if abs(value.predictedEndTranslation.width)
+                                > KBMetrics.swipeThreshold
+                            {
+                                move = value.predictedEndTranslation
+                            } else {
+                                return
+                            }
+                            // Still has to be a sideways gesture, judged on
+                            // whichever measure committed it.
+                            guard abs(move.width) > abs(move.height) * 1.5 else { return }
+                            bridge.stepPane(by: move.width < 0 ? 1 : -1)
                         }
                 )
             }
@@ -102,6 +117,10 @@ struct KeyboardRootView: View {
     /// and hid the fact that the pane swipes at all. Dots say "there is another
     /// one of these, sideways" — and they stay tappable, so nothing is lost.
     ///
+    /// They are a signpost and nothing more now: the bottom row of every pane
+    /// carries a real mode key (`ModeKey`), so nothing the user needs depends on
+    /// hitting a 5pt mark.
+    ///
     /// While a 注音 syllable is being typed the whole row is given over to the
     /// composition and its candidates. It is the one row the keyboard has to
     /// spare, and the alternative — a bar of its own above the keys — would make
@@ -117,7 +136,7 @@ struct KeyboardRootView: View {
                     windowChip
                     Spacer(minLength: 8)
                 }
-                paneName(bridge.pane)
+                bridge.pane.name
                     .font(.caption.weight(.medium))
                     .foregroundStyle(KBTheme.inkSoft(dark))
                     .padding(.trailing, 8)
@@ -132,26 +151,6 @@ struct KeyboardRootView: View {
         }
         .frame(height: KBMetrics.strip)
         .padding(.horizontal, 12)
-    }
-
-    /// The pane's short name. 注音 keeps its own name in both localizations: the
-    /// keys on that pane *are* 注音, and nothing an English word could say
-    /// would identify it faster.
-    @ViewBuilder
-    private func paneName(_ pane: KeyboardPane) -> some View {
-        switch pane {
-        case .voice: Text("Voice")
-        case .english: Text("English")
-        case .zhuyin: Text(verbatim: "注音")
-        }
-    }
-
-    private func paneLabel(_ pane: KeyboardPane) -> Text {
-        switch pane {
-        case .voice: return Text("Voice dictation")
-        case .english: return Text("English keyboard")
-        case .zhuyin: return Text("Bopomofo keyboard")
-        }
     }
 
     // MARK: 注音 composition
@@ -252,7 +251,7 @@ struct KeyboardRootView: View {
                 .animation(.easeInOut(duration: 0.2), value: selected)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(paneLabel(pane))
+        .accessibilityLabel(pane.label)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
@@ -270,25 +269,29 @@ struct KeyboardRootView: View {
     }
 
     /// The controls, arranged around the record button rather than in a row:
-    /// delete top-right, return under it, `@` bottom-left. Top-left is left
-    /// empty on purpose — it is where the pane breathes, and it is the slot the
-    /// globe takes on the devices that still need one.
+    /// delete top-right, return under it, and the mode key bottom-left with the
+    /// globe or `@` above it.
+    ///
+    /// Bottom-left is the mode key's corner on every pane, which is the whole
+    /// point of it — a key that moves between panes is only learnable if it is
+    /// in the same place on all of them — so the slot that used to be left empty
+    /// for the pane to breathe is now what the other two keys share. On the
+    /// devices where the system still asks us to draw a globe there are three
+    /// keys wanting two slots, and `@` is the one that gives: it is a
+    /// convenience here and a real key one swipe away on the letters pane,
+    /// whereas the globe is App Review 4.4.1's way out of the keyboard.
     private var deck: some View {
         HStack(spacing: 0) {
             VStack(spacing: KBMetrics.deckRowGap) {
                 if bridge.showsGlobe {
-                    atKey
-                } else {
-                    Color.clear.frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
-                }
-                if bridge.showsGlobe {
-                    // Bottom-left, where the system's own globe sits, so the
-                    // muscle memory carries over on the devices that show it.
                     GlobeKey(controller: bridge.controller, dark: dark, round: true)
                         .frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
                 } else {
                     atKey
                 }
+                ModeKey(
+                    bridge: bridge, dark: dark, width: KBMetrics.roundKey,
+                    height: KBMetrics.roundKey, round: true)
             }
             Spacer(minLength: 0)
             recordButton
@@ -360,7 +363,7 @@ struct KeyboardRootView: View {
     /// otherwise the tap goes to Parley, and the button says so. The colour
     /// stays either way — the button is still the thing to press.
     private var recordButton: some View {
-        PressableButton(action: toggle) { pressed in
+        PressableButton(action: toggle, onPressDown: startHaptic) { pressed in
             ZStack {
                 if bridge.listening && !reduceMotion {
                     PulseRing(color: KBTheme.recording)
@@ -406,6 +409,20 @@ struct KeyboardRootView: View {
 
     private var recordInk: Color {
         bridge.hasFullAccess ? .white : KBTheme.inkSoft(dark)
+    }
+
+    /// One solid thump as the finger lands on the record button, not when it
+    /// lifts: the press is the moment the user commits to speaking, and a
+    /// confirmation that arrives after the release confirms nothing.
+    ///
+    /// Only on the press that *starts* something — ⏹ ends with the success
+    /// pattern instead (`Haptics.dictationDelivered`), and the two are
+    /// deliberately different beats. A keyboard extension only gets haptics at
+    /// all with Full Access; without it the button is disabled anyway, and the
+    /// guard says so rather than leaving it to be inferred.
+    private func startHaptic() {
+        guard bridge.hasFullAccess, !bridge.listening else { return }
+        Haptics.dictationStarted()
     }
 
     private func toggle() {

--- a/ios/Keyboard/KeyboardSymbolPlanes.swift
+++ b/ios/Keyboard/KeyboardSymbolPlanes.swift
@@ -62,14 +62,17 @@ struct SymbolPlanes: View {
         }
     }
 
+    /// The mode key keeps the corner it has on every pane, so `123` does not
+    /// become the one plane you have to leave before you can change keyboard.
     private func bottomRow(_ m: KeyRowMetrics) -> some View {
         row {
+            ModeKey(bridge: bridge, dark: dark, width: m.mode)
             altKey(homeLabel, width: m.wide, action: onHome)
             if bridge.showsGlobe {
                 GlobeKey(controller: bridge.controller, dark: dark)
                     .frame(width: m.unit, height: KBMetrics.keyHeight)
             }
-            KeyButton(dark: dark, width: nil, action: { bridge.space() }) {
+            KeyButton(dark: dark, shape: .pill, width: nil, action: { bridge.space() }) {
                 Text("Space").font(.system(size: 15))
             }
             .accessibilityLabel(Text("Space"))
@@ -95,7 +98,7 @@ struct SymbolPlanes: View {
     private func altKey(
         _ label: String, width: CGFloat, action: @escaping () -> Void
     ) -> some View {
-        KeyButton(dark: dark, tint: .alt, width: width, action: action) {
+        KeyButton(dark: dark, tint: .alt, shape: .pill, width: width, action: action) {
             Text(verbatim: label).font(.system(size: 16, weight: .regular))
         }
         .accessibilityLabel(Text(verbatim: label))
@@ -117,7 +120,8 @@ struct ReturnKey: View {
     var body: some View {
         let accented = bridge.returnKeyIsAccented
         return KeyButton(
-            dark: dark, tint: accented ? .accent : .alt, width: width, height: height,
+            dark: dark, tint: accented ? .accent : .alt, shape: .pill, width: width,
+            height: height,
             ink: accented ? .white : KBTheme.ink(dark),
             action: { bridge.newline() }
         ) {

--- a/ios/Keyboard/KeyboardTheme.swift
+++ b/ios/Keyboard/KeyboardTheme.swift
@@ -70,6 +70,26 @@ enum KBTheme {
         dark ? Color(white: 0.30) : .white
     }
 
+    /// The colour under a key cap, ported from `@pathors/ui`'s `--shadow-sm`.
+    ///
+    /// A neutral blue-black rather than the brand blue on purpose: a shadow is
+    /// the absence of light, and tinting it with the accent is the fastest way
+    /// to make a keyboard look like a mock-up. The cap stacks two of these —
+    /// `capShadowNear` hugging the edge and `capShadowFar` under it — because
+    /// SwiftUI has no shadow *spread*, so the CSS token's tight-plus-soft pair
+    /// is approximated by two blurs rather than one.
+    private static let capShadowInk = Color(red: 0.078, green: 0.118, blue: 0.176)
+
+    /// Both appearances carry it. Dark mode used to draw no shadow at all,
+    /// which left every cap floating flat against the input view.
+    static func capShadowNear(_ dark: Bool) -> Color {
+        dark ? Color.black.opacity(0.50) : capShadowInk.opacity(0.10)
+    }
+
+    static func capShadowFar(_ dark: Bool) -> Color {
+        dark ? Color.black.opacity(0.50) : capShadowInk.opacity(0.06)
+    }
+
     /// The voice pane's round control buttons.
     ///
     /// Deliberately *not* a key cap. The voice pane is a control panel, not a
@@ -114,6 +134,30 @@ enum KBMetrics {
     static let sideInset: CGFloat = 3
     static let paneTop: CGFloat = 8
     static let paneBottom: CGFloat = 4
+
+    /// A character cap's corners. The function keys around them are pills
+    /// instead (`KeyShape`), which is what separates the two families at a
+    /// glance now that both carry the same soft shadow.
+    static let keyRadius: CGFloat = 7
+
+    /// The narrowest the mode key is allowed to get. A row's `wide` unit falls
+    /// below the 44pt minimum target on a 320pt SE, so the mode key takes the
+    /// difference out of the space bar rather than out of the finger.
+    static let modeKeyWidth: CGFloat = 44
+
+    // How a key answers a finger. The cap shrinks a hair going down and springs
+    // back coming up, on top of the fill swap that was already there.
+    //
+    // 80ms and 0.97 deliberately differ from the `@pathors/ui` web token
+    // (`active:scale-[0.98]`, 150ms): a key is pressed a few times a second,
+    // and at typing speed a 150ms settle reads as lag rather than as feedback.
+    // The tighter scale is what keeps the shorter animation legible.
+    static let pressScale: CGFloat = 0.97
+    static let pressDuration: Double = 0.08
+    static let pressDown = Animation.easeOut(duration: KBMetrics.pressDuration)
+    /// Coming back up is a spring rather than the ease: the release is the beat
+    /// the finger is no longer on the key for, so it can afford the overshoot.
+    static let pressUp = Animation.spring(response: 0.2, dampingFraction: 0.75)
 
     /// Four rows of caps: 8 + 4×42 + 3×11 + 4 = 213pt, within a few points of
     /// the ~216pt key area of the system portrait keyboard.

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -145,6 +145,11 @@ final class KeyboardViewController: UIInputViewController {
         readReadiness()
         readWindow()
         drainDownlink()
+        // Warm the Taptic Engine while the keyboard is coming up, so the thump
+        // lands with the first press on the record button rather than a beat
+        // after it. Pointless without Full Access, where a keyboard gets no
+        // haptics at all — and where the record button is disabled anyway.
+        if hasFullAccess { Haptics.prepareForDictation() }
     }
 
     /// The keyboard is going away, which is the end of the user's chance to fix
@@ -418,6 +423,26 @@ final class KeyboardViewController: UIInputViewController {
             var up = DictationChannel.readUplink() ?? .init(session: session)
             up.insertedCount = insertedCount
             DictationChannel.writeUplink(up)
+            // The words just landed in the user's field, and this process is
+            // the only one that can say so: **the keyboard is the only thing
+            // that ever delivers a transcript**. The app publishes `done` and
+            // stops there — its own dictation screen shows no transcript and
+            // the Action Button intent is inserted by "whatever Parley keyboard
+            // is frontmost" as well — so there is no second buzz to race, and
+            // the app is usually backgrounded by now anyway, where iOS drops
+            // haptics entirely. That is why the pattern moved here.
+            //
+            // Once per session for free: the whole branch is behind the
+            // `insertedCount` high-water mark, so the `done` state
+            // republishing (and this method running on every appearance)
+            // inserts nothing the second time and therefore buzzes nothing.
+            // `.error` never reaches it, which is the failure path staying
+            // silent.
+            //
+            // Full Access is the guard at the top of this method: without it
+            // there is no App Group to read a transcript from and no haptics to
+            // play, and the drain returns before it gets here.
+            Haptics.dictationDelivered()
         }
 
         bridge.partial = d.partial
@@ -439,6 +464,10 @@ final class KeyboardViewController: UIInputViewController {
         case .finishing:
             bridge.listening = true
             bridge.reconnecting = false
+            // The transcript is one AI-polish round trip away from landing;
+            // warm the engine now so the pattern is not a beat late. Cheap to
+            // repeat on the drains that follow.
+            Haptics.prepareForDelivery()
         case .done:
             bridge.listening = false
             bridge.reconnecting = false
@@ -479,13 +508,22 @@ final class KeyboardViewController: UIInputViewController {
     // MARK: 注音 (called from SwiftUI)
 
     /// A bopomofo key.
-    func zhuyinSymbol(_ symbol: Character) { apply(zhuyin.symbol(symbol)) }
+    func zhuyinSymbol(_ symbol: Character) {
+        click()
+        apply(zhuyin.symbol(symbol))
+    }
 
     /// A tone key: finalize the syllable and show its candidates.
-    func zhuyinTone(_ tone: ZhuyinTone) { apply(zhuyin.tone(tone)) }
+    func zhuyinTone(_ tone: ZhuyinTone) {
+        click()
+        apply(zhuyin.tone(tone))
+    }
 
     /// The user picked a character out of the candidate bar.
-    func zhuyinPick(_ candidate: String) { apply(zhuyin.pick(candidate)) }
+    func zhuyinPick(_ candidate: String) {
+        click()
+        apply(zhuyin.pick(candidate))
+    }
 
     /// Do whatever the composer asked for, then republish what it is holding.
     ///
@@ -510,14 +548,29 @@ final class KeyboardViewController: UIInputViewController {
 
     // MARK: keys (called from SwiftUI)
 
+    /// The system keyboard click.
+    ///
+    /// Every key the user can press comes through this class, so the click is
+    /// played here rather than in the views — one call per key action, in the
+    /// same place the key's actual effect happens.
+    ///
+    /// It needs no Full Access and no setting of its own: `playInputClick` is
+    /// silent unless the user has Keyboard Clicks switched on in Settings, which
+    /// is exactly the preference a second toggle here would be duplicating.
+    private func click() { UIDevice.current.playInputClick() }
+
     /// Delete edits the 注音 buffer before it edits the document — the candidate
     /// bar first, then the syllable slot by slot — and only reaches the field
     /// once there is nothing pending. See `ZhuyinComposer.delete()`.
     func deleteBackward() {
+        click()
         apply(zhuyin.delete()) { textDocumentProxy.deleteBackward() }
     }
 
-    func insert(_ text: String) { textDocumentProxy.insertText(text) }
+    func insert(_ text: String) {
+        click()
+        textDocumentProxy.insertText(text)
+    }
 
     /// Return always types a line break. A keyboard extension cannot submit a
     /// form — there is no public way to fire the host's return action — so a
@@ -528,6 +581,7 @@ final class KeyboardViewController: UIInputViewController {
     /// keyboard does: the first return closes the composition, the next one
     /// breaks the line.
     func insertReturn() {
+        click()
         apply(zhuyin.confirm()) { textDocumentProxy.insertText("\n") }
     }
 
@@ -544,6 +598,7 @@ final class KeyboardViewController: UIInputViewController {
     /// On the 注音 pane space is the first tone and then the confirm key, so a
     /// pending syllable claims it first.
     func insertSpace() {
+        click()
         switch zhuyin.space() {
         case .handled:
             publishComposition()
@@ -572,6 +627,17 @@ final class KeyboardViewController: UIInputViewController {
         textDocumentProxy.insertText(" ")
         lastSpaceAt = now
     }
+}
+
+/// Opt this keyboard into the system key click.
+///
+/// `UIDevice.playInputClick()` does nothing unless the input view that is on
+/// screen says it wants clicks, which is what this protocol is for; the
+/// controller answers for its own input view. The user's Settings switch still
+/// has the last word, in both directions — that is the point of routing through
+/// UIKit rather than playing a sound of our own.
+extension KeyboardViewController: UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
 }
 
 /// One pane on the track. Dictation and typing are different enough — different
@@ -696,6 +762,21 @@ final class KeyboardBridge: ObservableObject {
         guard panes.indices.contains(target) else { return }
         setPane(panes[target])
     }
+
+    /// Where the mode key goes next, and what it is therefore captioned with.
+    ///
+    /// Wrapping, where the swipe clamps. The two are answering different
+    /// questions: a drag has a direction and an edge to bump into, while a key
+    /// that did nothing on the last pane would just be broken — which is also
+    /// how the system's `123`/`ABC` key behaves.
+    var nextPane: KeyboardPane {
+        guard !panes.isEmpty else { return pane }
+        return panes[(paneIndex + 1) % panes.count]
+    }
+
+    /// The mode key's tap. The long press picks a pane outright, through
+    /// `setPane`.
+    func advancePane() { setPane(nextPane) }
 
     var returnKeyLabel: LocalizedStringKey {
         switch returnKeyType {

--- a/ios/Keyboard/KeyboardZhuyinPane.swift
+++ b/ios/Keyboard/KeyboardZhuyinPane.swift
@@ -50,14 +50,22 @@ struct ZhuyinPane: View {
         }
     }
 
-    /// `123`, the globe where the system asks for one, space, delete, return.
+    /// The mode key, `123`, the globe where the system asks for one, space,
+    /// delete, return.
     ///
     /// Delete lives here rather than beside the symbols, because all 41 大千 keys
-    /// are spoken for — there is no shift row to borrow a corner from.
+    /// are spoken for — there is no shift row to borrow a corner from. The mode
+    /// key takes the bottom-left corner it has on every other pane, and the
+    /// width it costs comes out of the space bar: this row is already five keys
+    /// in the height of four, so nothing here can grow downwards.
     private func functionRow(_ m: KeyRowMetrics) -> some View {
         row {
+            ModeKey(
+                bridge: bridge, dark: dark, width: m.mode,
+                height: KBMetrics.zhuyinKeyHeight)
             KeyButton(
-                dark: dark, tint: .alt, width: m.wide, height: KBMetrics.zhuyinKeyHeight,
+                dark: dark, tint: .alt, shape: .pill, width: m.wide,
+                height: KBMetrics.zhuyinKeyHeight,
                 action: { symbols = true }
             ) {
                 Text(verbatim: "123").font(.system(size: 16, weight: .regular))
@@ -73,7 +81,7 @@ struct ZhuyinPane: View {
             // caption changes under the finger is harder to aim at than one
             // whose meaning follows the state.
             KeyButton(
-                dark: dark, width: nil, height: KBMetrics.zhuyinKeyHeight,
+                dark: dark, shape: .pill, width: nil, height: KBMetrics.zhuyinKeyHeight,
                 action: { bridge.space() }
             ) {
                 Text("Space").font(.system(size: 15))

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -464,6 +464,23 @@
         }
       }
     },
+    "Switch input mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch input mode"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切換輸入模式"
+          }
+        }
+      }
+    },
     "Tap to open the app": {
       "localizations": {
         "en": {


### PR DESCRIPTION
## What this changes

Three reported complaints about the iOS keyboard — switching is a fight, the 注音 pane is hard to reach, and the keys feel like flat rectangles — plus two haptics for dictation.

### 1. The swipe accepts a flick

`KeyboardRootView.swift`. `onEnded` only compared `value.translation.width` against the 56pt threshold and never read `value.predictedEndTranslation`, so a fast flick — which lifts off long before travelling 56pt — was discarded outright. You had to *drag* a sixth of the screen width, deliberately, to change pane. Either measure now commits, and the horizontality gate is judged on whichever one did.

### 2. A mode key, so switching is not a gesture

The only non-swipe affordance was the page dots: **5×5pt** against Apple's 44pt minimum. Every pane's bottom row now carries a mode key in the same corner — **tap advances, long press opens a menu of all three panes** (`Menu`'s `primaryAction` is the tap). It reuses the existing `setPane`/`stepPane`/`panes` bridge; no new state machine. The dots stay as a signpost, and the swipe stays as a secondary gesture.

It goes in the **existing** bottom row and takes its width from the space bar. All three panes are pinned to the same 213pt height and `zhuyinKeyHeight` is derived from the letters pane, so a new row would have cost height three times over and shrunk the 注音 caps.

### 3. Keys that answer the finger

| | before | after |
| --- | --- | --- |
| press | fill swap only | fill swap **+ `scaleEffect(0.97)`**, `easeOut 0.08s` down, `spring(response: 0.2, dampingFraction: 0.75)` up |
| radius | 5pt everything | **7pt** characters, **`Capsule()`** function keys |
| shadow (light) | `radius: 0, y: 1`, α.28 hard edge | `radius: 1, y: 1` α.10 + `radius: 3, y: 2` α.06 |
| shadow (dark) | **none — flat** | same geometry, α.50 |
| sound | none | `playInputClick()` |

Shadows are a port of `@pathors/ui`'s `--shadow-sm`, including its deliberately neutral blue-black shadow colour. SwiftUI has no shadow spread, so the CSS token's tight-plus-soft pair is approximated with two blurs.

**80ms/0.97 deliberately differs from the web token's `active:scale-[0.98]`/150ms**, and `KeyboardTheme.swift` says so: a key is pressed several times a second, and at typing speed a 150ms settle reads as lag rather than feedback.

### 4. Two haptics for dictation

A `.medium` impact when the microphone opens (on press-down, not release), and `UINotificationFeedbackGenerator`'s `.success` two-beat when the words land — deliberately different patterns so the second one does not read as a stray tap.

**Both fire from the keyboard process.** `drainDownlink`'s single `insertText` is the only place a transcript is ever delivered: `DictationView` is a hand-off screen with no transcript and no stop control, and `StartDictationIntent` is inserted by "whatever Parley keyboard is frontmost" as well. The coordinator's `.done` means *ready*, not *delivered*, and by then the app is usually backgrounded — where iOS drops haptics entirely. The coordinator's diff is a comment saying so, so nobody re-adds it.

Firing once per session is free: the branch already sits behind the `insertedCount` high-water mark, and `.error` never reaches it. The whole method is behind `guard hasFullAccess`, which is also why haptics can never be load-bearing — guideline 4.4.1 requires the keyboard to work fully without Full Access.

## Deliberate trade-offs

- **`@` leaves the voice pane on devices that still draw their own globe.** The mode key has to be in the same corner on every pane or it is not learnable, and that leaves three keys wanting two slots. `@` is a convenience here and a real key one pane away; the globe is 4.4.1's way out of the keyboard. Unaffected on iPhone X and later, where the system draws the globe itself.
- **The symbol planes got the mode key too**, so `123` is not a plane you must leave before you can change keyboard.
- **Function keys are pills, characters are not.** Pathors' signature is fully-round controls, but pills on character keys widen the gaps between them and raise the miss rate.

## How it was verified

- `swiftc -frontend -parse` clean on every changed file; `Localizable.xcstrings` validated as JSON, new key carries **both** `en` and `zh-Hant`.
- All `KeyCap`/`KeyButton` call sites audited by hand after `shape` was inserted into the memberwise init.

**It has not been compiled.** There is no Xcode on the machine this was written on (Command Line Tools only, no `xcodegen`), and `ci.yml` has `paths-ignore: ios/**`, so no CI job type-checks iOS on a PR either. The first real compile will be the `ios-v1.6` tag build. Worth a reviewer's eye specifically on: the controller-level `UIInputViewAudioFeedback` conformance, `Menu` presenting inside a keyboard extension, and the `simultaneousGesture` that gives the mode key its press state coexisting with `Menu`'s own recognizer.

## Not in this PR

Emitting characters on touch-down instead of touch-up, a magnified key-preview popup (an extension cannot draw above its own top edge), and the 注音 candidate-bar and punctuation work — all proposed separately.