### PR TITLE
[feature] ⌘K jumps straight to a folder or a recording

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -9,6 +9,7 @@ import { LiveScreen } from "../live/LiveScreen";
 import { StudyScreen } from "../study/StudyScreen";
 import { HomeScreen } from "../home/HomeScreen";
 import { AppSidebar } from "./AppSidebar";
+import { CommandPalette } from "./CommandPalette";
 import { useLibraryTree } from "./useLibraryTree";
 import { useStore, isMeetingActive, type AppMode } from "../../lib/store";
 
@@ -46,24 +47,30 @@ export function AppShell() {
   }
 
   return (
-    <ResizablePanelGroup
-      orientation="horizontal"
-      className="min-h-0 flex-1"
-      defaultLayout={saved.defaultLayout}
-      onLayoutChanged={saved.onLayoutChanged}
-    >
-      {/* Sizes carry explicit units: a bare number is read as a PIXEL size by
-          this version, which pinned the tree to a 32px sliver on first run. */}
-      <ResizablePanel id="tree" defaultSize="19%" minSize="180px" maxSize="30%">
-        <AppSidebar tree={tree} />
-      </ResizablePanel>
-      <ResizableHandle withHandle />
-      <ResizablePanel id="route" defaultSize="81%" minSize="480px">
-        <div className="flex h-full min-h-0 flex-col">
-          <RouteContent mode={appMode} tree={tree} />
-        </div>
-      </ResizablePanel>
-    </ResizablePanelGroup>
+    <>
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="min-h-0 flex-1"
+        defaultLayout={saved.defaultLayout}
+        onLayoutChanged={saved.onLayoutChanged}
+      >
+        {/* Sizes carry explicit units: a bare number is read as a PIXEL size by
+            this version, which pinned the tree to a 32px sliver on first run. */}
+        <ResizablePanel id="tree" defaultSize="19%" minSize="180px" maxSize="30%">
+          <AppSidebar tree={tree} />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel id="route" defaultSize="81%" minSize="480px">
+          <div className="flex h-full min-h-0 flex-col">
+            <RouteContent mode={appMode} tree={tree} />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+      {/* ⌘K (#332): the other way to reach a node — by name instead of by aim.
+          Deliberately absent from the focused branch above, where a running
+          meeting owns the window. */}
+      <CommandPalette tree={tree} />
+    </>
   );
 }
 

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { AudioLines, Folder, FolderClosed, House, Mic, Search, UsersRound } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { buildOwnershipIndex, countByNode, nodeKey, type LibraryNode } from "../../lib/library/scope";
+import {
+  searchTargets,
+  targetKey,
+  targetLabel,
+  type QuickSwitchLabels,
+  type QuickTarget,
+} from "../../lib/library/quickSwitch";
+import { loadHistoryEntry } from "../../lib/history/history";
+import { isMeetingActive, useStore } from "../../lib/store";
+import { useI18n, type TranslationKey } from "../../i18n";
+import { log } from "../../lib/log";
+import type { LibraryTree } from "./useLibraryTree";
+
+/**
+ * ⌘K — name it and go (issue #332).
+ *
+ * The one tree beside this is aim-and-click: to reach 和運租車 you first have to
+ * find the row, which means knowing where it sits. That is the right default
+ * for browsing and the wrong one for the case that actually dominates — you
+ * already know the name, you just want to be there. This is that path: type
+ * four characters, hit ↵, land.
+ *
+ * It is deliberately a JUMP-TO switcher, not a command runner. Every row is a
+ * PLACE (a folder, an org, a recording, home), never an action, so pressing ↵
+ * on a highlighted row can only ever navigate — it can't rename, delete, share
+ * or start a meeting. A palette that mixes destinations and verbs makes ↵ a
+ * gamble, and the one place you must never gamble is over a list your finger is
+ * already scrolling through. Actions stay where they are: on the row, on the
+ * card, under the pointer.
+ *
+ * It never opens over a RUNNING meeting, for the same reason the shell hides
+ * the tree there — the live coach owns that window.
+ */
+export function CommandPalette({ tree }: Readonly<{ tree: LibraryTree }>) {
+  const { t } = useI18n();
+  const meetingActive = useStore((s) => isMeetingActive(s.meetingStatus));
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  // ⌘K / Ctrl+K toggles. The guard reads the store directly rather than the
+  // subscribed value so the listener never has to be re-registered.
+  useEffect(() => {
+    const onKeyDown = (e: globalThis.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        if (isMeetingActive(useStore.getState().meetingStatus)) return;
+        setOpen((o) => !o);
+      }
+    };
+    globalThis.addEventListener("keydown", onKeyDown);
+    return () => globalThis.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // A meeting starting while the palette is up takes the window back.
+  useEffect(() => {
+    if (meetingActive) setOpen(false);
+  }, [meetingActive]);
+
+  // Every open is a fresh start: last search left up is a search you have to
+  // clear before you can use the thing.
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setActive(0);
+  }, [open]);
+
+  // Warm the org folder caches so a SECOND open can already offer them. The
+  // palette never blocks on a fetch — what isn't cached simply isn't listed.
+  const { signedIn, orgs, ensureOrgFolders } = tree;
+  useEffect(() => {
+    if (!open || !signedIn) return;
+    for (const org of orgs) ensureOrgFolders(org.id);
+  }, [open, signedIn, orgs, ensureOrgFolders]);
+
+  const labels: QuickSwitchLabels = {
+    home: t("home.title"),
+    unassigned: t("library.unassigned"),
+    voice: t("history.sidebar.voiceTyping"),
+  };
+
+  // The same index and the same rule the sidebar counts with (lib/library/scope),
+  // so "和運租車 · 8" reads the same here as it does in the tree.
+  const index = buildOwnershipIndex(tree.personalFolders);
+  const counts = countByNode(tree.summaries, index);
+  const countAt = (node: LibraryNode) => counts.get(nodeKey(node)) ?? 0;
+  const folderNames = new Map(tree.personalFolders.map((f) => [f.id, f.name]));
+
+  const targets: QuickTarget[] = [{ kind: "home" }];
+  for (const f of tree.personalFolders) {
+    targets.push({
+      kind: "folder",
+      id: f.id,
+      name: f.name,
+      count: countAt({ kind: "folder", folderId: f.id }),
+    });
+  }
+  targets.push({ kind: "unassigned", count: countAt({ kind: "unassigned" }) });
+  targets.push({ kind: "voice" });
+  if (tree.signedIn) {
+    for (const org of tree.orgs) {
+      targets.push({ kind: "org", orgId: org.id, orgName: org.name });
+      for (const f of tree.orgFolders[org.id] ?? []) {
+        targets.push({
+          kind: "orgFolder",
+          orgId: org.id,
+          orgName: org.name,
+          id: f.id,
+          name: f.name,
+        });
+      }
+    }
+  }
+  for (const s of tree.summaries) {
+    targets.push({
+      kind: "recording",
+      id: s.id,
+      title: s.title,
+      createdAt: s.createdAt,
+      folderId: s.folderId ?? null,
+    });
+  }
+
+  // Cheap enough to redo per render, and always in step with the tree.
+  const results = open ? searchTargets(targets, query, labels) : [];
+  const count = results.length;
+
+  // A shorter list must not leave the highlight pointing past the end.
+  useEffect(() => {
+    setActive((i) => (count === 0 ? 0 : Math.min(i, count - 1)));
+  }, [count]);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [active, count]);
+
+  async function activate(target: QuickTarget) {
+    const { openHome, openLibrary } = useStore.getState();
+    // Close first: the palette must never sit over the route it just opened.
+    setOpen(false);
+    switch (target.kind) {
+      case "home":
+        openHome();
+        return;
+      case "folder":
+        openLibrary({ kind: "personal", node: { kind: "folder", folderId: target.id } });
+        return;
+      case "unassigned":
+        openLibrary({ kind: "personal", node: { kind: "unassigned" } });
+        return;
+      case "voice":
+        openLibrary({ kind: "voice" });
+        return;
+      case "org":
+        tree.ensureOrgFolders(target.orgId);
+        openLibrary({ kind: "org", id: target.orgId, name: target.orgName, folderId: null });
+        return;
+      case "orgFolder":
+        openLibrary({ kind: "org", id: target.orgId, name: target.orgName, folderId: target.id });
+        return;
+      case "recording":
+        try {
+          // Switches the app to the study route itself.
+          await loadHistoryEntry(target.id);
+        } catch (e) {
+          log.error("palette: open failed", { id: target.id, error: String(e) });
+          toast.error(
+            t("shell.palette.openFailed", {
+              error: e instanceof Error ? e.message : String(e),
+            })
+          );
+        }
+    }
+  }
+
+  function step(delta: 1 | -1) {
+    if (count === 0) return;
+    setActive((i) => (i + delta + count) % count);
+  }
+
+  function onInputKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      step(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      step(-1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const target = results[active];
+      if (target) void activate(target);
+    }
+    // Escape is the Dialog's — it already closes and restores focus.
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[94] bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          data-slot="command-palette"
+          className="fixed left-1/2 top-[15vh] z-[95] flex w-[calc(100%-2rem)] max-w-[34rem] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-xl data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            inputRef.current?.focus();
+          }}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            {t("shell.palette.title")}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            {t("shell.palette.placeholder")}
+          </DialogPrimitive.Description>
+
+          <div className="flex shrink-0 items-center gap-2 px-3 py-2.5">
+            <Search className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              value={query}
+              placeholder={t("shell.palette.placeholder")}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+              }}
+              onKeyDown={onInputKeyDown}
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+
+          <div className="h-px shrink-0 bg-border" />
+
+          <div className="max-h-[22rem] overflow-y-auto p-1">
+            {count === 0 ? (
+              <div className="px-3 py-8 text-center">
+                <p className="text-sm text-muted-foreground">{t("shell.palette.empty")}</p>
+                <p className="mt-1 text-xs text-muted-foreground/70">
+                  {t("shell.palette.emptyHint")}
+                </p>
+              </div>
+            ) : (
+              results.map((target, i) => (
+                <PaletteRow
+                  key={targetKey(target)}
+                  rowRef={i === active ? activeRef : undefined}
+                  icon={iconFor(target)}
+                  label={targetLabel(target, labels)}
+                  meta={metaFor(target, folderNames, t)}
+                  active={i === active}
+                  onMouseEnter={() => setActive(i)}
+                  onSelect={() => void activate(target)}
+                />
+              ))
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-3 border-t px-3 py-1.5 text-[10px] text-muted-foreground/70">
+            <Hint keys="↑↓" label={t("shell.palette.hint.move")} />
+            <Hint keys="↵" label={t("shell.palette.hint.open")} />
+            <Hint keys="esc" label={t("shell.palette.hint.close")} />
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+/** The icons match the sidebar's, so a row means the same thing in both. */
+function iconFor(target: QuickTarget): ReactNode {
+  switch (target.kind) {
+    case "home":
+      return <House className="size-3.5" />;
+    case "folder":
+    case "orgFolder":
+      return <Folder className="size-3.5" />;
+    case "unassigned":
+      return <FolderClosed className="size-3.5" />;
+    case "voice":
+      return <Mic className="size-3.5" />;
+    case "org":
+      return <UsersRound className="size-3.5 text-sky-500" />;
+    case "recording":
+      return <AudioLines className="size-3.5" />;
+  }
+}
+
+/** The muted right-hand line: WHERE the row lives, so two same-named things
+ *  are still tellable apart without opening either. */
+function metaFor(
+  target: QuickTarget,
+  folderNames: ReadonlyMap<string, string>,
+  t: (key: TranslationKey, vars?: Record<string, string | number>) => string
+): string {
+  switch (target.kind) {
+    case "recording": {
+      const folder = (target.folderId && folderNames.get(target.folderId)) || t("library.unassigned");
+      return t("shell.palette.recordingIn", { folder });
+    }
+    case "orgFolder":
+      return target.orgName;
+    case "folder":
+      return target.count > 0 ? String(target.count) : "";
+    default:
+      return "";
+  }
+}
+
+function PaletteRow({
+  icon,
+  label,
+  meta,
+  active,
+  onSelect,
+  onMouseEnter,
+  rowRef,
+}: Readonly<{
+  icon: ReactNode;
+  label: string;
+  meta: string;
+  active: boolean;
+  onSelect: () => void;
+  onMouseEnter: () => void;
+  rowRef?: Ref<HTMLButtonElement>;
+}>) {
+  return (
+    <button
+      ref={rowRef}
+      type="button"
+      onClick={onSelect}
+      onMouseEnter={onMouseEnter}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        active ? "bg-muted font-medium text-foreground" : "text-muted-foreground"
+      )}
+    >
+      <span className="shrink-0">{icon}</span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {meta && (
+        <span className="max-w-[40%] shrink-0 truncate text-[11px] text-muted-foreground/70">
+          {meta}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function Hint({ keys, label }: Readonly<{ keys: string; label: string }>) {
+  return (
+    <span className="flex items-center gap-1">
+      <kbd className="rounded border bg-muted px-1 py-px font-sans text-[10px] leading-none">
+        {keys}
+      </kbd>
+      {label}
+    </span>
+  );
+}

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -104,8 +104,7 @@ export function CommandPalette({ tree }: Readonly<{ tree: LibraryTree }>) {
       count: countAt({ kind: "folder", folderId: f.id }),
     });
   }
-  targets.push({ kind: "unassigned", count: countAt({ kind: "unassigned" }) });
-  targets.push({ kind: "voice" });
+  targets.push({ kind: "unassigned", count: countAt({ kind: "unassigned" }) }, { kind: "voice" });
   if (tree.signedIn) {
     for (const org of tree.orgs) {
       targets.push({ kind: "org", orgId: org.id, orgName: org.name });

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -147,6 +147,17 @@ export const zhTW = {
   // ── App shell：一棵樹（#195）──
   "shell.folders": "資料夾",
   "shell.toggle": "展開／收合 {name}",
+
+  // ── ⌘K 快速切換（#332）──
+  "shell.palette.title": "快速跳到",
+  "shell.palette.placeholder": "搜尋資料夾或錄音…",
+  "shell.palette.empty": "沒有符合的項目",
+  "shell.palette.emptyHint": "換個關鍵字試試。",
+  "shell.palette.hint.move": "移動",
+  "shell.palette.hint.open": "開啟",
+  "shell.palette.hint.close": "關閉",
+  "shell.palette.recordingIn": "在 {folder}",
+  "shell.palette.openFailed": "開啟錄音失敗：{error}",
   "library.unassigned": "還沒歸檔",
   "library.unassigned.empty": "這裡沒有錄音",
   "library.unassigned.emptyHint": "還沒放進資料夾的錄音會落在這裡。用卡片上的資料夾圖示挑一個，它就會搬過去。",
@@ -1127,6 +1138,17 @@ export const en = {
   // ── App shell: the one tree (#195) ──
   "shell.folders": "Folders",
   "shell.toggle": "Expand or collapse {name}",
+
+  // ── ⌘K quick switcher (#332) ──
+  "shell.palette.title": "Jump to",
+  "shell.palette.placeholder": "Search folders and recordings…",
+  "shell.palette.empty": "Nothing matches",
+  "shell.palette.emptyHint": "Try another keyword.",
+  "shell.palette.hint.move": "Move",
+  "shell.palette.hint.open": "Open",
+  "shell.palette.hint.close": "Close",
+  "shell.palette.recordingIn": "in {folder}",
+  "shell.palette.openFailed": "Couldn’t open that recording: {error}",
   "library.unassigned": "Not filed yet",
   "library.unassigned.empty": "Nothing here",
   "library.unassigned.emptyHint":

--- a/src/lib/library/quickSwitch.test.ts
+++ b/src/lib/library/quickSwitch.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_QUERY_SCORE,
+  scoreMatch,
+  searchTargets,
+  targetKey,
+  targetLabel,
+  type QuickSwitchLabels,
+  type QuickTarget,
+} from "./quickSwitch";
+
+/**
+ * The #332 contract: what you type ranks the places you can go, and typing
+ * nothing still shows you the tree in the order the tree has.
+ */
+
+const labels: QuickSwitchLabels = {
+  home: "首頁",
+  unassigned: "還沒歸檔",
+  voice: "語音輸入",
+};
+
+/** Score, asserting the match exists — keeps the comparisons below readable. */
+function must(query: string, text: string): number {
+  const score = scoreMatch(query, text);
+  expect(score, `expected "${query}" to match "${text}"`).not.toBeNull();
+  return score as number;
+}
+
+describe("scoreMatch", () => {
+  it("returns null when a character is missing or out of order", () => {
+    expect(scoreMatch("zzz", "Sales Meeting")).toBeNull();
+    // Subsequence, so ORDER matters: the "g" comes before the "m" here.
+    expect(scoreMatch("gm", "Meeting")).toBeNull();
+  });
+
+  it("treats an empty query as 'everything matches'", () => {
+    expect(scoreMatch("", "anything")).toBe(EMPTY_QUERY_SCORE);
+    expect(scoreMatch("   ", "anything")).toBe(EMPTY_QUERY_SCORE);
+  });
+
+  it("ignores case", () => {
+    expect(must("MEET", "meeting")).toBe(must("meet", "MEETING"));
+  });
+
+  it("ranks exact above prefix above mid-string", () => {
+    const exact = must("meet", "Meet");
+    const prefix = must("meet", "Meeting");
+    const middle = must("meet", "Team Meet");
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(middle);
+  });
+
+  it("rewards characters that land at the start of a word", () => {
+    expect(must("sm", "Sales Meeting")).toBeGreaterThan(must("sm", "Assembly"));
+    // Separators count as word breaks too, not just spaces.
+    expect(must("ab", "alpha-beta")).toBeGreaterThan(must("ab", "xalphaxbeta"));
+  });
+
+  it("prefers a contiguous run over a scattered one", () => {
+    expect(must("abc", "xabc")).toBeGreaterThan(must("abc", "xaxbxc"));
+  });
+
+  it("prefers a match that starts earlier in the text", () => {
+    expect(must("acme", "Acme Corp")).toBeGreaterThan(must("acme", "The Acme Corp"));
+  });
+
+  it("strips whitespace from the query but not from the text", () => {
+    expect(scoreMatch("lib scr", "LibraryScreen")).not.toBeNull();
+    expect(scoreMatch("sales meeting", "Sales Meeting")).not.toBeNull();
+  });
+
+  it("matches a CJK name on a subsequence", () => {
+    expect(scoreMatch("和車", "和運租車")).not.toBeNull();
+    expect(scoreMatch("台科", "台數科")).not.toBeNull();
+    expect(scoreMatch("車和", "和運租車")).toBeNull();
+  });
+});
+
+describe("targetKey", () => {
+  it("gives every kind its own namespace", () => {
+    const keys = [
+      targetKey({ kind: "home" }),
+      targetKey({ kind: "folder", id: "x", name: "X", count: 0 }),
+      targetKey({ kind: "unassigned", count: 0 }),
+      targetKey({ kind: "voice" }),
+      targetKey({ kind: "org", orgId: "x", orgName: "X" }),
+      targetKey({ kind: "orgFolder", orgId: "o", orgName: "O", id: "x", name: "X" }),
+      targetKey({ kind: "recording", id: "x", title: "X", createdAt: 1, folderId: null }),
+    ];
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("targetLabel", () => {
+  it("takes the fixed nodes' names from the caller's dictionary", () => {
+    expect(targetLabel({ kind: "home" }, labels)).toBe("首頁");
+    expect(targetLabel({ kind: "unassigned", count: 3 }, labels)).toBe("還沒歸檔");
+    expect(targetLabel({ kind: "voice" }, labels)).toBe("語音輸入");
+  });
+});
+
+// The shape of a real tree: home, two folders, unassigned, voice, one org with
+// a folder, then three recordings newest-first.
+const HOME: QuickTarget = { kind: "home" };
+const ACME: QuickTarget = { kind: "folder", id: "f-acme", name: "Acme", count: 2 };
+const HEYUN: QuickTarget = { kind: "folder", id: "f-heyun", name: "和運租車", count: 8 };
+const UNASSIGNED: QuickTarget = { kind: "unassigned", count: 7 };
+const VOICE: QuickTarget = { kind: "voice" };
+const ORG: QuickTarget = { kind: "org", orgId: "o1", orgName: "Pathors" };
+const ORG_FOLDER: QuickTarget = {
+  kind: "orgFolder",
+  orgId: "o1",
+  orgName: "Pathors",
+  id: "of-1",
+  name: "Sales Meeting",
+};
+const REC_NEW: QuickTarget = {
+  kind: "recording",
+  id: "r3",
+  title: "和運租車 kickoff",
+  createdAt: 300,
+  folderId: "f-heyun",
+};
+const REC_MID: QuickTarget = {
+  kind: "recording",
+  id: "r2",
+  title: "Acme pricing call",
+  createdAt: 200,
+  folderId: "f-acme",
+};
+const REC_OLD: QuickTarget = {
+  kind: "recording",
+  id: "r1",
+  title: "Assembly standup",
+  createdAt: 100,
+  folderId: null,
+};
+
+const TREE: QuickTarget[] = [
+  HOME,
+  ACME,
+  HEYUN,
+  UNASSIGNED,
+  VOICE,
+  ORG,
+  ORG_FOLDER,
+  REC_NEW,
+  REC_MID,
+  REC_OLD,
+];
+
+describe("searchTargets", () => {
+  it("lists the whole tree in its natural order for an empty query", () => {
+    // Navigation first, exactly as handed in; then the recordings, newest first.
+    expect(searchTargets(TREE, "", labels).map((t) => targetKey(t))).toEqual([
+      "home",
+      "folder:f-acme",
+      "folder:f-heyun",
+      "unassigned",
+      "voice",
+      "org:o1",
+      "orgFolder:o1:of-1",
+      "recording:r3",
+      "recording:r2",
+      "recording:r1",
+    ]);
+  });
+
+  it("honours the limit", () => {
+    expect(searchTargets(TREE, "", labels, 3).map((t) => targetKey(t))).toEqual([
+      "home",
+      "folder:f-acme",
+      "folder:f-heyun",
+    ]);
+    expect(searchTargets(TREE, "", labels, 0)).toEqual([]);
+    // The default cap is 30, which this tree is comfortably inside.
+    expect(searchTargets(TREE, "", labels)).toHaveLength(TREE.length);
+  });
+
+  it("drops everything that doesn't match", () => {
+    expect(searchTargets(TREE, "zzzz", labels)).toEqual([]);
+  });
+
+  it("puts the folder ahead of the recordings that live in it", () => {
+    const keys = searchTargets(TREE, "acme", labels).map((t) => targetKey(t));
+    expect(keys[0]).toBe("folder:f-acme");
+    expect(keys).toContain("recording:r2");
+  });
+
+  it("ranks a word-start match above an incidental one", () => {
+    const keys = searchTargets(TREE, "sm", labels).map((t) => targetKey(t));
+    // "Sales Meeting" (both letters start a word) beats "Assembly".
+    expect(keys.indexOf("orgFolder:o1:of-1")).toBeLessThan(keys.indexOf("recording:r1"));
+  });
+
+  it("finds a CJK folder and its recording from a subsequence", () => {
+    const keys = searchTargets(TREE, "和車", labels).map((t) => targetKey(t));
+    expect(keys).toEqual(["folder:f-heyun", "recording:r3"]);
+  });
+
+  it("matches the fixed nodes through the supplied labels", () => {
+    expect(searchTargets(TREE, "語音", labels).map((t) => targetKey(t))).toEqual(["voice"]);
+    expect(searchTargets(TREE, "首頁", labels).map((t) => targetKey(t))).toEqual(["home"]);
+  });
+});

--- a/src/lib/library/quickSwitch.ts
+++ b/src/lib/library/quickSwitch.ts
@@ -1,0 +1,192 @@
+/**
+ * Ranking for the ⌘K quick switcher (issue #332).
+ *
+ * The tree in the sidebar is aim-and-click: you have to know where a thing
+ * lives before you can reach it. This module is the other half — name it and
+ * go. It answers exactly one question ("which of these places best matches
+ * what the user typed?") and knows nothing about React, the store, or i18n, so
+ * the ordering can be pinned down by tests instead of by clicking around.
+ *
+ * The matcher is deliberately a small greedy subsequence scan rather than a
+ * fuzzy-search engine: a folder list is tens of rows, not tens of thousands,
+ * and a scorer you can read in one sitting is worth more here than one that
+ * squeezes out the last few percent of ranking quality.
+ */
+
+/** Somewhere the palette can jump to. */
+export type QuickTarget =
+  | { kind: "home" }
+  | { kind: "folder"; id: string; name: string; count: number }
+  | { kind: "unassigned"; count: number }
+  | { kind: "voice" }
+  | { kind: "org"; orgId: string; orgName: string }
+  | { kind: "orgFolder"; orgId: string; orgName: string; id: string; name: string }
+  | { kind: "recording"; id: string; title: string; createdAt: number; folderId: string | null };
+
+/**
+ * The three fixed nodes are named by the dictionary, not by the data, so the
+ * caller hands their translated labels in rather than this module importing
+ * `i18n` (which would drag the store into a pure, node-tested module).
+ */
+export interface QuickSwitchLabels {
+  home: string;
+  unassigned: string;
+  voice: string;
+}
+
+/** Stable identity for a target — for React keys and selection comparison. */
+export function targetKey(t: QuickTarget): string {
+  switch (t.kind) {
+    case "home":
+      return "home";
+    case "folder":
+      return `folder:${t.id}`;
+    case "unassigned":
+      return "unassigned";
+    case "voice":
+      return "voice";
+    case "org":
+      return `org:${t.orgId}`;
+    case "orgFolder":
+      return `orgFolder:${t.orgId}:${t.id}`;
+    case "recording":
+      return `recording:${t.id}`;
+  }
+}
+
+/** The text a target is matched against. */
+export function targetLabel(t: QuickTarget, labels: QuickSwitchLabels): string {
+  switch (t.kind) {
+    case "home":
+      return labels.home;
+    case "unassigned":
+      return labels.unassigned;
+    case "voice":
+      return labels.voice;
+    case "folder":
+    case "orgFolder":
+      return t.name;
+    case "org":
+      return t.orgName;
+    case "recording":
+      return t.title;
+  }
+}
+
+/** What an empty query scores: a constant, so "no query" means "everything". */
+export const EMPTY_QUERY_SCORE = 0;
+
+/** Characters that make the next character read as the start of a word. */
+const WORD_BREAKS = new Set([" ", "-", "_", "/", "·"]);
+
+const MATCHED_CHAR = 10;
+const WORD_START = 15;
+const CONTIGUOUS = 12;
+/** A skipped run costs a little, but never enough to swamp a real match. */
+const MAX_GAP_PENALTY = 8;
+/** How far a late first match can be punished for starting late. */
+const MAX_OFFSET_PENALTY = 20;
+const PREFIX = 300;
+const EXACT = 1000;
+
+function isWordStart(text: string, at: number): boolean {
+  return at === 0 || WORD_BREAKS.has(text[at - 1]);
+}
+
+/**
+ * How well `query` matches `text` — `null` when it doesn't at all, otherwise a
+ * score where higher is better. Case-insensitive, and matched as a SUBSEQUENCE
+ * of the query's characters, so `和車` finds `和運租車` and `lib scr` finds
+ * `LibraryScreen` (whitespace is stripped from the query, never from the text).
+ */
+export function scoreMatch(query: string, text: string): number | null {
+  const trimmed = query.trim().toLowerCase();
+  const needle = trimmed.replace(/\s+/g, "");
+  if (needle.length === 0) return EMPTY_QUERY_SCORE;
+
+  const hay = text.toLowerCase();
+  let score = 0;
+  let from = 0;
+  let prev = -1;
+  let firstAt = -1;
+
+  for (const ch of needle) {
+    const at = hay.indexOf(ch, from);
+    if (at < 0) return null;
+    if (firstAt < 0) firstAt = at;
+    score += MATCHED_CHAR;
+    if (isWordStart(hay, at)) score += WORD_START;
+    if (at === prev + 1) score += CONTIGUOUS;
+    else if (prev >= 0) score -= Math.min(at - prev - 1, MAX_GAP_PENALTY);
+    prev = at;
+    from = at + 1;
+  }
+
+  // A match that starts earlier is the one the user more likely meant.
+  score -= Math.min(firstAt, MAX_OFFSET_PENALTY);
+
+  if (hay === trimmed || hay === needle) return score + EXACT;
+  if (hay.startsWith(trimmed) || hay.startsWith(needle)) return score + PREFIX;
+  return score;
+}
+
+/** Navigation nodes sort ahead of recordings when scores tie. */
+function isNavigation(t: QuickTarget): boolean {
+  return t.kind !== "recording";
+}
+
+function isFolderish(t: QuickTarget): boolean {
+  return t.kind === "folder" || t.kind === "orgFolder";
+}
+
+interface Scored {
+  target: QuickTarget;
+  score: number;
+  /** Input position — the "natural order" an empty query has to preserve. */
+  index: number;
+}
+
+/**
+ * The palette's result list: everything that matches `query`, best first,
+ * capped at `limit`.
+ *
+ * With an EMPTY query this is the default listing rather than nothing — the
+ * navigation nodes in the order the caller supplied them, then the newest
+ * recordings — because a switcher that opens blank makes you type before it
+ * will admit what it can do.
+ */
+export function searchTargets(
+  targets: readonly QuickTarget[],
+  query: string,
+  labels: QuickSwitchLabels,
+  limit = 30
+): QuickTarget[] {
+  const blank = query.trim().length === 0;
+  const scored: Scored[] = [];
+  targets.forEach((target, index) => {
+    const score = scoreMatch(query, targetLabel(target, labels));
+    if (score === null) return;
+    scored.push({ target, score, index });
+  });
+
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    const navA = isNavigation(a.target);
+    const navB = isNavigation(b.target);
+    if (navA !== navB) return navA ? -1 : 1;
+    if (a.target.kind === "recording" && b.target.kind === "recording") {
+      if (a.target.createdAt !== b.target.createdAt) {
+        return b.target.createdAt - a.target.createdAt;
+      }
+    }
+    // Folder names only break ties once the user has typed: with a blank query
+    // the caller's own order IS the answer (home, folders, unassigned, …).
+    if (!blank && isFolderish(a.target) && isFolderish(b.target)) {
+      const byName = targetLabel(a.target, labels).localeCompare(targetLabel(b.target, labels));
+      if (byName !== 0) return byName;
+    }
+    return a.index - b.index;
+  });
+
+  return scored.slice(0, Math.max(0, limit)).map((s) => s.target);
+}


### PR DESCRIPTION
## What this changes

`⌘K` (`Ctrl+K` on Windows) opens a quick switcher over the main window. One field, one flat ranked list, covering everything you can navigate to at once:

- personal folders (with the same counts the sidebar shows)
- `Not filed yet` / `未分類`, `Voice typing`, `Home`
- orgs and their shared folders, when signed in
- every local recording, matched on its title

`↑` `↓` move, `↵` lands, `esc` closes; rows are clickable and highlight on hover. An empty query lists the tree rather than nothing, so the palette never opens blank. Each row carries a muted right-hand line saying where it lives — a recording shows its folder, an org folder shows its org — so two similarly named things are tellable apart without opening either.

It never opens over a running meeting, for the same reason the shell hides the tree there.

## Why

Reaching a recording meant aiming: pick the right folder in the tree, scan the grid, click the card. Three deliberate acts for something the user could already name in two keystrokes. The library's search box only helps *after* you have picked the scope it searches, so it can't answer "where did I put that one".

Closes #332. Related to #330 — the other half of the same complaint, that finding one specific meeting means remembering where you filed it.

## Notes for review

- **Every row is a place, never an action.** `↵` on a highlighted row can only navigate — it can't rename, delete, share or start a meeting. A palette that mixes destinations and verbs makes `↵` a gamble over a list your finger is already scrolling through. Actions stay on the row and on the card.
- **The ranking is a pure module** (`src/lib/library/quickSwitch.ts`) rather than logic buried in the component, so the ordering is pinned by tests instead of by clicking around. Greedy subsequence scan with word-start / contiguity / prefix / exact bonuses — a folder list is tens of rows, not tens of thousands, and a scorer you can read in one sitting is worth more here than the last few percent of ranking quality. CJK subsequences work (`和車` finds `和運租車`).
- **Counts come from the same pass the sidebar uses** (`buildOwnershipIndex` + `countByNode` from `lib/library/scope`), so a row means the same thing in both places — the invariant #195 exists to protect.
- **No new dependency.** Built on the `radix-ui` `Dialog` primitive already used by `ui/sheet.tsx`; no `ui/dialog.tsx` was added since nothing else needs one yet.
- Org folders are listed from the cache `useLibraryTree` already holds. Opening the palette warms `ensureOrgFolders` for the next open; it never blocks on a fetch, so what isn't cached simply isn't listed.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes — 29 files, 325 tests
- [ ] Ran the app (`bun run tauri dev`) and exercised the change
- [x] Added or updated tests — 18 new cases in `src/lib/library/quickSwitch.test.ts`
- [x] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts`

> Not yet exercised in a running app — the automated gate is green, but somebody should press `⌘K` before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
