### PR TITLE
[feature] the keyboard can throw a dictation away instead of having to finish it

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -60,6 +60,37 @@ hand-off, and the in-app dictation session are new.
    its high-water mark (`insertedCount`), so a keyboard killed mid-session and
    relaunched after the session ended still pastes exactly once. `error` inserts
    nothing at all.
+6. **Or ✕, and nothing at all.** The keyboard's ✕ writes the same
+   `stopRequested` with `cancelRequested` beside it. The app cuts the relay
+   instead of finishing it — no drain, no cloud polish — clears the transcript,
+   and marks the session `cancelled`, a third terminal state the keyboard never
+   inserts from. The microphone goes back to the window the user chose, exactly
+   as it does after ⏹, because nothing failed.
+
+#### Three ways a session ends
+
+`done` delivers, `error` explains, `cancelled` says nothing and leaves the
+field as it was. They are three states rather than two plus a special case,
+because the keyboard's rule for `done` is "insert what is here": an empty
+transcript from a session where nobody spoke and a transcript the user threw
+away have to be different events, or the rule needs an exception, and the
+exception is the bug.
+
+✕ is the only one of the three the user can reach on purpose, and it stays
+reachable through `finishing` — the polish round trip is up to six seconds
+during which the pane still reads as live. So ⏹ and ✕ can cross in flight. The
+app's side is safe because the polish result is dropped unless the session is
+still `finishing`; the keyboard's side is safe because it remembers the id it
+cancelled and refuses every later downlink for it. Both halves are needed: the
+app may answer slowly, or (killed) not at all.
+
+Why ✕ is not "⏹ and then delete": ⏹ *is* the delivery path. It drains the relay
+for one more utterance, folds in the partial, and spends a cloud request
+polishing text that is about to be thrown away — and then the user is holding
+⌫ through a paragraph they never wanted, on a pane whose delete key is a 44pt
+disc. The words are already visible above the record button while they are
+being spoken, so before this the pane let someone watch a mistake happen and
+do nothing about it.
 
 #### Why one insertion rather than a stream
 
@@ -88,7 +119,9 @@ processes never contend on a file:
 
 - `dictation-down.json` — app → keyboard: `{session, committed, partial, state}`.
 - `dictation-up.json` — keyboard → app: `{session, hostBundleID, stopRequested,
-  insertedCount}`.
+  cancelRequested?, insertedCount}`. `cancelRequested` is optional so an uplink
+  written by an older build still decodes — a mailbox that fails to decode
+  reads as "nothing there", which here would mean a stop the app never hears.
 - `dictation-window.json` — app → keyboard: `{length, openedAt, expiresAt,
   updatedAt}`, the microphone window and its heartbeat.
 - `dictation-window-control.json` — keyboard → app: `{closeRequestedAt}`, the
@@ -607,7 +640,7 @@ three ⌀44 translucent discs arranged around it:
 ```
         live transcript (74pt, three lines, bottom-aligned)
 
-                                              ⌫
+   ✕ (while listening)                        ⌫
    @                    ◉  record
                                               ⏎
 ```
@@ -616,7 +649,23 @@ three ⌀44 translucent discs arranged around it:
 edits a dictating user actually reaches for. `@` takes the bottom-left corner —
 low-frequency, and the corner the system's own globe occupies on the devices
 that ask us to draw one (in which case `@` moves up and the globe takes that
-corner). **The top-left is deliberately empty**: it is where the pane breathes.
+corner). **The top-left is empty except during a session**: it is where the
+pane breathes, and keeping it that way the rest of the time is what lets `✕`
+arrive without the deck reflowing. The two ways out of a dictation end up at
+the same height, one disc apart, and nothing else on the pane moves when `✕`
+appears or goes.
+
+On the devices that draw their own globe, `@` is in that slot and a session
+borrows it. That is the whole cost, and it is the right thing to spend: `@` is
+a shortcut for something nobody is doing in the middle of speaking. The globe
+below it is never touched — a keyboard you cannot switch away from is a
+keyboard you are trapped in.
+
+`✕` is drawn as an ordinary control disc, not in the recording red. The pane
+keeps its one colour on the record button, which is *already* red while a
+session runs; a second red disc beside it would compete with the control the
+user reaches for most, and would read as the more dangerous of the two rather
+than the smaller one.
 
 The pane used to be caps — a mic pill flanked by two 56pt caps over a
 full-width `return` — and that was the mistake. A cap's raised look says "there
@@ -631,7 +680,8 @@ like Parley rather than iOS: idle it carries Pathors' brand gradient (`#1469D4`
 outward, so "armed" is never something you have to read out of a gradient — and
 never needs a second element saying "Listening…" beside it. The other is the
 wordmark (`#1469D4` light, `#2DB6F3` dark). Nothing else on the pane carries a
-colour, including `⏎` when the host has asked for an action.
+colour, including `⏎` when the host has asked for an action and `✕` when a
+session is running.
 
 #### Four states, and only one of them is a microphone
 

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -418,7 +418,9 @@ final class DictationCoordinator: ObservableObject {
     }
 
     /// The uplink channel, listened to for the process's whole life:
-    ///   - stop: the keyboard's ⏹ for the running session.
+    ///   - stop: the keyboard's ⏹ for the running session, or its ✕ — the same
+    ///     request with `wantsCancel` set, which ends the session without
+    ///     delivering anything.
     ///   - start: a keyboard minted a new session while this process happens
     ///     to be awake (foreground, or lingering in the background right after
     ///     a session). Starting here means the user never leaves their app —
@@ -429,7 +431,15 @@ final class DictationCoordinator: ObservableObject {
             Task { @MainActor in
                 guard let self, let up = DictationChannel.readUplink() else { return }
                 if up.stopRequested {
-                    if self.active, up.session == self.session { await self.stop() }
+                    guard self.active, up.session == self.session else { return }
+                    // ✕ before ⏹: a cancel is written as both, so that an
+                    // uplink this app only half understands still ends the
+                    // session rather than leaving a microphone open.
+                    if up.wantsCancel {
+                        await self.cancel()
+                    } else {
+                        await self.stop()
+                    }
                 } else if !up.session.isEmpty, up.session != self.session {
                     // Only honor a start here if the mic can actually open.
                     // A background process cannot show the permission prompt —
@@ -537,6 +547,13 @@ final class DictationCoordinator: ObservableObject {
         guard eventLeg == leg else { return }
         switch event {
         case .segment(let seg):
+            // Same rule the two ending branches below already follow: a session
+            // that is over does not grow. It matters most for ✕ — a segment
+            // landing from a socket that is still dying would put the discarded
+            // words straight back into a `cancelled` downlink — and the drain
+            // after ⏹ is unaffected, because a session stays `active` until
+            // `finishUp` runs.
+            guard active else { return }
             if seg.id.hasSuffix("-tail") {
                 partial = seg.text
             } else if let i = runs.firstIndex(where: { $0.id == seg.id }) {
@@ -748,6 +765,55 @@ final class DictationCoordinator: ObservableObject {
             await relay.finish()  // drain: the relay flushes the last utterance
         }
         finishUp()  // which hands the microphone to the window, or closes it
+    }
+
+    /// The keyboard's ✕: end the session and throw away everything it heard.
+    ///
+    /// Deliberately not `stop()` with the transcript blanked afterwards. `stop`
+    /// is the *delivery* path — it drains the relay for the last utterance,
+    /// folds the partial in, and spends a cloud round trip polishing text that
+    /// is about to be inserted. None of that is work anyone wants done to words
+    /// they have just decided to throw away, and the drain in particular is a
+    /// network wait standing between the user's finger and a microphone going
+    /// quiet. So the relay is cut rather than finished, and the session ends
+    /// with `cancelled` — a terminal state the keyboard never inserts from.
+    ///
+    /// Not `fail()` either: nothing went wrong, so this keeps the microphone
+    /// window the user chose (`releaseMicrophone` decides) instead of closing
+    /// it the way an error does. The next tap is still served in place.
+    func cancel() async {
+        guard active else { return }
+        #if DEBUG
+            demoTask?.cancel()
+            demoTask = nil
+        #endif
+        // Same as `stop`: from here a closing socket is expected, and no redial
+        // already in flight should land.
+        finishRequested = true
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        capTimer?.cancel()
+        capTimer = nil
+        audio.discard()
+        reportsLevel.set(false)
+        micLevel = 0
+        let dying = relay
+        relay = nil
+        dying?.cancel()
+        // Cleared before publishing, so the file the keyboard reads never
+        // carries the discarded words at all — `cancelled` with a transcript
+        // still in it would be a downlink whose two halves disagree.
+        runs = []
+        committed = ""
+        partial = ""
+        errorMessage = nil
+        state = .cancelled
+        publish()
+        // In this order, and for the same reason `finishUp` uses it:
+        // `releaseMicrophone` declines to act while the session still looks
+        // live, and it is what arms either the window or the ~30 s linger.
+        active = false
+        Task { await releaseMicrophone() }
     }
 
     private func finishUp() {

--- a/ios/App/Parley/DictationView.swift
+++ b/ios/App/Parley/DictationView.swift
@@ -89,6 +89,9 @@ struct DictationView: View {
         switch coordinator.state {
         case .error: return "exclamationmark.triangle"
         case .finishing, .done: return "checkmark"
+        // The session ended with nothing delivered, which is what the user
+        // asked for — so the mark says "gone", not "went wrong".
+        case .cancelled: return "xmark"
         // Deliberately not the warning triangle: the microphone is still open
         // and the words are being kept. This is a pause, not a failure.
         case .reconnecting: return "arrow.triangle.2.circlepath"
@@ -116,6 +119,7 @@ struct DictationView: View {
         case .finishing: return String(localized: "Wrapping up…")
         case .done: return String(localized: "Done")
         case .error: return String(localized: "Couldn't start")
+        case .cancelled: return String(localized: "Discarded")
         // Handled above, before the swipe guidance.
         case .reconnecting: return String(localized: "Reconnecting…")
         }
@@ -137,6 +141,9 @@ struct DictationView: View {
                     "Keep talking — the microphone is still on and what you say is kept until the connection is back."
             )
         }
+        if coordinator.state == .cancelled {
+            return String(localized: "Nothing was typed. Tap the microphone again to start over.")
+        }
         if needsManualReturn {
             return String(
                 localized:
@@ -148,9 +155,10 @@ struct DictationView: View {
 
     // MARK: footer — only the swipe guide, hugging the home indicator
 
-    /// No stop control here on purpose: stopping (like everything else about
-    /// dictation) belongs to the keyboard's red ⏹. This screen never competes
-    /// with the keyboard for the session — its whole vocabulary is "go back".
+    /// No stop control here on purpose: ending a session — ⏹ to keep the words,
+    /// ✕ to throw them away — belongs to the keyboard, like everything else
+    /// about dictation. This screen never competes with the keyboard for the
+    /// session; its whole vocabulary is "go back".
     private var footer: some View {
         VStack(spacing: 14) {
             // Last element on the screen, right above the real home indicator,

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -868,6 +868,22 @@
         }
       }
     },
+    "Discarded": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discarded"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已捨棄"
+          }
+        }
+      }
+    },
     "Discovery call — Halcyon Labs": {
       "extractionState": "manual",
       "localizations": {
@@ -1744,6 +1760,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "還沒學到任何東西。"
+          }
+        }
+      }
+    },
+    "Nothing was typed. Tap the microphone again to start over.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing was typed. Tap the microphone again to start over."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有輸入任何文字。要重來就再按一次麥克風。"
           }
         }
       }

--- a/ios/Keyboard/Haptics.swift
+++ b/ios/Keyboard/Haptics.swift
@@ -34,9 +34,15 @@ enum Haptics {
     /// what UIKit requires of feedback generators.
     nonisolated(unsafe) private static let start = UIImpactFeedbackGenerator(style: .medium)
     nonisolated(unsafe) private static let finish = UINotificationFeedbackGenerator()
+    nonisolated(unsafe) private static let discard = UIImpactFeedbackGenerator(style: .rigid)
 
-    /// Warm the engine up before the press that will need it.
-    static func prepareForDictation() { start.prepare() }
+    /// Warm the engine up before the press that will need it. Both presses: the
+    /// ✕ appears the moment a session starts, so the beat that answers it has
+    /// the same claim on being ready as the one that opened the microphone.
+    static func prepareForDictation() {
+        start.prepare()
+        discard.prepare()
+    }
 
     /// The microphone is opening: one solid thump, on the press rather than on
     /// the release.
@@ -50,4 +56,14 @@ enum Haptics {
     /// never on the failure path: a session that ended in an error delivered
     /// nothing, and saying "done" with the body would be the wrong news.
     static func dictationDelivered() { finish.notificationOccurred(.success) }
+
+    /// The session was thrown away: one short, hard tick, on the press.
+    ///
+    /// A third pattern rather than a reuse of either of the other two, because
+    /// it is a third outcome. The success pattern would be celebrating a
+    /// delivery that did not happen; the system's `.warning` would say
+    /// something went wrong, and nothing did — the user asked for this. What is
+    /// left is the feel of the thing itself: shorter and harder than the thump
+    /// that opened the microphone, so the two ends of a session never blur.
+    static func dictationDiscarded() { discard.impactOccurred() }
 }

--- a/ios/Keyboard/KeyboardKeys.swift
+++ b/ios/Keyboard/KeyboardKeys.swift
@@ -83,9 +83,9 @@ struct ControlDisc: View {
 /// gives no feedback at all, which is what made the keys feel dead.
 struct PressableButton<Content: View>: View {
     let action: () -> Void
-    /// Fired as the finger lands, before `action`, for the one caller that
-    /// needs the press itself rather than the tap: the record button's haptic.
-    /// A confirmation that arrives on the release confirms nothing.
+    /// Fired as the finger lands, before `action`, for the callers that need
+    /// the press itself rather than the tap: the haptics on the record button
+    /// and on ✕. A confirmation that arrives on the release confirms nothing.
     var onPressDown: (() -> Void)?
     @ViewBuilder var content: (Bool) -> Content
 

--- a/ios/Keyboard/KeyboardRootView.swift
+++ b/ios/Keyboard/KeyboardRootView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 /// The Parley keyboard's face.
 ///
 /// N panes under one strip: the voice pane — a live-transcript slot, one round
-/// record button and the three controls a dictating user reaches for — followed
+/// record button, the three controls a dictating user reaches for and the ✕
+/// that only exists while a session does — followed
 /// by the typing keyboards the user has enabled, QWERTY and 注音. The panes sit
 /// side by side on a track that follows the finger, so a horizontal drag moves
 /// one pane either way and the strip's dots are a signpost rather than the only
@@ -270,17 +271,24 @@ struct KeyboardRootView: View {
     }
 
     /// The controls, arranged around the record button rather than in a row:
-    /// delete top-right, return under it, `@` bottom-left. Top-left is left
-    /// empty on purpose — it is where the pane breathes, and it is the slot the
-    /// globe takes on the devices that still need one.
+    /// delete top-right, return under it, `@` bottom-left, and — while a
+    /// session is live — ✕ top-left.
+    ///
+    /// Top-left is empty the rest of the time. It is where the pane breathes,
+    /// and keeping it that way is what lets ✕ arrive without the deck
+    /// reflowing: the two ways out of a dictation sit at the same height, one
+    /// disc apart, and nothing else on the pane moves when they appear.
+    ///
+    /// On the devices that draw their own globe the slot holds `@`, and a
+    /// session borrows it. That is the one thing this costs, and it is the
+    /// right thing to spend: `@` is a shortcut, and it is a shortcut for
+    /// something nobody is doing in the middle of speaking. The globe below it
+    /// is never touched — a keyboard that can't be switched away from is a
+    /// keyboard the user is trapped in.
     private var deck: some View {
         HStack(spacing: 0) {
             VStack(spacing: KBMetrics.deckRowGap) {
-                if bridge.showsGlobe {
-                    atKey
-                } else {
-                    Color.clear.frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
-                }
+                leftTopKey
                 if bridge.showsGlobe {
                     // Bottom-left, where the system's own globe sits, so the
                     // muscle memory carries over on the devices that show it.
@@ -290,6 +298,7 @@ struct KeyboardRootView: View {
                     atKey
                 }
             }
+            .animation(.easeInOut(duration: 0.16), value: bridge.listening)
             Spacer(minLength: 0)
             recordButton
             Spacer(minLength: 0)
@@ -301,6 +310,17 @@ struct KeyboardRootView: View {
         .frame(height: KBMetrics.deckHeight)
     }
 
+    @ViewBuilder
+    private var leftTopKey: some View {
+        if bridge.listening {
+            cancelKey.transition(.opacity)
+        } else if bridge.showsGlobe {
+            atKey
+        } else {
+            Color.clear.frame(width: KBMetrics.roundKey, height: KBMetrics.roundKey)
+        }
+    }
+
     // MARK: the round controls
 
     private var atKey: some View {
@@ -310,6 +330,38 @@ struct KeyboardRootView: View {
             }
         }
         .accessibilityLabel(Text("At sign"))
+    }
+
+    /// ✕ — end the session and throw away what was said.
+    ///
+    /// It exists because ⏹ is not a way out. ⏹ means *deliver*: a sentence
+    /// nobody wanted still had to be transcribed into the field and then
+    /// deleted by hand, which on this pane means holding ⌫ through a paragraph.
+    /// The words are visible above the button while they are being spoken, so
+    /// until now the pane let the user watch a mistake happen and do nothing
+    /// about it.
+    ///
+    /// Drawn as an ordinary control disc rather than in the recording red. The
+    /// pane keeps its one colour on the record button — which is already red
+    /// while a session runs — and a second red thing beside it would compete
+    /// with the control the user actually reaches for most. It only exists
+    /// while there is a session to throw away, which is most of what it has to
+    /// say about itself.
+    private var cancelKey: some View {
+        PressableButton(action: { bridge.cancel() }, onPressDown: discardHaptic) { pressed in
+            disc(pressed: pressed) {
+                Image(systemName: "xmark").font(.system(size: 17, weight: .semibold))
+            }
+        }
+        .accessibilityLabel(Text("Discard dictation"))
+    }
+
+    /// The counterpart to `startHaptic`, and deliberately a different beat —
+    /// see `Haptics.dictationDiscarded`. On the press, like the start: the
+    /// press is where the decision is.
+    private func discardHaptic() {
+        guard bridge.hasFullAccess else { return }
+        Haptics.dictationDiscarded()
     }
 
     private var deleteKey: some View {

--- a/ios/Keyboard/KeyboardViewController.swift
+++ b/ios/Keyboard/KeyboardViewController.swift
@@ -30,6 +30,16 @@ final class KeyboardViewController: UIInputViewController {
     /// session is a leftover from a previous dictation and is ignored.
     private var session = ""
     private var insertedCount = 0
+    /// A session the user threw away with ✕.
+    ///
+    /// The app answers a cancel by publishing `cancelled`, which inserts
+    /// nothing — but the two can cross in flight: ✕ is reachable through
+    /// `finishing`, which is where the transcript spends its polish round trip,
+    /// and a `done` published a beat before the tap would otherwise be drained
+    /// and pasted afterwards. Remembering the id makes that impossible here
+    /// rather than merely unlikely, and it survives the app answering slowly or
+    /// not at all.
+    private var cancelledSession = ""
     /// Learns the user's words from the edits they make right after dictating.
     /// Everything it does lives in `KeyboardLexiconWatch`; this class only tells
     /// it when the text landed and when the editing is over.
@@ -345,9 +355,40 @@ final class KeyboardViewController: UIInputViewController {
         var up = DictationChannel.readUplink() ?? .init(session: session)
         up.session = session
         up.stopRequested = true
+        up.cancelRequested = false
         up.insertedCount = insertedCount
         DictationChannel.writeUplink(up)
         bridge.listening = false
+    }
+
+    /// Ask the app to end the session and throw the words away — the ✕ next to
+    /// ⏹.
+    ///
+    /// The pane goes quiet under the finger rather than a round trip later. The
+    /// app has to be told (it is the one holding the microphone and the socket)
+    /// but nothing here waits for it to answer: the only thing its reply could
+    /// add is a transcript, and a transcript is exactly what the user just said
+    /// they did not want. So the echo is cleared now, and `cancelledSession`
+    /// makes sure no late downlink for this session can put it back.
+    func cancelDictation() {
+        guard !session.isEmpty else { return }
+        cancelledSession = session
+        var up = DictationChannel.readUplink() ?? .init(session: session)
+        up.session = session
+        // Both flags: `stopRequested` is what makes this read as "end the
+        // session" to the whole existing path, and `cancelRequested` is the
+        // only thing that says how.
+        up.stopRequested = true
+        up.cancelRequested = true
+        up.insertedCount = insertedCount
+        DictationChannel.writeUplink(up)
+        bridge.listening = false
+        bridge.reconnecting = false
+        bridge.partial = ""
+        bridge.tail = ""
+        // Not an error, so nothing is left on screen saying otherwise — the
+        // slot goes back to the idle invitation to speak.
+        bridge.errorText = nil
     }
 
     /// How old a downlink may be and still get adopted by a keyboard that
@@ -381,6 +422,12 @@ final class KeyboardViewController: UIInputViewController {
     private func drainDownlink() {
         guard hasFullAccess, let d = DictationChannel.readDownlink() else { return }
 
+        // A session the user threw away is finished here, whatever the app goes
+        // on to publish for it. `cancelDictation` already cleared the pane, so
+        // there is nothing left to read out of this file — and the one thing it
+        // could still carry is a transcript that must never reach the document.
+        if d.session == cancelledSession { return }
+
         // Adopt a session this process didn't mint. iOS kills the keyboard
         // almost every time the user bounces to the app, so on the way back the
         // downlink belongs to a session the (relaunched) keyboard has never
@@ -394,6 +441,11 @@ final class KeyboardViewController: UIInputViewController {
         // keyboard that just minted a new session (its uplink carries the new
         // id) can never resurrect the previous transcript. Errors are never
         // adopted; the message belongs on the app's screen, not in a field.
+        // A cancelled one *is* adopted, and safely: what makes `error` special
+        // is its message, not its finality, and `cancelled` carries neither a
+        // message nor anything to insert. Adopting it is how a keyboard that
+        // was killed between the ✕ and the app's answer comes back to an idle
+        // pane instead of a session it thinks is still running.
         if d.session != session {
             guard d.state != .error,
                 let at = d.updatedAt,
@@ -473,6 +525,18 @@ final class KeyboardViewController: UIInputViewController {
             lexicon.noteInserted(context: textDocumentProxy.documentContextBeforeInput)
             // The tail stays: the last thing said is worth still being able to
             // read once the button has gone quiet.
+        case .cancelled:
+            // The app confirming a ✕. For the keyboard that pressed it this is
+            // never reached — that process cleared the pane on the spot and
+            // returns at the top, on `cancelledSession`. This branch belongs to
+            // the one that did *not*: killed between the tap and the answer,
+            // relaunched, and reading the ending out of the file. It says the
+            // same nothing.
+            bridge.listening = false
+            bridge.reconnecting = false
+            bridge.partial = ""
+            bridge.tail = ""
+            bridge.errorText = nil
         case .error:
             bridge.listening = false
             bridge.reconnecting = false
@@ -771,6 +835,8 @@ final class KeyboardBridge: ObservableObject {
     /// and find the app.
     func endWindow() { controller?.endMicWindow() }
     func stop() { controller?.stopDictation() }
+    /// End the session and throw the words away — the ✕ beside ⏹.
+    func cancel() { controller?.cancelDictation() }
     func backspace() { controller?.deleteBackward() }
     func type(_ text: String) { controller?.insert(text) }
     func space() { controller?.insertSpace() }

--- a/ios/Keyboard/Localizable.xcstrings
+++ b/ios/Keyboard/Localizable.xcstrings
@@ -118,6 +118,23 @@
         }
       }
     },
+    "Discard dictation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard dictation"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捨棄這次語音輸入"
+          }
+        }
+      }
+    },
     "Done": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
+++ b/ios/ParleyKit/Sources/ParleyKit/DictationChannel.swift
@@ -8,7 +8,8 @@ import Foundation
 /// Five single-writer mailboxes, each with its own Darwin notification, so the
 /// two processes never contend on the same file:
 ///   - `downlink` (app → keyboard): the growing transcript + session state.
-///   - `uplink`   (keyboard → app): the session request, host bundle id, stop.
+///   - `uplink`   (keyboard → app): the session request, host bundle id, and
+///     how it should end — ⏹ (deliver) or ✕ (throw away).
 ///   - `window`   (app → keyboard): the microphone window — whether the next
 ///     tap will be served where the user is, or has to open Parley.
 ///   - `window control` (keyboard → app): end the window now.
@@ -33,9 +34,10 @@ public enum DictationChannel {
 
     /// app → keyboard: the transcript grew or the state changed.
     public static let downNote = "com.pathors.parley.dictation.down"
-    /// keyboard → app: stop was requested (the app is running during dictation,
-    /// so a Darwin note reaches it; starting instead goes through the URL so it
-    /// can launch a suspended app).
+    /// keyboard → app: the session should end — ⏹ to deliver the transcript,
+    /// ✕ to throw it away (the app is running during dictation, so a Darwin
+    /// note reaches it; starting instead goes through the URL so it can launch
+    /// a suspended app).
     public static let upNote = "com.pathors.parley.dictation.up"
     /// app → keyboard: the microphone window opened, closed, or ticked. Its own
     /// note rather than `downNote` because the window outlives sessions — most
@@ -84,13 +86,27 @@ public enum DictationChannel {
         /// worth inserting after a relaunch (see `KeyboardViewController`).
         public var updatedAt: Date?
 
-        public enum State: String, Codable, Sendable {
+        /// `CaseIterable` so the wire-format test iterates the states rather
+        /// than listing them: a state that decodes to something the other
+        /// process does not expect is silent, and a test that has to be
+        /// remembered is exactly the one that will not be.
+        public enum State: String, Codable, Sendable, CaseIterable {
             case starting, listening, finishing, done, error
             /// The relay socket dropped and the app is redialling it. The
             /// microphone is still open and the audio is being held, so this
             /// is a pause in the words arriving — deliberately not `error`,
             /// which is where the session actually ends.
             case reconnecting
+            /// The user pressed ✕: the session ended and the words were thrown
+            /// away on purpose.
+            ///
+            /// A third terminal state rather than a flavour of `done` with an
+            /// empty transcript, because the keyboard's rule for `done` is
+            /// "insert what is here" and a rule that says "…unless it happens
+            /// to be empty" would make an empty result and a discarded one the
+            /// same event. It is not `error` either: nothing failed, and the
+            /// pane must not show red copy for something the user asked for.
+            case cancelled
         }
 
         public init(
@@ -127,6 +143,16 @@ public enum DictationChannel {
         /// the pre-iOS-26.4 auto-return. `nil` when it could not be resolved.
         public var hostBundleID: String?
         public var stopRequested: Bool
+        /// The stop is a ✕ rather than a ⏹: end the session and throw the
+        /// transcript away. Always written together with `stopRequested`, so
+        /// the request still reads as "end this" to anything that only knows
+        /// about ⏹ — this field only says *how* it should end.
+        ///
+        /// Optional so an uplink written by an older build still decodes: a
+        /// synthesized `init(from:)` requires every non-optional key, and a
+        /// mailbox that fails to decode reads as "nothing there", which here
+        /// would mean a stop request the app never hears.
+        public var cancelRequested: Bool?
         /// How much of `committed` the keyboard has already inserted. Persisted
         /// here so a keyboard that was killed mid-session does not double-insert
         /// when it relaunches.
@@ -134,13 +160,17 @@ public enum DictationChannel {
 
         public init(
             session: String, hostBundleID: String? = nil,
-            stopRequested: Bool = false, insertedCount: Int = 0
+            stopRequested: Bool = false, cancelRequested: Bool? = nil, insertedCount: Int = 0
         ) {
             self.session = session
             self.hostBundleID = hostBundleID
             self.stopRequested = stopRequested
+            self.cancelRequested = cancelRequested
             self.insertedCount = insertedCount
         }
+
+        /// The keyboard asked for this session to be thrown away.
+        public var wantsCancel: Bool { cancelRequested == true }
     }
 
     public static func writeUplink(_ value: Uplink) {

--- a/ios/ParleyKit/Tests/ParleyKitTests/DictationChannelTests.swift
+++ b/ios/ParleyKit/Tests/ParleyKitTests/DictationChannelTests.swift
@@ -46,10 +46,7 @@ final class DictationChannelTests: XCTestCase {
     // MARK: session mailboxes
 
     func testDownlinkRoundTripsEveryState() throws {
-        for state in [
-            DictationChannel.Downlink.State.starting, .listening, .reconnecting, .finishing,
-            .done, .error,
-        ] {
+        for state in DictationChannel.Downlink.State.allCases {
             let back = try roundTrip(
                 DictationChannel.Downlink(
                     session: "s", committed: "hello ", partial: "world", state: state))
@@ -57,6 +54,16 @@ final class DictationChannelTests: XCTestCase {
             XCTAssertEqual(back.committed, "hello ")
             XCTAssertEqual(back.partial, "world")
         }
+    }
+
+    func testCancelledIsItsOwnEnding() throws {
+        // The keyboard inserts on `done` and only on `done`. If a discarded
+        // session ever encoded as anything the other side reads as `done`, the
+        // words the user threw away would land in their document — so this is
+        // the one state whose raw value is worth pinning down.
+        XCTAssertEqual(DictationChannel.Downlink.State.cancelled.rawValue, "cancelled")
+        XCTAssertNotEqual(DictationChannel.Downlink.State.cancelled, .done)
+        XCTAssertNotEqual(DictationChannel.Downlink.State.cancelled, .error)
     }
 
     func testUplinkCarriesTheInsertionHighWaterMark() throws {
@@ -67,6 +74,29 @@ final class DictationChannelTests: XCTestCase {
         XCTAssertEqual(back.insertedCount, 42)
         XCTAssertEqual(back.hostBundleID, "com.example.app")
         XCTAssertTrue(back.stopRequested)
+        XCTAssertFalse(back.wantsCancel)
+    }
+
+    func testUplinkCarriesTheCancelAlongsideTheStop() throws {
+        // ✕ is written as both flags: `stopRequested` is what makes it read as
+        // "end this session" to the whole existing path, and `cancelRequested`
+        // is the only thing that says the transcript is to be thrown away.
+        let back = try roundTrip(
+            DictationChannel.Uplink(session: "s", stopRequested: true, cancelRequested: true))
+        XCTAssertTrue(back.stopRequested)
+        XCTAssertTrue(back.wantsCancel)
+    }
+
+    func testUplinkFromAnOlderBuildStillDecodes() throws {
+        // `cancelRequested` is optional for this reason and no other. A
+        // mailbox that fails to decode reads as "nothing there", and the file
+        // this parses is how the app hears ⏹ at all — an uplink left behind by
+        // the build before this one must not silently swallow a stop.
+        let json = Data(#"{"session":"s","stopRequested":true,"insertedCount":7}"#.utf8)
+        let value = try JSONDecoder().decode(DictationChannel.Uplink.self, from: json)
+        XCTAssertTrue(value.stopRequested)
+        XCTAssertFalse(value.wantsCancel)
+        XCTAssertEqual(value.insertedCount, 7)
     }
 
     // MARK: URLs


### PR DESCRIPTION
## What this changes

The voice keyboard gets a **✕ beside ⏹**, shown only while a dictation is
running. It ends the session and throws the transcript away: nothing is
inserted, the host's field is left exactly as it was, and the microphone goes
back to the window the user chose.

```
        live transcript (74pt, three lines, bottom-aligned)

   ✕ (while listening)                        ⌫
   @                    ◉  record
                                              ⏎
```

## Why

Closes #325.

⏹ is not a way out — it means *deliver*. A false start, a wrong word, someone
interrupting: the sentence still had to be transcribed into the document
before it could be deleted by hand, which on this pane means holding ⌫ through
a paragraph. The keyboard already shows the words live above the record
button, so until now the pane let the user watch a mistake happen and do
nothing about it. It also spent what it did not need to: a session nobody
wanted still paid for the relay drain and a cloud polish request.

## How it works

`✕` writes the existing `stopRequested` with a new `cancelRequested` beside
it. The app cuts the relay instead of finishing it — no drain, no polish —
clears the transcript, and publishes `cancelled`, a third terminal
`Downlink.State`.

Three endings rather than two plus a special case: `done` delivers, `error`
explains, `cancelled` says nothing. The keyboard's rule for `done` is "insert
what is here", so a session where nobody spoke and a session the user threw
away have to be different events — otherwise the rule needs an exception, and
the exception is the bug.

**`cancel()` is not `stop()` with the text blanked afterwards.** `stop` is the
delivery path: it drains the relay for one more utterance, folds the partial
in, and spends up to six seconds polishing text that is about to be discarded
— with the drain standing as a network wait between the user's finger and the
microphone going quiet. It is not `fail()` either: nothing went wrong, so the
microphone window survives and the next tap is still served in place, instead
of an error's "microphone visibly off".

### The race, closed on both sides

✕ stays reachable through `finishing` (the polish round trip), which is where
`done` gets published — so the two can cross in flight. Both halves are needed
because the app may answer slowly, or, killed, not at all:

- **App:** a polish result is already dropped unless the session is still
  `finishing`, and a cancelled one is `cancelled`.
- **Keyboard:** `cancelledSession` remembers the id and refuses every later
  downlink for it, so a `done` published a beat before the tap can never be
  drained and pasted afterwards.

While in here, relay segments now also stop rebuilding the transcript once a
session is no longer `active` — the same rule the two ending branches beside
them already followed. Without it a segment from a socket that is still dying
could put the discarded words straight back into a `cancelled` downlink.

### Wire compatibility

`cancelRequested` is `Bool?` on purpose: a synthesized `init(from:)` requires
every non-optional key, and a mailbox that fails to decode reads as "nothing
there" — which for the uplink would mean a stop the app never hears. An uplink
left behind by the previous build has to keep working. There is a test for
exactly that.

### Placement

Top-left was the slot the pane deliberately kept empty ("where the pane
breathes"), which is what lets ✕ arrive without the deck reflowing: the two
ways out of a dictation end up at the same height, one disc apart, and nothing
else moves. On devices that draw their own globe, `@` is in that slot and a
session borrows it — `@` is a shortcut for something nobody is doing in the
middle of speaking. The globe below is never touched.

Drawn as an ordinary control disc, not in the recording red: the pane keeps
its one colour on the record button, which is *already* red during a session,
and a second red disc would read as the more dangerous of the two rather than
the smaller one. It gets a third haptic — `.rigid`, on the press — because it
is a third outcome; the success pattern would celebrate a delivery that did
not happen, and `.warning` would say something went wrong when nothing did.

## How it was verified

The desktop checklist below does not apply — this is `ios/` only, which `ci.yml`
excludes from CI, and **this machine has no Xcode** (Command Line Tools only,
no simulator runtimes), so the app and keyboard targets could not be compiled
or run here. Stating that plainly rather than ticking boxes:

- [x] `ParleyKit` builds (`swift build`) — the shared `DictationChannel` change
- [x] Wire-format assertions actually executed, against the built `ParleyKit`,
      via a scratch executable (XCTest itself needs Xcode): every
      `Downlink.State` round trips including `cancelled`; `cancelled` is
      distinct from `done`/`error`; a ✕ uplink carries both flags; a ⏹ uplink
      reads as not-a-cancel; **an uplink written without `cancelRequested`
      still decodes**. All pass. The same assertions are committed as XCTest
      cases in `DictationChannelTests`
- [x] `swiftc -frontend -parse` clean on all eight changed Swift files
- [x] New strings added to **both** `en` and `zh-Hant`
      (`Keyboard/Localizable.xcstrings`, `App/Parley/Localizable.xcstrings`)
- [x] `docs/design/ios-voice-keyboard.md` updated: the third ending, the deck
      diagram, the uplink mailbox
- [ ] **Not done here:** `xcodebuild` / simulator run / device run. The two
      exhaustive `switch`es over `Downlink.State` (`DictationView.statusTitle`,
      `KeyboardViewController.drainDownlink`) both got their new case, so the
      compiler should be satisfied, but that is reasoning rather than a build.
      Someone with Xcode should build once and try ✕ mid-sentence before this
      ships in a TestFlight build.

## Screenshots

None — see above; the keyboard could not be run on this machine. The layout
change is one disc appearing in the previously-empty top-left slot, drawn with
the existing `ControlDisc` at the existing `KBMetrics.roundKey` size.
