### PR TITLE
[feature] a finished recording proposes its own name and folder

### DIFF
--- a/src/components/study/FilingSuggestionCard.tsx
+++ b/src/components/study/FilingSuggestionCard.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Plus, Sparkles, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useStore } from "../../lib/store";
+import { useI18n } from "../../i18n";
+import { log } from "../../lib/log";
+import { createLocalFolder, emitFoldersUpdated } from "../../lib/history/folders";
+import { personalDestination } from "../../lib/library/destination";
+import { useRefile } from "../useRefile";
+import type { FilingSuggestion, FilingFolderSuggestion } from "../../lib/types";
+
+/**
+ * The one-click home for the post-transcription filing suggestion: what this
+ * recording should be CALLED and where it should LIVE.
+ *
+ * Both doors into a finished recording name it badly. A live meeting is saved as
+ * "即時會議 · <date>" and an upload keeps whatever the file was called, so the
+ * library fills up with rows nobody can tell apart. Filing is worse: the ingest
+ * wizard asks which folder to use BEFORE transcription, at the one moment when
+ * nobody — not the user, not the model — yet knows what the meeting was about.
+ * So the good answer can only be produced afterwards, and it has to be offered
+ * somewhere the user is already looking. That is the report page, directly above
+ * the filing bar that shows the folder this would change.
+ *
+ * It is a SUGGESTION, not a control: soft accent, one button per row, and a
+ * dismiss. Nothing here happens on its own.
+ *
+ * Acceptance state is DERIVED, never stored. Each row compares the suggestion
+ * against live state and hides itself when it has nothing left to offer — the
+ * title row when the recording is already called that, a folder chip when the
+ * recording is already filed there. An "applied" flag would only be a second
+ * copy of that same fact, free to drift: renaming from the titlebar, or filing
+ * from the bar below, would leave a stale row claiming there is still something
+ * to accept. Deriving it means every route to the same outcome retires the row.
+ * Once BOTH rows are empty the suggestion has been fully spent, so it is cleared
+ * from the store and persisted as null — it must not come back on the next load,
+ * and must not be regenerated.
+ */
+export function FilingSuggestionCard() {
+  const { t } = useI18n();
+  const suggestion = useStore((s) => s.filingSuggestion);
+  const setFilingSuggestion = useStore((s) => s.setFilingSuggestion);
+  const loadedHistoryId = useStore((s) => s.loadedHistoryId);
+  // Same derivation as StudyLinkBar: a read-only org recording can't be written
+  // back, and a session with no saved entry has nothing to rename or re-file.
+  const readOnly = useStore((s) => s.replayReadOnly) || !loadedHistoryId;
+  const replayName = useStore((s) => s.replay?.name ?? "");
+  const renameReplay = useStore((s) => s.renameReplay);
+  const folderId = useStore((s) => s.replayFolderId);
+  const refile = useRefile();
+
+  const suggestedTitle = suggestion?.title.trim() ?? "";
+  // Nothing to offer once the recording already carries the suggested name —
+  // however it got there (this card, or the titlebar's rename).
+  const showTitle = suggestedTitle !== "" && suggestedTitle !== replayName.trim();
+
+  // Drop the chip pointing at the folder the recording is ALREADY in. A
+  // new-folder chip carries folderId === null, which is also the "personal root"
+  // id, so it is compared out explicitly rather than by equality — an unfiled
+  // recording is exactly the case a new folder is being proposed for.
+  const chips = useMemo(
+    () => (suggestion?.folders ?? []).filter((f) => f.folderId === null || f.folderId !== folderId),
+    [suggestion, folderId]
+  );
+
+  const spent = !!suggestion && !showTitle && chips.length === 0;
+
+  // Resolve a fully-spent suggestion for good. Keyed on the suggestion object so
+  // it fires once per suggestion: `spent` stays true until the store clears, and
+  // a later recording gets its own object and its own chance to resolve.
+  const resolvedRef = useRef<FilingSuggestion | null>(null);
+  useEffect(() => {
+    if (!spent || !suggestion || resolvedRef.current === suggestion) return;
+    resolvedRef.current = suggestion;
+    setFilingSuggestion(null);
+    void import("../../lib/history/history")
+      .then((m) => m.persistFilingSuggestion())
+      .catch((e) => log.warn("filing: clearing a spent suggestion failed", { error: String(e) }));
+  }, [spent, suggestion, setFilingSuggestion]);
+
+  const dismiss = useCallback(() => {
+    setFilingSuggestion(null);
+    void import("../../lib/history/history")
+      .then((m) => m.persistFilingSuggestion())
+      .catch((e) => log.warn("filing: persisting a dismissal failed", { error: String(e) }));
+  }, [setFilingSuggestion]);
+
+  // The titlebar's rename path, reused verbatim — one write, one failure toast.
+  // Deliberately does NOT dismiss: the title row retires itself once the name
+  // matches, and the folder chips are still worth a click.
+  const applyTitle = useCallback(async () => {
+    const clean = suggestedTitle;
+    if (!clean || clean === replayName.trim() || !loadedHistoryId) return;
+    try {
+      const { renameHistoryEntry } = await import("../../lib/history/history");
+      await renameHistoryEntry(loadedHistoryId, clean);
+      renameReplay(clean);
+      toast.success(t("study.filing.titleApplied"));
+    } catch (e) {
+      log.error("filing: rename failed", { id: loadedHistoryId, error: String(e) });
+      toast.error(
+        t("replay.renameFailed", { error: e instanceof Error ? e.message : String(e) })
+      );
+    }
+  }, [suggestedTitle, replayName, loadedHistoryId, renameReplay, t]);
+
+  // Filing shows up in the bar immediately below, so the card has said all it
+  // has to say — retire it rather than leave a redundant copy on screen.
+  //
+  // The store clears at once (the card must not linger for a disk round-trip),
+  // but the PERSIST waits for the move to land: both writes are read-modify-write
+  // over the same meta.json, so running them concurrently lets whichever finishes
+  // last overwrite the other from a stale read — losing the folder the user just
+  // picked, visibly only after a reload. Hence sequencing rather than `dismiss()`.
+  const applyFolder = useCallback(
+    (chip: FilingFolderSuggestion) => {
+      let id = chip.folderId;
+      if (id === null) {
+        id = createLocalFolder(chip.name).id;
+        emitFoldersUpdated().catch((e) =>
+          log.warn("filing: folder broadcast failed", { error: String(e) })
+        );
+      }
+      setFilingSuggestion(null);
+      void refile(personalDestination(id), null)
+        .then(() => import("../../lib/history/history"))
+        .then((m) => m.persistFilingSuggestion())
+        .catch((e) => log.warn("filing: persisting after a move failed", { error: String(e) }));
+    },
+    [refile, setFilingSuggestion]
+  );
+
+  if (!suggestion || readOnly) return null;
+  if (!showTitle && chips.length === 0) return null;
+
+  return (
+    <div className="mb-3 rounded-lg border border-violet-500/30 bg-violet-500/5 px-3 py-2">
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-4 shrink-0 text-violet-600 dark:text-violet-400" />
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-violet-700 dark:text-violet-300">
+          {t("study.filing.heading")}
+        </span>
+        <button
+          type="button"
+          aria-label={t("study.filing.dismiss")}
+          title={t("study.filing.dismiss")}
+          onClick={dismiss}
+          className="grid size-6 shrink-0 cursor-pointer place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      {showTitle && (
+        <div className="mt-2 flex items-center gap-2">
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {t("study.filing.titleLabel")}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-sm font-medium" title={suggestedTitle}>
+            {suggestedTitle}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 shrink-0 text-xs"
+            onClick={() => void applyTitle()}
+          >
+            {t("study.filing.apply")}
+          </Button>
+        </div>
+      )}
+
+      {chips.length > 0 && (
+        <div className="mt-2 flex items-start gap-2">
+          <span className="shrink-0 pt-1 text-xs text-muted-foreground">
+            {t("study.filing.folderLabel")}
+          </span>
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+            {chips.map((chip) => {
+              const isNew = chip.folderId === null;
+              return (
+                <button
+                  key={chip.folderId ?? `new:${chip.name}`}
+                  type="button"
+                  title={chip.reason || undefined}
+                  onClick={() => applyFolder(chip)}
+                  className={`flex max-w-full cursor-pointer items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors hover:bg-muted ${
+                    isNew ? "border-dashed text-muted-foreground" : "bg-background"
+                  }`}
+                >
+                  {isNew && <Plus className="size-3 shrink-0" />}
+                  <span className="truncate">
+                    {isNew ? t("study.filing.newFolder", { name: chip.name }) : chip.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/study/FilingSuggestionCard.tsx
+++ b/src/components/study/FilingSuggestionCard.tsx
@@ -89,20 +89,24 @@ export function FilingSuggestionCard() {
   // The titlebar's rename path, reused verbatim — one write, one failure toast.
   // Deliberately does NOT dismiss: the title row retires itself once the name
   // matches, and the folder chips are still worth a click.
-  const applyTitle = useCallback(async () => {
+  const applyTitle = useCallback(() => {
     const clean = suggestedTitle;
     if (!clean || clean === replayName.trim() || !loadedHistoryId) return;
-    try {
+    const rename = async () => {
       const { renameHistoryEntry } = await import("../../lib/history/history");
       await renameHistoryEntry(loadedHistoryId, clean);
       renameReplay(clean);
       toast.success(t("study.filing.titleApplied"));
-    } catch (e) {
+    };
+    // Kept synchronous so the handler can be passed to onClick directly: an
+    // `async` callback would have to be discarded at the call site, and the
+    // rejection is already handled here.
+    rename().catch((e) => {
       log.error("filing: rename failed", { id: loadedHistoryId, error: String(e) });
       toast.error(
         t("replay.renameFailed", { error: e instanceof Error ? e.message : String(e) })
       );
-    }
+    });
   }, [suggestedTitle, replayName, loadedHistoryId, renameReplay, t]);
 
   // Filing shows up in the bar immediately below, so the card has said all it
@@ -164,7 +168,7 @@ export function FilingSuggestionCard() {
             size="sm"
             variant="outline"
             className="h-7 shrink-0 text-xs"
-            onClick={() => void applyTitle()}
+            onClick={applyTitle}
           >
             {t("study.filing.apply")}
           </Button>

--- a/src/components/study/StudyScreen.tsx
+++ b/src/components/study/StudyScreen.tsx
@@ -10,6 +10,7 @@ import { DeliveryPanel } from "../delivery/DeliveryPanel";
 import { ActionItemsPanel } from "../replay/ActionItemsPanel";
 import { AskPanel } from "../sidebar/AskPanel";
 import { StudyLinkBar } from "./StudyLinkBar";
+import { FilingSuggestionCard } from "./FilingSuggestionCard";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
@@ -91,6 +92,7 @@ function ReportPage() {
     <div className="relative min-h-0 flex-1">
       <ScrollArea className="h-full">
         <div ref={scrollRef} className="mx-auto max-w-2xl px-6 py-5">
+          <FilingSuggestionCard />
           <StudyLinkBar />
           <div className="flex flex-col gap-8 pb-10">
             <ReportSection id="study-brief" title={t("study.brief")}>

--- a/src/components/useRefile.ts
+++ b/src/components/useRefile.ts
@@ -16,8 +16,19 @@ import type { LibraryDestination, OrgHandoffMode } from "../lib/library/destinat
  * the org copy is in. After a move there is no local entry left, so the replay
  * session drops its history pointer — the transcript on screen stays readable,
  * but a later re-analysis has nothing local to overwrite.
+ *
+ * It RESOLVES when the move has landed on disk, so a caller that also writes to
+ * the same entry can sequence behind it. Both `setEntryFolder` and the study
+ * persists are read-modify-write over one meta.json; started concurrently, the
+ * later write reads a pre-move copy and silently drops the folder change (the
+ * store already shows the new folder, so it only surfaces on the next load).
+ * Callers with no follow-up write can ignore the promise — failures are logged
+ * and toasted here either way.
  */
-export function useRefile(): (destination: LibraryDestination, mode: OrgHandoffMode | null) => void {
+export function useRefile(): (
+  destination: LibraryDestination,
+  mode: OrgHandoffMode | null
+) => Promise<void> {
   const { t } = useI18n();
   const loadedHistoryId = useStore((s) => s.loadedHistoryId);
   const setLoadedHistoryId = useStore((s) => s.setLoadedHistoryId);
@@ -25,15 +36,14 @@ export function useRefile(): (destination: LibraryDestination, mode: OrgHandoffM
   return useCallback(
     (destination: LibraryDestination, mode: OrgHandoffMode | null) => {
       const id = loadedHistoryId;
-      if (!id) return;
+      if (!id) return Promise.resolve();
       if (destination.scope === "personal") {
-        setEntryFolder(id, destination.folderId).catch((e) =>
+        return setEntryFolder(id, destination.folderId).catch((e) =>
           log.warn("refile: folder change failed", { id, error: String(e) })
         );
-        return;
       }
       const { orgId, folderId } = destination;
-      import("../lib/cloud/sync")
+      return import("../lib/cloud/sync")
         .then(async ({ moveRecordingToOrg, shareRecordingToOrg }) => {
           if (mode === "move") {
             await moveRecordingToOrg(id, orgId, folderId);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -112,6 +112,15 @@ export const zhTW = {
   "study.link.menu": "更多動作",
   "study.link.context": "會議背景",
 
+  // ── 轉錄完成後的命名與歸檔建議 ──
+  "study.filing.heading": "轉錄完成，建議這樣命名與歸檔",
+  "study.filing.titleLabel": "標題",
+  "study.filing.apply": "採用",
+  "study.filing.titleApplied": "已改名",
+  "study.filing.folderLabel": "歸到",
+  "study.filing.newFolder": "新增「{name}」",
+  "study.filing.dismiss": "不用了",
+
   // ── 會議類型：決定這場錄音用哪一套分析 ──
   "meetingKind.internal": "內部會議",
   "meetingKind.sales": "銷售通話",
@@ -1078,6 +1087,15 @@ export const en = {
   "study.link.change": "Change",
   "study.link.menu": "More actions",
   "study.link.context": "Meeting context",
+
+  // ── Post-transcription naming and filing suggestion ──
+  "study.filing.heading": "Suggested name and folder",
+  "study.filing.titleLabel": "Name",
+  "study.filing.apply": "Use it",
+  "study.filing.titleApplied": "Renamed",
+  "study.filing.folderLabel": "File under",
+  "study.filing.newFolder": "New folder “{name}”",
+  "study.filing.dismiss": "Dismiss",
 
   // ── Meeting kind: which analysis this recording gets ──
   "meetingKind.internal": "Internal meeting",

--- a/src/lib/ai/filing.test.ts
+++ b/src/lib/ai/filing.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { resolveFilingFolders } from "./filing";
+
+const folders = [
+  { id: "f-acme", name: "Acme Corp" },
+  { id: "f-hiring", name: "Hiring" },
+  { id: "f-board", name: "Board" },
+  { id: "f-ops", name: "Ops" },
+];
+
+/** Shorthand for one raw pick off the model. */
+const pick = (name: string, isNew = false, reason = "fits") => ({ name, isNew, reason });
+
+describe("resolveFilingFolders", () => {
+  it("matches an existing folder by exact name", () => {
+    expect(resolveFilingFolders([pick("Acme Corp")], folders)).toEqual([
+      { folderId: "f-acme", name: "Acme Corp", reason: "fits" },
+    ]);
+  });
+
+  it("matches case- and whitespace-insensitively, keeping the registry's spelling", () => {
+    expect(resolveFilingFolders([pick("  acme CORP ")], folders)).toEqual([
+      { folderId: "f-acme", name: "Acme Corp", reason: "fits" },
+    ]);
+  });
+
+  it("treats a name matching nothing as a new folder", () => {
+    expect(resolveFilingFolders([pick("Globex")], folders)).toEqual([
+      { folderId: null, name: "Globex", reason: "fits" },
+    ]);
+  });
+
+  it("resolves to the existing folder even when the model claims it is new", () => {
+    expect(resolveFilingFolders([pick("Hiring", true)], folders)).toEqual([
+      { folderId: "f-hiring", name: "Hiring", reason: "fits" },
+    ]);
+  });
+
+  it("keeps only the first new-folder suggestion", () => {
+    const out = resolveFilingFolders(
+      [pick("Globex", true), pick("Initech", true), pick("Acme Corp")],
+      folders
+    );
+    expect(out).toEqual([
+      { folderId: null, name: "Globex", reason: "fits" },
+      { folderId: "f-acme", name: "Acme Corp", reason: "fits" },
+    ]);
+  });
+
+  it("collapses duplicate folder ids to one entry", () => {
+    const out = resolveFilingFolders(
+      [pick("Acme Corp", false, "customer"), pick("acme corp", true, "same again"), pick("Ops")],
+      folders
+    );
+    expect(out).toEqual([
+      { folderId: "f-acme", name: "Acme Corp", reason: "customer" },
+      { folderId: "f-ops", name: "Ops", reason: "fits" },
+    ]);
+  });
+
+  it("caps at three entries, preserving the model's order", () => {
+    const out = resolveFilingFolders(
+      [pick("Acme Corp"), pick("Hiring"), pick("Board"), pick("Ops")],
+      folders
+    );
+    expect(out.map((f) => f.folderId)).toEqual(["f-acme", "f-hiring", "f-board"]);
+  });
+
+  it("drops empty and whitespace-only names", () => {
+    const out = resolveFilingFolders([pick(""), pick("   "), pick("Board")], folders);
+    expect(out).toEqual([{ folderId: "f-board", name: "Board", reason: "fits" }]);
+  });
+
+  it("trims the reason and allows an empty one", () => {
+    expect(resolveFilingFolders([pick("Board", false, "  ongoing governance  ")], folders)).toEqual([
+      { folderId: "f-board", name: "Board", reason: "ongoing governance" },
+    ]);
+    expect(resolveFilingFolders([pick("Board", false, "   ")], folders)).toEqual([
+      { folderId: "f-board", name: "Board", reason: "" },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(resolveFilingFolders([], folders)).toEqual([]);
+    expect(resolveFilingFolders([], [])).toEqual([]);
+  });
+});

--- a/src/lib/ai/filing.ts
+++ b/src/lib/ai/filing.ts
@@ -59,6 +59,23 @@ FOLDERS
 - reason is ONE short clause saying why the folder fits — it is shown as a tooltip, not read as prose.`;
 
 /**
+ * Index the folder registry by trimmed, lowercased name. Models re-type folder
+ * names rather than copying them, and "Acme Corp" vs "acme corp " is the model
+ * being sloppy about spelling, not the user wanting a second folder. First
+ * occurrence wins, so two folders sharing a name resolve to the older one.
+ */
+function indexByName(
+  folders: readonly { id: string; name: string }[]
+): Map<string, { id: string; name: string }> {
+  const byName = new Map<string, { id: string; name: string }>();
+  for (const folder of folders) {
+    const key = folder.name.trim().toLowerCase();
+    if (key && !byName.has(key)) byName.set(key, folder);
+  }
+  return byName;
+}
+
+/**
  * Turn the model's raw folder picks into the suggestions the UI can act on.
  *
  * Exported and pure because this is where the product's rules actually live:
@@ -70,15 +87,7 @@ export function resolveFilingFolders(
   raw: readonly { name: string; isNew: boolean; reason: string }[],
   folders: readonly { id: string; name: string }[]
 ): FilingFolderSuggestion[] {
-  // Match on the trimmed, lowercased name: models re-type folder names rather
-  // than copying them, and "Acme Corp" vs "acme corp " is the model being
-  // sloppy about spelling, not the user wanting a second folder.
-  const byName = new Map<string, { id: string; name: string }>();
-  for (const folder of folders) {
-    const key = folder.name.trim().toLowerCase();
-    if (key && !byName.has(key)) byName.set(key, folder);
-  }
-
+  const byName = indexByName(folders);
   const out: FilingFolderSuggestion[] = [];
   const seenIds = new Set<string>();
   let newTaken = false;
@@ -131,7 +140,8 @@ function folderMenu(folders: readonly { id: string; name: string }[]): string {
       "return exactly ONE folder, with isNew: true.\n\n"
     );
   }
-  return `The user's existing folders:\n${names.map((n) => `- ${n}`).join("\n")}\n\n`;
+  const list = names.map((n) => `- ${n}`).join("\n");
+  return `The user's existing folders:\n${list}\n\n`;
 }
 
 /**

--- a/src/lib/ai/filing.ts
+++ b/src/lib/ai/filing.ts
@@ -1,0 +1,187 @@
+import { z } from "zod";
+import { JSON_MODE_INSTRUCTION } from "./provider";
+import { streamObjectResilient } from "./generate";
+import { transcriptWithTimestamps } from "../store";
+import { recordLlmUsage } from "../usage/log";
+import { profileContext, outputLanguageInstruction } from "./profile";
+import { log } from "../log";
+import type {
+  FilingFolderSuggestion,
+  FilingSuggestion,
+  MeetingKind,
+  Settings,
+  TranscriptSegment,
+} from "../types";
+
+// No .min()/.max() on the array: the JSON-mode providers we wire (Groq and the
+// other openai-compatible ones) choke on count constraints, and a rejected
+// schema costs us the whole pass. The 1-3 count is asked for in the prompt and
+// ENFORCED in resolveFilingFolders, which has to survive a disobedient model
+// anyway (cf. timeline.ts / actionItems.ts, which take the same line).
+const schema = z.object({
+  title: z
+    .string()
+    .describe(
+      "The proposed display title for this recording — what it was about and, where clear, with whom. " +
+        "Return the current title unchanged if it is already good."
+    ),
+  folders: z
+    .array(
+      z.object({
+        name: z
+          .string()
+          .describe(
+            "The folder name. Copy an existing folder's name EXACTLY when you mean that folder."
+          ),
+        isNew: z
+          .boolean()
+          .describe("true only when this folder does not exist yet and must be created."),
+        reason: z.string().describe("One short clause saying why this folder fits."),
+      })
+    )
+    .describe("2-3 candidate folders for this recording, best first."),
+});
+
+const SYSTEM = `Given a finished meeting transcript, decide what the recording should be CALLED and where it should be FILED. Both doors into a recording name it badly — a live meeting arrives as "即時會議 · <date>" and an upload arrives as its file name — so this is usually the first honest title the recording gets.
+
+TITLE
+- Say what the meeting was ABOUT and, where it is clear, WITH WHOM: a company or a person plus the topic or the decision reached.
+- No date and no time. The library card already shows those, so spending the title on them wastes the only line the user reads.
+- No filler as the subject: "meeting", "recording", "call", "討論" and the like describe every recording in the library and therefore identify none of them. A title that would fit any meeting is a failed title.
+- Keep it short — roughly 10-24 characters of CJK, or about 4-8 English words.
+- If the current title is already specific and accurate, return it UNCHANGED. Churn for its own sake makes the library harder to trust, not easier.
+
+FOLDERS
+- The user's existing folders are listed below. Strongly prefer them. One folder is typically one customer/company or one ongoing workstream, so ask which of those this conversation belongs to.
+- Return 2-3 candidates ordered best-first. If only one is genuinely defensible, return one — a padded list is worse than a short one.
+- Copy an existing folder's name EXACTLY (character for character) when you mean that folder, and set isNew to false.
+- AT MOST ONE candidate may be a folder that does not exist yet (isNew: true), and only when no existing folder honestly fits. A new folder per meeting would grow the registry faster than the user can prune it.
+- reason is ONE short clause saying why the folder fits — it is shown as a tooltip, not read as prose.`;
+
+/**
+ * Turn the model's raw folder picks into the suggestions the UI can act on.
+ *
+ * Exported and pure because this is where the product's rules actually live:
+ * the model is asked for the same constraints in the prompt, but a filing
+ * suggestion that quietly creates three folders (or five) is worse than no
+ * suggestion at all, so nothing here trusts the model to have complied.
+ */
+export function resolveFilingFolders(
+  raw: readonly { name: string; isNew: boolean; reason: string }[],
+  folders: readonly { id: string; name: string }[]
+): FilingFolderSuggestion[] {
+  // Match on the trimmed, lowercased name: models re-type folder names rather
+  // than copying them, and "Acme Corp" vs "acme corp " is the model being
+  // sloppy about spelling, not the user wanting a second folder.
+  const byName = new Map<string, { id: string; name: string }>();
+  for (const folder of folders) {
+    const key = folder.name.trim().toLowerCase();
+    if (key && !byName.has(key)) byName.set(key, folder);
+  }
+
+  const out: FilingFolderSuggestion[] = [];
+  const seenIds = new Set<string>();
+  let newTaken = false;
+
+  for (const entry of raw) {
+    // Cap at 3. The model returns best-first, so truncating the tail drops its
+    // weakest picks; the UI has room for three chips.
+    if (out.length >= 3) break;
+
+    const name = entry.name?.trim() ?? "";
+    // A blank name names no folder. Half-streamed and hallucinated rows both
+    // land here, and there is nothing to file into either way.
+    if (!name) continue;
+
+    const reason = entry.reason?.trim() ?? "";
+    const match = byName.get(name.toLowerCase());
+
+    if (match) {
+      // isNew is deliberately ignored when a real folder matches: the model
+      // claiming "new" about a folder that already exists is a model error, not
+      // the user asking for a duplicate. Filing into the existing one is always
+      // what was meant.
+      if (seenIds.has(match.id)) continue; // one entry per folder — repeats are noise
+      seenIds.add(match.id);
+      // The registry's spelling wins, so the chip reads exactly like the folder
+      // the user already knows.
+      out.push({ folderId: match.id, name: match.name, reason });
+      continue;
+    }
+
+    // Unmatched → a folder that would have to be created. Only the FIRST one
+    // survives: a new folder per meeting would explode the registry, and the
+    // model orders best-first, so the first is the one worth offering. (This
+    // also subsumes de-duping new suggestions by name — a second one is dropped
+    // whether or not it repeats the first.)
+    if (newTaken) continue;
+    newTaken = true;
+    out.push({ folderId: null, name, reason });
+  }
+
+  return out;
+}
+
+/** Render the folder registry as the model's menu of existing homes. */
+function folderMenu(folders: readonly { id: string; name: string }[]): string {
+  const names = folders.map((f) => f.name.trim()).filter(Boolean);
+  if (names.length === 0) {
+    return (
+      "The user has NO folders yet, so every suggestion would have to be created — " +
+      "return exactly ONE folder, with isNew: true.\n\n"
+    );
+  }
+  return `The user's existing folders:\n${names.map((n) => `- ${n}`).join("\n")}\n\n`;
+}
+
+/**
+ * Propose a better title and 2-3 filing folders for a finished recording.
+ * Rides the cheap realtime lane for the same reason meetingKind does — it is
+ * one short label off an already-transcribed conversation, not an analysis.
+ *
+ * Returns null when there is nothing to read or the pass fails; the caller keeps
+ * the recording's current title and leaves it unfiled rather than guessing.
+ */
+export async function suggestFiling(opts: {
+  settings: Settings;
+  segments: TranscriptSegment[];
+  names?: Record<string, string>;
+  meetingContext?: string;
+  meetingKind?: MeetingKind | null;
+  /** The personal folder registry, as the model's menu of existing homes. */
+  folders: readonly { id: string; name: string }[];
+  /** What the recording is called right now, so the model can decline to change it. */
+  currentTitle: string;
+}): Promise<FilingSuggestion | null> {
+  const { settings, segments, names, meetingContext, meetingKind, folders, currentTitle } = opts;
+  const transcript = transcriptWithTimestamps(segments, names);
+  if (!transcript.trim()) return null;
+
+  const ctx =
+    profileContext(settings) +
+    (meetingContext?.trim() ? `Meeting context: ${meetingContext.trim()}\n\n` : "") +
+    (meetingKind ? `Meeting kind: ${meetingKind}\n\n` : "") +
+    `The recording is currently called: ${currentTitle.trim() || "(untitled)"}\n\n` +
+    folderMenu(folders);
+
+  try {
+    const { object, usage } = await streamObjectResilient({
+      settings,
+      workload: "realtime",
+      schema,
+      // The title and each reason are shown in the library, so they follow the
+      // UI language rather than the transcript's.
+      system: SYSTEM + JSON_MODE_INSTRUCTION + outputLanguageInstruction(settings),
+      prompt: `${ctx}Transcript:\n${transcript}`,
+    });
+    void recordLlmUsage(settings, "realtime", "eval", usage);
+
+    const title = typeof object.title === "string" ? object.title.trim() : "";
+    const resolved = resolveFilingFolders(object.folders ?? [], folders);
+    log.info("ai.filing: suggested", { title, folders: resolved.length });
+    return { title, folders: resolved };
+  } catch (e) {
+    log.warn("ai.filing: failed", { error: String(e) });
+    return null;
+  }
+}

--- a/src/lib/analysis/filingRun.ts
+++ b/src/lib/analysis/filingRun.ts
@@ -1,0 +1,59 @@
+import { useStore, isTrimmed, hasSpokenSegment, meetingBriefText } from "../store";
+import { hasProviderKey } from "../ai/settings";
+import { suggestFiling } from "../ai/filing";
+import { listLocalFolders } from "../history/folders";
+import { makeRunGuard } from "./runGuard";
+import { log } from "../log";
+
+/**
+ * Propose a better title for the loaded recording plus the folders it could be
+ * filed under, into the store and onto the loaded entry. The ONE entry point for
+ * both the study pipeline (which dispatches it as soon as there is a transcript
+ * — it depends on nothing upstream) and the card's manual regenerate (`force`
+ * re-runs over a done/error state; the pipeline never forces). A run that
+ * outlives its session or is superseded by a newer pass stops writing (runGuard).
+ *
+ * Unlike the report artifacts this rides the cheap REALTIME lane, so a user who
+ * only configured that provider still gets the suggestion.
+ */
+const guard = makeRunGuard();
+export async function runFilingSuggestion(opts?: { force?: boolean }): Promise<void> {
+  const state = useStore.getState();
+  if (state.filingStatus === "running") return;
+  if (!opts?.force && state.filingStatus !== "idle") return;
+  if (!hasProviderKey(state.settings, "realtime")) return;
+  // A read-only org recording can be neither renamed nor refiled, so a suggestion
+  // for it would be pure spend on something the user cannot act on.
+  if (state.replayReadOnly) return;
+  // Honor the trim keep-window, same as the analysis + brief passes.
+  const segments = state.segments.filter((s) => !isTrimmed(s, state.replayTrim));
+  if (!hasSpokenSegment(segments)) return;
+
+  const alive = guard.begin();
+  state.setFilingStatus("running");
+  try {
+    const suggestion = await suggestFiling({
+      settings: state.settings,
+      segments,
+      names: state.speakerNames,
+      meetingContext: meetingBriefText(state),
+      meetingKind: state.meetingKind,
+      folders: listLocalFolders().map((f) => ({ id: f.id, name: f.name })),
+      currentTitle: state.replay?.name ?? "",
+    });
+    if (!alive()) return;
+    // A null suggestion (the model had nothing better to propose) is still a
+    // COMPLETED run: record it as done and persist, so this recording never pays
+    // for the pass a second time. See HistoryEntry.filingSuggested.
+    useStore.getState().setFilingSuggestion(suggestion);
+    useStore.getState().setFilingStatus("done");
+    void import("../history/history").then((m) =>
+      m.persistFilingSuggestion().catch((e) =>
+        log.warn("filing: persist failed", { error: String(e) })
+      )
+    );
+  } catch (e) {
+    log.error("filing: suggestion failed", { error: String(e) });
+    if (alive()) useStore.getState().setFilingStatus("error");
+  }
+}

--- a/src/lib/analysis/studyPipeline.test.ts
+++ b/src/lib/analysis/studyPipeline.test.ts
@@ -6,16 +6,22 @@ import {
   type StudyPipelineFacts,
 } from "./studyPipeline";
 
+/** A ready deep-lane session. The realtime key is OFF by default so the
+ *  artifact-topology cases below stay about the four report artifacts; the
+ *  filing cases opt in with `hasRealtimeKey: true`. */
 function facts(patch: Partial<StudyPipelineFacts> = {}): StudyPipelineFacts {
   return {
     inReplay: true,
     wizardOpen: false,
     hasDeepKey: true,
+    hasRealtimeKey: false,
+    readOnly: false,
     hasTranscript: true,
     analysisStatus: "idle",
     actionItemsStatus: "idle",
     briefStatus: "idle",
     deliveryStatus: "idle",
+    filingStatus: "idle",
     autoAnalyze: true,
     ...patch,
   };
@@ -74,6 +80,43 @@ describe("evaluateStages (the scheduler's whole topology)", () => {
     expect(
       evaluateStages({ ...ready, autoAnalyze: false, analysisStatus: "done" })
     ).toEqual([]);
+  });
+});
+
+describe("evaluateStages: the filing pass (a stage, not a report artifact)", () => {
+  const filing = (patch: Partial<StudyPipelineFacts> = {}) =>
+    facts({ hasRealtimeKey: true, ...patch });
+
+  it("goes out in the SAME tick as findings — it waits on nothing upstream", () => {
+    const out = evaluateStages(filing());
+    expect(out).toContain("filing");
+    expect(out).toContain("findings");
+    // Not "after findings finish": the suggestion must land with the transcript.
+    expect(evaluateStages(filing({ analysisStatus: "running" }))).toEqual(["filing"]);
+  });
+
+  it("runs on a realtime-only key, where the four report artifacts cannot", () => {
+    const out = evaluateStages(filing({ hasDeepKey: false }));
+    expect(out).toEqual(["filing"]);
+    // ...and the deep lane alone still gets the artifacts but no suggestion.
+    expect(evaluateStages(facts({ hasRealtimeKey: false }))).toEqual(["findings"]);
+  });
+
+  it("declines on a READ-ONLY recording — nothing there to rename or refile", () => {
+    expect(evaluateStages(filing({ readOnly: true }))).toEqual(["findings"]);
+  });
+
+  it("runs once: any status but idle means it already ran or is running", () => {
+    for (const filingStatus of ["running", "done", "error"] as const) {
+      expect(evaluateStages(filing({ filingStatus }))).toEqual(["findings"]);
+    }
+  });
+
+  it("still defers to the wizard and to auto-analysis being off", () => {
+    expect(evaluateStages(filing({ wizardOpen: true }))).toEqual([]);
+    expect(evaluateStages(filing({ autoAnalyze: false }))).toEqual([]);
+    expect(evaluateStages(filing({ hasTranscript: false }))).toEqual([]);
+    expect(evaluateStages(filing({ inReplay: false }))).toEqual([]);
   });
 });
 
@@ -145,4 +188,14 @@ describe("deriveStudyPipeline (what the chip + sections say)", () => {
     expect(p.hasTranscript).toBe(true);
   });
 
+  it("the chip still counts FOUR artifacts — filing is a stage, not one of them", () => {
+    const p = deriveStudyPipeline(facts({ hasRealtimeKey: true, filingStatus: "running" }));
+    expect(p.total).toBe(4);
+    expect(p.artifacts.map((a) => a.key)).toEqual([
+      "findings",
+      "actions",
+      "brief",
+      "delivery",
+    ]);
+  });
 });

--- a/src/lib/analysis/studyPipeline.ts
+++ b/src/lib/analysis/studyPipeline.ts
@@ -5,6 +5,7 @@
 //
 //   findings ──done──▶ action items ──settled──▶ brief
 //        └────done──▶ delivery
+//   filing   (no upstream — the transcript alone is its input)
 //
 // Scheduling is a plain store subscription (initStudyPipeline, mounted once in
 // App — the same pattern as initHistoryPersistSync), not a React hook: the
@@ -28,12 +29,25 @@ import { runAnalysis } from "./engine";
 import { runActionItems } from "./actionItems";
 import { runBriefGeneration } from "./briefRun";
 import { runDeliveryAnalysis } from "./deliveryRun";
+import { runFilingSuggestion } from "./filingRun";
 import { persistStudyOutputs, saveUploadToHistory } from "../history/history";
 import { log } from "../log";
 
 type StoreState = ReturnType<typeof useStore.getState>;
 
 export type StudyArtifactKey = "findings" | "actions" | "brief" | "delivery";
+
+/**
+ * Everything the SCHEDULER dispatches — the four report artifacts plus the
+ * stages that aren't ones. A stage is a model pass this module starts; an
+ * artifact is a piece of the report the titlebar chip counts. Filing is the
+ * first stage that is one but not the other: it proposes a title and a folder,
+ * which is a prompt to the user rather than a section of the report, so it must
+ * not move the chip's "3 of 4 ready". Keeping the two key types distinct means
+ * the distinction is checked by the compiler instead of by a filter someone has
+ * to remember to write.
+ */
+export type StudyStageKey = StudyArtifactKey | "filing";
 
 export type StudyArtifactDisplay = "idle" | "queued" | "running" | "done" | "error";
 
@@ -45,12 +59,19 @@ export interface StudyPipelineFacts {
    *  while it's open so no pass spends on an unconfirmed transcript. */
   wizardOpen: boolean;
   hasDeepKey: boolean;
+  /** The cheap lane. Only the filing pass rides it, which is why it can run for a
+   *  user who has no deep-lane key at all. */
+  hasRealtimeKey: boolean;
+  /** A read-only org recording can be neither renamed nor refiled — nothing for
+   *  the filing pass to act on. */
+  readOnly: boolean;
   /** Spoken content inside the keep-window — same predicate the runners guard on. */
   hasTranscript: boolean;
   analysisStatus: AsyncTaskStatus;
   actionItemsStatus: AsyncTaskStatus;
   briefStatus: AsyncTaskStatus;
   deliveryStatus: AsyncTaskStatus;
+  filingStatus: AsyncTaskStatus;
   /** May the pipeline spend on its own? `settings.autoStudyAnalysis` OR a manual
    *  regenerate pinned to THIS recording — folded into one fact here so the
    *  scheduler and the display derivation can't disagree, and so evaluateStages
@@ -67,11 +88,14 @@ export function factsOf(s: StoreState): StudyPipelineFacts {
     inReplay: s.appMode === "study" && s.replay != null,
     wizardOpen: s.ingestWizardOpen,
     hasDeepKey: hasProviderKey(s.settings, "deep"),
+    hasRealtimeKey: hasProviderKey(s.settings, "realtime"),
+    readOnly: s.replayReadOnly,
     hasTranscript: hasSpokenSegment(s.segments, trim),
     analysisStatus: s.analysisStatus,
     actionItemsStatus: s.actionItemsStatus,
     briefStatus: s.briefStatus,
     deliveryStatus: s.deliveryStatus,
+    filingStatus: s.filingStatus,
     autoAnalyze:
       s.settings.autoStudyAnalysis ||
       (replayId != null && s.studyManualForId === replayId),
@@ -83,14 +107,25 @@ function settled(status: AsyncTaskStatus): boolean {
 }
 
 /** Which stages should START now — the whole topology, in one place. */
-export function evaluateStages(f: StudyPipelineFacts): StudyArtifactKey[] {
-  if (!f.inReplay || !f.hasDeepKey || !f.hasTranscript) return [];
+export function evaluateStages(f: StudyPipelineFacts): StudyStageKey[] {
+  // Being in replay, having a transcript, the wizard being shut and auto-analysis
+  // being allowed gate EVERY stage. The deep-lane key does not: it only gates the
+  // four report artifacts, since filing rides the cheap realtime lane.
+  if (!f.inReplay || !f.hasTranscript) return [];
   if (f.wizardOpen) return [];
   // Auto-analysis off and no manual request for this recording: leave it
   // unanalyzed so an external AI can write the analysis back over MCP.
   if (!f.autoAnalyze) return [];
 
-  const out: StudyArtifactKey[] = [];
+  const out: StudyStageKey[] = [];
+  // Filing has NO upstream dependency — it reads the transcript alone, so it
+  // goes out in the same tick as the findings pass rather than queueing behind
+  // the expensive one. That IS the point: the suggested title and folder should
+  // land the moment the transcript does, while the user is still looking at the
+  // recording. It is also the one stage a realtime-only user ever gets.
+  if (!f.readOnly && f.hasRealtimeKey && f.filingStatus === "idle") out.push("filing");
+
+  if (!f.hasDeepKey) return out;
   const analysisDone = f.analysisStatus === "done";
   if (f.analysisStatus === "idle") out.push("findings");
   if (analysisDone && f.actionItemsStatus === "idle") out.push("actions");
@@ -107,7 +142,7 @@ export function evaluateStages(f: StudyPipelineFacts): StudyArtifactKey[] {
 let forceNextFindings = false;
 
 /** How each stage runs. A keyed table, so dispatch is data — not a switch. */
-const RUNNERS: Record<StudyArtifactKey, () => Promise<unknown> | void> = {
+const RUNNERS: Record<StudyStageKey, () => Promise<unknown> | void> = {
   findings: () => {
     const force = forceNextFindings;
     forceNextFindings = false;
@@ -116,6 +151,7 @@ const RUNNERS: Record<StudyArtifactKey, () => Promise<unknown> | void> = {
   actions: () => runActionItems(),
   brief: () => runBriefGeneration(),
   delivery: () => runDeliveryAnalysis(),
+  filing: () => runFilingSuggestion(),
 };
 
 const STATUS_FIELD = {
@@ -123,7 +159,8 @@ const STATUS_FIELD = {
   actions: "actionItemsStatus",
   brief: "briefStatus",
   delivery: "deliveryStatus",
-} as const satisfies Record<StudyArtifactKey, keyof StoreState>;
+  filing: "filingStatus",
+} as const satisfies Record<StudyStageKey, keyof StoreState>;
 
 /**
  * Manual regeneration = invalidation: reset the artifact's status to "idle"
@@ -135,7 +172,7 @@ const STATUS_FIELD = {
  * still works when auto-analysis is off (otherwise the reset to "idle" would
  * just sit there — the scheduler would never dispatch it).
  */
-export function regenerateArtifact(key: StudyArtifactKey): void {
+export function regenerateArtifact(key: StudyStageKey): void {
   const s = useStore.getState();
   if (s[STATUS_FIELD[key]] === "running") return;
   if (key === "findings") forceNextFindings = true;
@@ -184,6 +221,7 @@ const WATCHED = [
   "actionItemsStatus",
   "briefStatus",
   "deliveryStatus",
+  "filingStatus",
   "loadedHistoryId",
   "replayReadOnly",
   "studyManualForId",

--- a/src/lib/history/history.ts
+++ b/src/lib/history/history.ts
@@ -102,6 +102,12 @@ function snapshotAnalysis() {
     speechRateHz: s.replay?.speechRateHz ?? null,
     // Study outputs ride along so a plain save/overwrite never drops them.
     brief: s.brief,
+    // Same for the filing suggestion: the upload's FIRST save happens while the
+    // pass may already have landed, and a re-analysis overwrite must not drop a
+    // suggestion the user hasn't answered yet. The completion flag comes from the
+    // status for the same reason `analyzed` does — see HistoryEntry.filingSuggested.
+    filingSuggestion: s.filingSuggestion,
+    filingSuggested: s.filingStatus === "done",
     // The kind SHAPED those outputs, so it is part of them.
     meetingKind: s.meetingKind,
   };
@@ -535,6 +541,45 @@ export async function persistStudyOutputs(): Promise<void> {
   });
   pushToCloud(id);
   log.info("history: study outputs saved", { id, brief: !!updated.brief });
+}
+
+/**
+ * Persist the loaded entry's FILING SUGGESTION — the proposed title + folders,
+ * or its absence once the user has answered it.
+ *
+ * Deliberately NOT folded into {@link persistStudyOutputs}: that function writes
+ * `store ?? disk ?? null` so one output finishing can't clobber another that is
+ * still generating, and under that rule a null can only ever mean "I have
+ * nothing to say", never "write null". A dismissal is exactly the second thing,
+ * so the filing fields get their own writer — the one place that copies them
+ * from the store authoritatively.
+ *
+ * No-op for a read-only org recording (nothing to rename or refile, so it never
+ * had a suggestion) and for a not-yet-saved upload (there is no entry yet; its
+ * first save carries the fields via snapshotAnalysis).
+ */
+export async function persistFilingSuggestion(): Promise<void> {
+  const s = useStore.getState();
+  const id = s.loadedHistoryId;
+  if (!isTauri() || s.replayReadOnly || !id) return;
+  // An upload's initial save may still be compressing — wait so the entry exists.
+  await Promise.resolve(uploadSaveInFlight).catch(() => {});
+  const { meta } = await invoke<HistoryReadResult>("read_history_entry", { id });
+  const updated: HistoryEntry = {
+    ...meta,
+    filingSuggestion: s.filingSuggestion,
+    // The pass ran, whatever it produced — so reopening never pays for it twice.
+    filingSuggested: true,
+  };
+  await invoke("save_history_entry", {
+    id,
+    summaryJson: JSON.stringify(buildSummary(updated)),
+    metaJson: JSON.stringify(updated),
+    audioSourcePath: null, // leave the recording untouched
+    compress: false,
+  });
+  pushToCloud(id);
+  log.info("history: filing suggestion saved", { id, pending: !!updated.filingSuggestion });
 }
 
 // ── List / read / delete ─────────────────────────────────────────────────────

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -8,6 +8,7 @@
 import type {
   ActionItem,
   DeliveryAssessment,
+  FilingSuggestion,
   MeetingKind,
   TimelineEvent,
   TranscriptSegment,
@@ -65,6 +66,16 @@ export interface HistoryEntry {
    *  the outputs it shaped. Absent on entries predating the field (and on ones
    *  whose detection failed) → read as the decision lens. */
   meetingKind?: MeetingKind | null;
+  /** The filing suggestion still waiting on the user — a better title plus the
+   *  folders this recording could move to. Null once accepted or dismissed: the
+   *  suggestion is a prompt, not a property of the recording, so resolving it
+   *  clears it. */
+  filingSuggestion?: FilingSuggestion | null;
+  /** True once the filing pass COMPLETED for this recording. Exists for the same
+   *  reason {@link HistoryEntry.analyzed} does: a null `filingSuggestion` can't
+   *  distinguish "never ran" from "ran, and the user has since dealt with it",
+   *  so without this flag every reopen would re-spend the pass. */
+  filingSuggested?: boolean;
 }
 
 /** The card shown in the history grid — small, so listing stays cheap. */

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,6 +6,7 @@ import type {
   DeliveryAssessment,
   DeliveryNudge,
   Evaluation,
+  FilingSuggestion,
   FindingSolutionEntry,
   LlmProvider,
   MeetingKind,
@@ -237,6 +238,8 @@ const CLEARED_STUDY_SLICE: Pick<
   | "deliveryStatus"
   | "brief"
   | "briefStatus"
+  | "filingSuggestion"
+  | "filingStatus"
   | "meetingKind"
 > = {
   findings: [],
@@ -253,6 +256,8 @@ const CLEARED_STUDY_SLICE: Pick<
   deliveryStatus: "idle",
   brief: null,
   briefStatus: "idle",
+  filingSuggestion: null,
+  filingStatus: "idle",
   meetingKind: null,
 };
 
@@ -398,6 +403,16 @@ interface ParleyState {
   /** Append a streamed chunk to the brief (streaming render). */
   appendBrief: (chunk: string) => void;
   setBriefStatus: (status: AsyncTaskStatus) => void;
+  /** The pending filing suggestion for the LOADED recording — a better title and
+   *  the folders it could move to. Per-recording, like the brief: it is cleared
+   *  with the rest of the study slice and restored from the entry on load. `null`
+   *  means nothing is pending, which covers both "never generated" and "the user
+   *  already accepted or dismissed it" — `filingStatus` is what tells those apart
+   *  (see HistoryEntry.filingSuggested). */
+  filingSuggestion: FilingSuggestion | null;
+  filingStatus: AsyncTaskStatus;
+  setFilingSuggestion: (suggestion: FilingSuggestion | null) => void;
+  setFilingStatus: (status: AsyncTaskStatus) => void;
   /** Insert one finding (MCP/external add) without replacing the list, keeping it
    *  ordered by atMs. A colliding id is reassigned so existing findings are safe. */
   addFinding: (event: TimelineEvent) => void;
@@ -758,6 +773,10 @@ export const useStore = create<ParleyState>()(
       deliveryStatus: entry.deliveryAssessment ? "done" : "idle",
       brief: entry.brief ?? null,
       briefStatus: entry.brief ? "done" : "idle",
+      // A read-only org recording can be neither renamed nor refiled, so it
+      // carries no suggestion — and the pass that would produce one declines too.
+      filingSuggestion: opts?.readOnly ? null : entry.filingSuggestion ?? null,
+      filingStatus: entry.filingSuggested || entry.filingSuggestion ? "done" : "idle",
       meetingKind: entry.meetingKind ?? null,
       // Restore the per-meeting context + negotiation setup.
       meetingContext: entry.meetingContext,
@@ -820,6 +839,10 @@ export const useStore = create<ParleyState>()(
   setMeetingKind: (meetingKind) => set({ meetingKind }),
   appendBrief: (chunk) => set((s) => ({ brief: (s.brief ?? "") + chunk })),
   setBriefStatus: (status) => set({ briefStatus: status }),
+  filingSuggestion: null,
+  filingStatus: "idle",
+  setFilingSuggestion: (filingSuggestion) => set({ filingSuggestion }),
+  setFilingStatus: (filingStatus) => set({ filingStatus }),
   // Replace the findings list, keeping the selection + cached solutions of any
   // finding that STILL EXISTS in the new list. During streaming, partials commit
   // a growing list with stable ids, so a finding the user opened mid-stream (and

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -475,3 +475,31 @@ export interface DeliveryAssessment {
   /** One-line plain-language summary of how the user is coming across. */
   summary: string;
 }
+
+/**
+ * One suggested home for a finished recording. `folderId` null means the model
+ * proposed a folder that does NOT exist yet — accepting the chip creates it.
+ * At most one such new-folder suggestion is ever offered (see resolveFilingFolders).
+ */
+export interface FilingFolderSuggestion {
+  /** Existing personal folder this points at, or null for a not-yet-created one. */
+  folderId: string | null;
+  name: string;
+  /** One short clause saying why this folder fits — shown as the chip's tooltip. */
+  reason: string;
+}
+
+/**
+ * The post-transcription filing suggestion: what this recording should be CALLED
+ * and where it should LIVE. Generated once per recording off the transcript alone
+ * (it needs no findings), because both doors into a finished recording name it
+ * badly — a live meeting gets "即時會議 · <date>" and an upload gets its file
+ * name, and the ingest wizard asks for the folder BEFORE transcription, when
+ * nobody yet knows what the meeting was about.
+ */
+export interface FilingSuggestion {
+  /** Proposed display title. Empty string = the model had nothing better. */
+  title: string;
+  /** 1–3 candidate folders, best first. */
+  folders: FilingFolderSuggestion[];
+}


### PR DESCRIPTION
## What this changes

After a recording is transcribed, a card above the report page's filing bar proposes a better **title** for it plus **2–3 candidate folders**, each one click to accept. At most one candidate may be a folder that does not exist yet.

## Why

Both doors into a finished recording name it badly: a live meeting is saved as `即時會議 · <date>` and an upload keeps its file name, so the library fills with rows nobody can tell apart. Filing is worse — the ingest wizard asks which folder to use *before* transcription, at the one moment when nobody yet knows what the meeting was about. `IngestWizard.tsx` already carries a comment conceding that this is what produces "recordings needing after-the-fact filing". This is the after-the-fact answer.

### Design notes

**It rides the cheap realtime lane and has no upstream dependency.** The transcript alone is its input, so it dispatches in the *same tick* as the findings pass rather than queueing behind the expensive one — the suggestion should land while the user is still looking at the recording. It is also the one stage a realtime-only user ever gets.

```
findings ──done──▶ action items ──settled──▶ brief
     └────done──▶ delivery
filing   (no upstream — the transcript alone is its input)
```

**A stage, but not an artifact.** The titlebar chip counts four report artifacts and must keep counting four; a suggestion is a prompt to the user, not a section of the report. The split is carried in the types (`StudyStageKey` vs `StudyArtifactKey`) so the compiler enforces it, rather than a filter someone has to remember to write.

**Acceptance state is derived, never stored.** The title row hides once the recording is already called that; a folder chip hides once it is already filed there. So renaming from the titlebar, or filing from the bar below, retires the row just as well as the card's own buttons — an `applied` flag would only be a second copy of that fact, free to drift.

**What *is* stored is `filingSuggested`**, for the same reason `analyzed` exists: a null `filingSuggestion` cannot distinguish "never ran" from "ran, and the user dealt with it", and without the flag every reopen would re-spend the pass.

**The model is not trusted with the product rules.** `resolveFilingFolders` is pure and enforces them regardless of what comes back: at most one new folder, at most three chips, the registry's spelling wins over the model's, and a model claiming `isNew` about a folder that already exists resolves to the existing one.

### A write race this also fixes

`useRefile` now resolves when the move has landed. `setEntryFolder` and the study persists are both read-modify-write over one `meta.json`; started concurrently, the later write reads a pre-move copy and silently drops the folder change. The store already shows the new folder, so it only surfaces on the next load.

### Storage shape

No DB migration. Two optional fields are added to `HistoryEntry` (`filingSuggestion`, `filingSuggested`), which is persisted as opaque JSON in `meta.json` and pushed to the cloud verbatim — older entries simply omit them and read as "never ran".

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes — 27 files, 285 tests
- [ ] Ran the app (`bun run tauri dev`) and exercised the change
- [x] Added or updated tests — 10 new for `resolveFilingFolders`, 5 new for the pipeline scheduling
- [x] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts` (7 keys, parity checked)

> **Not yet run in the app.** The logic and scheduling are covered by tests, but the card has not been rendered on screen — the violet accent, chip wrapping and dark mode are unverified. Screenshots to follow before this merges.

## Screenshots

_Pending — see the note above._
