### PR TITLE
[fix] a dictation borrows the microphone only if it is still running

### DIFF
--- a/docs/design/ios-voice-keyboard.md
+++ b/docs/design/ios-voice-keyboard.md
@@ -209,12 +209,25 @@ tap 3   …
 tap 4   round trip again
 ```
 
-`AudioCapture` is unchanged. `DictationCoordinator` simply stopped treating the
-microphone as a session's property: `releaseMicrophone()` at the end of a
-dictation either hands it to the window or closes it, and `launch()` reuses
-whatever is already running. While no dictation is attached, chunks go into
-`RelayAudioBridge` with no leg and no hold, which counts them and drops them —
-**an open window records nothing, because there is nowhere for the audio to go.**
+`DictationCoordinator` stopped treating the microphone as a session's property:
+`releaseMicrophone()` at the end of a dictation either hands it to the window or
+closes it, and `launch()` reuses whatever is already running. While no dictation
+is attached, chunks go into `RelayAudioBridge` with no leg and no hold, which
+counts them and drops them — **an open window records nothing, because there is
+nowhere for the audio to go.**
+
+`AudioCapture` gained one thing for this: `isCapturing`. A borrow has to ask
+whether the capture is *running*, not whether the coordinator still happens to
+hold one. The engine can be torn down behind its owner's back — a rebuild that
+runs out of attempts, a status that arrives when there is no window left to end
+it — and a non-nil `AudioCapture` that will never produce another sample is the
+worst thing there is to hand a dictation: the session goes to `.listening`, the
+user talks, nothing is transcribed, and it happens in the background, where the
+microphone cannot be reopened to recover. So `launch()` stops a capture that says
+it is not capturing and opens a fresh one, and if that start is refused — the
+ordinary answer in the background — the session fails with the window closed
+behind it, which is what puts the keyboard back to honestly promising a trip
+through Parley.
 
 ### What it costs, and where that is said
 

--- a/ios/App/Parley/AudioCapture.swift
+++ b/ios/App/Parley/AudioCapture.swift
@@ -33,7 +33,10 @@ import ParleyKit
 ///
 /// `@unchecked Sendable` because every mutable field is confined to `queue`:
 /// start, stop, the four notification handlers, and the watchdog all run there,
-/// and nothing else reads them.
+/// and nothing else reads them. The single exception is the flag behind
+/// `isCapturing`, which is written on `queue` like everything else but has to
+/// be *readable* from off it — see there for why that read cannot simply hop
+/// onto the queue and wait.
 final class AudioCapture: @unchecked Sendable {
 
     /// Where the microphone stands. Anything other than `.running` is worth
@@ -76,11 +79,11 @@ final class AudioCapture: @unchecked Sendable {
 
     /// The user wants to be recording. Stays true across interruptions: it is
     /// what tells a route change to rebuild rather than stay silent.
-    private var wantsCapture = false
+    private var wantsCapture = false { didSet { publishCapturing() } }
     /// A tap is installed and the engine is running.
-    private var live = false
+    private var live = false { didSet { publishCapturing() } }
     /// The system holds the microphone; do not fight it for the hardware.
-    private var interrupted = false
+    private var interrupted = false { didSet { publishCapturing() } }
     /// The hardware format the current tap and converter were built for.
     private var tapFormat: AVAudioFormat?
     private var recoveryAttempts = 0
@@ -88,6 +91,17 @@ final class AudioCapture: @unchecked Sendable {
     /// the notifications arrive in clusters, so without this a slow recovery
     /// would end up with several chains racing each other for the same engine.
     private var rebuilding = false
+
+    /// What `isCapturing` reports, kept in step with the three flags above by
+    /// their `didSet`. Written on `queue` like they are, read from anywhere,
+    /// which is why this one field is guarded by a lock instead of by the
+    /// queue. `didSet` rather than assignments at the handful of sites that
+    /// move those flags, so that a mutation added later cannot forget to keep
+    /// this honest — and so that the order of two assignments in the same
+    /// function (`end()` clears `wantsCapture` before tearing the engine down)
+    /// can never publish a moment of "capturing" that was never true.
+    private var capturing = false
+    private let capturingLock = NSLock()
 
     /// `onChunk(samples, rmsLevel)` fires on an audio thread. `onStatus` fires
     /// on this object's private queue.
@@ -114,6 +128,56 @@ final class AudioCapture: @unchecked Sendable {
     /// fails as if the user had said no, without the user ever being asked.
     static var permission: AVAudioApplication.recordPermission {
         AVAudioApplication.shared.recordPermission
+    }
+
+    /// Whether the microphone is genuinely open right now: nobody has stopped
+    /// this capture, the engine is running with a tap installed, and the system
+    /// is not holding the hardware.
+    ///
+    /// ## Why holding the object is not knowing
+    ///
+    /// A caller that keeps a capture alive between uses — the dictation
+    /// coordinator's microphone window does exactly that — cannot tell a
+    /// running capture from a dead one by the fact that it still has a
+    /// reference to it. `onStatus` is a push, and a push has to be caught: the
+    /// coordinator only reacts to statuses it is awake and in the right shape
+    /// to hear, so a capture that gives up its rebuilds at an awkward moment
+    /// can end up torn down with its owner none the wiser. What the owner then
+    /// hands the next dictation is an object that will never produce another
+    /// sample, and the next dictation is usually served from the background,
+    /// where iOS will not let it open a microphone to recover. So this state
+    /// has to be *askable*, not only announced.
+    ///
+    /// ## Why a mirrored flag rather than `queue.sync`
+    ///
+    /// The three flags this reports on are confined to `queue`, so the obvious
+    /// read is `queue.sync { wantsCapture && live && !interrupted }`. The
+    /// obvious read is also a way to stall the main actor for the better part
+    /// of a second: every caller is `@MainActor`, and `queue` is where
+    /// `setActive(true)` and every engine rebuild run — which is precisely the
+    /// work in flight when a capture is sick, which is precisely when anyone
+    /// thinks to ask this. A `Bool` mirrored under a lock held for one
+    /// assignment answers immediately, cannot deadlock, and cannot be starved
+    /// by a rebuild.
+    ///
+    /// It is a snapshot, and deliberately strict. A rebuild in flight reads
+    /// `false` for the beat between the teardown and the engine coming back,
+    /// so a caller can be told "not capturing" about a capture that would have
+    /// recovered on its own. That trade is on purpose: the cost of the strict
+    /// answer is opening a microphone that did not strictly need opening, and
+    /// the cost of a generous one is a dictation spent listening to an engine
+    /// that is never coming back.
+    var isCapturing: Bool {
+        capturingLock.lock()
+        defer { capturingLock.unlock() }
+        return capturing
+    }
+
+    private func publishCapturing() {
+        let value = wantsCapture && live && !interrupted
+        capturingLock.lock()
+        capturing = value
+        capturingLock.unlock()
     }
 
     /// Configure the session and open the microphone.

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -1014,8 +1014,18 @@ final class DictationCoordinator: ObservableObject {
     /// seconds. Idempotent: both `stop` and the relay signing off reach it.
     private func releaseMicrophone() async {
         guard !active else { return }
+        // `isCapturing`, not `capture != nil`: an open window is a promise to
+        // the keyboard that the next tap will be served where the user already
+        // is, and the keyboard renders that promise. Publishing one over a
+        // capture that is not capturing makes it a lie the user only discovers
+        // by tapping — the same "holding it is not having it" mistake `launch`
+        // and `endWindow` were both making, reached from the third side. A
+        // transient interruption landing exactly here costs the window, and a
+        // window nobody opened is a state the keyboard already knows how to
+        // describe.
         if !yieldedToMeeting,
-            let opened = MicWindowState.opened(length: windowLength, at: Date()), capture != nil
+            let opened = MicWindowState.opened(length: windowLength, at: Date()),
+            capture?.isCapturing == true
         {
             openWindow(opened)
             return

--- a/ios/App/Parley/DictationCoordinator.swift
+++ b/ios/App/Parley/DictationCoordinator.swift
@@ -348,6 +348,24 @@ final class DictationCoordinator: ObservableObject {
         // backgrounded process, so a session that had to open the microphone
         // here would have to bring the app forward first — which is the app
         // switch this whole feature exists to avoid.
+        //
+        // **Only if there is something running to borrow.** Holding an
+        // `AudioCapture` is not the same as having a microphone. The engine can
+        // be torn down behind this object's back — a rebuild that runs out of
+        // attempts, a media-server reset that never recovers — and the only
+        // announcement is a status push, which has paths that reach nobody in a
+        // position to act on it. What is left is a non-nil capture that will
+        // never produce another sample; borrowing it put the session into
+        // `.listening` over a dead microphone, and because the borrow happens
+        // in the background there was no way back short of force-quitting
+        // Parley. So the question is whether the capture *is capturing*, not
+        // whether it exists.
+        if let stale = capture, !stale.isCapturing {
+            capture = nil
+            // Stopped rather than dropped: it still holds an audio session that
+            // the fresh capture below is about to activate for itself.
+            await stale.stop()
+        }
         if capture == nil {
             let fresh = makeCapture()
             do {
@@ -357,7 +375,22 @@ final class DictationCoordinator: ObservableObject {
                 relay = nil
                 audio.discard()
                 client.cancel()
-                fail(String(localized: "Couldn't open the microphone."))
+                // The realistic cause is iOS refusing a backgrounded process
+                // the microphone — which is exactly where a capture that died
+                // in a window leaves us, and not something this process can
+                // argue its way out of. `fail` takes the window down with it
+                // (see there), so the keyboard's pane goes back to promising a
+                // trip through Parley, where the microphone can be opened from
+                // the foreground. Handing the user back to a path that works
+                // beats leaving them talking into a session that is listening
+                // to nothing.
+                fail(
+                    UIApplication.shared.applicationState == .active
+                        ? String(localized: "Couldn't open the microphone.")
+                        : String(
+                            localized:
+                                "Couldn't open the microphone. Open Parley and tap the mic again."
+                        ))
                 return
             }
         }
@@ -1058,8 +1091,22 @@ final class DictationCoordinator: ObservableObject {
     /// the microphone not to be *held afterwards*, and taking their sentence
     /// away mid-word to honour that would be a strange reading of it. The
     /// session finishes and `releaseMicrophone` then finds no window to open.
+    ///
+    /// ## Why the guard is not "is a window open"
+    ///
+    /// It was, and that turned out to drop the call that mattered most. A
+    /// capture can outlive its window: the window expires, or is ended from the
+    /// keyboard, and the microphone is closed — but a capture that dies *first*
+    /// arrives here through `handle(capture:)` with the window already closed
+    /// behind it, and an `openedAt`-only guard sent it away with the dead
+    /// `AudioCapture` still held. The next dictation then borrowed a corpse.
+    ///
+    /// So the question is whether there is anything left to end, which is the
+    /// window *or* the microphone it was holding. The "one window ends once"
+    /// property survives: the first call closes both, and a second finds
+    /// neither and returns before touching anything.
     func endWindow() async {
-        guard window.openedAt != nil else { return }
+        guard window.openedAt != nil || capture != nil else { return }
         windowTask?.cancel()
         windowTask = nil
         closeWindowState()
@@ -1110,6 +1157,14 @@ final class DictationCoordinator: ObservableObject {
             window.length = length
             publishWindow()
             return
+        }
+        // A dead capture would make this window a promise about a microphone
+        // that is not there — the same trap `launch` avoids, reached from the
+        // other end. Foreground is the one place a replacement can actually be
+        // opened, so this is where it is worth replacing.
+        if let stale = capture, !stale.isCapturing {
+            capture = nil
+            await stale.stop()
         }
         if capture == nil {
             switch AudioCapture.permission {

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -723,6 +723,12 @@
             "state": "translated",
             "value": "Couldn't open the microphone. Open Parley and tap the mic again."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法開啟麥克風。請先開啟 Parley，再按一次麥克風。"
+          }
         }
       }
     },

--- a/ios/App/Parley/Localizable.xcstrings
+++ b/ios/App/Parley/Localizable.xcstrings
@@ -715,6 +715,17 @@
         }
       }
     },
+    "Couldn't open the microphone. Open Parley and tap the mic again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't open the microphone. Open Parley and tap the mic again."
+          }
+        }
+      }
+    },
     "Couldn't start": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## The bug

Dictation stops working entirely, and only force-quitting Parley brings it back.

`DictationCoordinator.launch()` decided whether to open the microphone with
`if capture == nil` — a pointer check, not a liveness check. The microphone
window deliberately keeps an `AudioCapture` alive between dictations so the next
one can borrow it (iOS refuses to let a backgrounded process *start* recording,
so borrowing is the only way a keyboard tap avoids a trip through Parley).

But the engine can die behind that object's back — a rebuild that runs out of
attempts, a media-server reset that never recovers — and the only announcement
is a status push, which has paths that reach nobody in a position to act. What
is left is a non-nil capture that will never produce another sample. The next
session skipped `start()`, attached the relay to a dead microphone, went to
`.listening`, and heard nothing. `capture = nil` is only executed in `fail()`
and `closeMicrophone()`, both of which need that same status push to be reached,
so the only thing that cleared it was killing the process.

`endWindow()` made it worse: it opened with `guard window.openedAt != nil`, so
the one call that mattered — a capture dying with its window already closed,
arriving via `handle(capture:)` — was turned away before it could tear the dead
capture down.

## The fix

**`AudioCapture` can now be asked.** `isCapturing` reports
`wantsCapture && live && !interrupted`, mirrored into a lock-guarded `Bool` by
`didSet` on the three flags. Not `queue.sync`: every caller is `@MainActor`, and
`queue` is where `setActive(true)` and the rebuilds run — precisely the work in
flight when a capture is sick, which is precisely when anyone asks.

**Three places stop confusing holding with having.** `launch()` (borrow),
`beginWindowFromForeground()` (open a window), and `releaseMicrophone()` (hand
the microphone to a window) all now require `isCapturing` rather than non-nil.
The invariant is uniform: a window is opened, borrowed from, and kept only while
the capture behind it is actually running.

**`endWindow()` guards on "is there anything left to end"** — the window *or* the
microphone it was holding. "One window ends once" survives: the first call closes
both, the second finds neither.

**Failure is loud.** If the fresh `start()` fails — realistically iOS refusing a
backgrounded process the microphone, which is exactly where a dead window leaves
us — the session no longer sits in `.listening` collecting silence. `fail()`
takes the window down with it, so the keyboard's pane goes back to promising a
trip through Parley, where the microphone can be opened from the foreground. The
message keys off `applicationState`, because telling a foreground user to "open
Parley" is nonsense.

## Deliberately strict

`isCapturing` reads `false` while a rebuild is in flight, so a tap landing in
that window tears down a capture that would have recovered and — in the
background — fails with the "open Parley" message instead of borrowing.

That trade is on purpose and it is the conservative direction: the cost of the
strict answer is one visible, actionable error during a rare 250 ms–4 s window;
the cost of a generous one is the bug this PR exists to fix. Given none of this
can be tested off-device, failing loudly beats listening to nothing.

## ⚠️ Verification — read this before merging

**Nothing here has been compiled, and CI will not compile it either.**

- This machine has Command Line Tools only: no Xcode, no simulator, no XCTest.
- `swiftc -parse` passes on both changed files — that is a **syntax check only**.
  It does not resolve `import AVFoundation`/`UIKit`, does no type checking, and
  would not catch a wrong overload, an actor-isolation error, or a Swift 6
  concurrency diagnostic.
- `swift build --package-path ios/ParleyKit` passes, but ParleyKit is untouched —
  it only proves nothing else broke.
- **`.github/workflows/ci.yml` has `paths-ignore: ios/**`**, so this PR gets no
  CI build at all.
- All the new logic is `@MainActor` + AVFoundation + UIKit, so none of it could
  be moved into ParleyKit where it would at least be buildable.

**The first real build is the iOS release workflow.** Someone with Xcode should
build this before it is tagged, and the fix itself needs a device to confirm:
open a microphone window, dictate, press stop, swipe back, wait for the engine
to die, and tap again — it should now either serve you or tell you to open
Parley, never sit listening to nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
