### PR TITLE
[feature] an agent can pull recordings from the account's other devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Parley runs a local Model Context Protocol server. Point your MCP client at it �
 claude mcp add --transport http parley http://127.0.0.1:3011/mcp
 ```
 
-The exact endpoint, a ready-to-paste command, and a live view of what your client is doing are in **Settings → MCP Server**. 52 tools, in six groups:
+The exact endpoint, a ready-to-paste command, and a live view of what your client is doing are in **Settings → MCP Server**. 54 tools, in six groups:
 
 | Group | What it reaches | Tools |
 | --- | --- | --- |
 | **The meeting happening now** | What is on screen, what has been said, the checklist beside it | `get_app_context`, `get_focused_content`, `get_transcript`, `list_todos`, `add_todo`, `check_todo`, `list_evaluations` |
-| **Everything you have recorded** | Full-text search and full reads across history | `search_meetings`, `list_recordings`, `get_recording`, `rename_recording` |
+| **Everything you have recorded** | Full-text search and full reads across history, on this device and your others | `search_meetings`, `list_recordings`, `get_recording`, `rename_recording`, `list_cloud_recordings`, `download_cloud_recording` |
 | **The library, organized** | Personal folders, filing, bulk text import, deletion | `list_folders`, `create_folder`, `rename_folder`, `delete_folder`, `move_recording_to_folder`, `import_transcript`, `delete_recording` |
 | **Your team's shared space** | The org side, with the same permissions the app enforces | `list_orgs`, `list_org_recordings`, `list_org_folders`, `create_org_folder`, `share_recording_to_org`, `move_org_recording_to_folder`, `copy_org_recording_to_personal`, `delete_org_recording` |
 | **Hand over the analysis** | Writing findings, action items and the debrief back into the app | `set_recording_analysis`, `update_recording_meta`, `list_findings`, `set_findings`, `update_finding`, `upsert_eval_template`, `upsert_todo_template` |

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -362,9 +362,9 @@ fn now_ms() -> u64 {
 
 /// Coarse read/write classification for the activity feed, by tool-name verb.
 fn tool_kind(name: &str) -> &'static str {
-    const WRITE_VERBS: [&str; 13] = [
+    const WRITE_VERBS: [&str; 14] = [
         "upsert_", "delete_", "add_", "remove_", "check_", "set_", "update_", "rename_", "move_",
-        "share_", "copy_", "create_", "import_",
+        "share_", "copy_", "create_", "import_", "download_",
     ];
     if WRITE_VERBS.iter().any(|v| name.starts_with(v)) {
         "write"
@@ -676,8 +676,10 @@ fn tools() -> Vec<Value> {
              cards saved before it existed = state unknown). Optional text query filters by \
              title + transcript snippet; `since` keeps only recordings created at/after that \
              epoch-ms timestamp — the cheap way for an external analyst to poll for new \
-             recordings. Org-shared recordings live in the cloud — list those with \
-             list_org_recordings.",
+             recordings. This is THIS DEVICE only: recordings made on the user's other \
+             devices sit in the cloud until pulled down — find those with \
+             list_cloud_recordings. Org-shared recordings live in the cloud too — list \
+             those with list_org_recordings.",
             json!({
                 "type": "object",
                 "properties": {
@@ -686,6 +688,47 @@ fn tools() -> Vec<Value> {
                     "since": { "type": "number", "description": "Only recordings with createdAt >= this epoch-ms timestamp." },
                     "limit": { "type": "number", "description": "Max results (default 50)." }
                 }
+            }),
+        ),
+        tool(
+            "list_cloud_recordings",
+            "List the account's recordings across all devices",
+            "List the signed-in account's PERSONAL cloud mirror — including recordings \
+             made on the user's other devices, which never appear in list_recordings \
+             until downloaded. Same summary cards as list_recordings plus `sync`: \
+             \"cloud\" (only on another device — not on this one yet), \"stale\" (a local \
+             copy exists but the cloud one is newer, e.g. another device re-analyzed \
+             it), or \"synced\" (this device is current). Pass pending: true for exactly \
+             the set this device is missing or behind on. Pull one down with \
+             download_cloud_recording. Requires the user to be signed in with sync \
+             enabled. This is the personal library — an org's shared space is \
+             list_org_recordings.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Case-insensitive text filter over title + snippet." },
+                    "since": { "type": "number", "description": "Only recordings with createdAt >= this epoch-ms timestamp." },
+                    "limit": { "type": "number", "description": "Max results (default 50)." },
+                    "pending": { "type": "boolean", "description": "Only what this device lacks: sync is \"cloud\" or \"stale\"." }
+                }
+            }),
+        ),
+        tool(
+            "download_cloud_recording",
+            "Download one of the account's cloud recordings to this device",
+            "Pull a recording from the account's personal cloud onto THIS device — the \
+             transcript, the saved analysis, and the audio when the cloud copy has it. \
+             Afterwards it is a normal local recording: it shows up in list_recordings, \
+             is readable with get_recording, searchable with search_meetings, and \
+             openable in replay. Re-downloading a \"stale\" entry refreshes the local \
+             copy from the cloud. Get ids from list_cloud_recordings. This is the \
+             personal library — the org equivalent is copy_org_recording_to_personal.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "Cloud recording id (from list_cloud_recordings)." }
+                },
+                "required": ["id"]
             }),
         ),
         tool(
@@ -1286,6 +1329,29 @@ async fn call_tool(state: &HttpState, params: Value) -> anyhow::Result<Value> {
                     "id": required_str(&args, "id")?,
                     "folderId": args.get("folderId").cloned().unwrap_or(Value::Null)
                 }),
+            )
+            .await?
+        }
+        // The personal cloud mirror lives behind the account's bearer token, which
+        // only the frontend holds — so both of these are RPCs into the app.
+        "list_cloud_recordings" => {
+            call_frontend(
+                state,
+                "list_cloud_recordings",
+                json!({
+                    "query": args.get("query").cloned().unwrap_or(Value::Null),
+                    "since": args.get("since").cloned().unwrap_or(Value::Null),
+                    "limit": args.get("limit").cloned().unwrap_or(Value::Null),
+                    "pending": args.get("pending").cloned().unwrap_or(Value::Null)
+                }),
+            )
+            .await?
+        }
+        "download_cloud_recording" => {
+            call_frontend(
+                state,
+                "download_cloud_recording",
+                json!({ "id": required_str(&args, "id")? }),
             )
             .await?
         }
@@ -2513,11 +2579,31 @@ mod tests {
     }
 
     #[test]
+    fn pulling_a_cloud_recording_counts_as_a_write() {
+        // It puts a recording on this device's disk, so the activity log must not
+        // file it away as a harmless read.
+        assert_eq!(tool_kind("list_cloud_recordings"), "read");
+        assert_eq!(tool_kind("download_cloud_recording"), "write");
+    }
+
+    #[test]
     fn recording_downloads_get_a_longer_deadline_than_bookkeeping() {
         // A meeting's audio can take far longer than a folder rename; timing the
         // download out would report failure while the app is still downloading.
         let bookkeeping = rpc_timeout("rename_folder");
         assert!(rpc_timeout("download_cloud_recording") > bookkeeping);
         assert!(rpc_timeout("copy_org_recording_to_personal") > bookkeeping);
+    }
+
+    #[test]
+    fn every_tool_name_is_unique() {
+        let names: Vec<String> = tools()
+            .iter()
+            .filter_map(|t| t.get("name")?.as_str().map(str::to_string))
+            .collect();
+        let mut unique = names.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(names.len(), unique.len(), "duplicate tool name in tools()");
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1971,10 +1971,25 @@ fn speaker_label(names: &Value, source: &str, speaker: i64) -> String {
 
 // ── RPC bridge: enqueue a command, wait for the frontend's result ─────────────
 
+/// How long to wait for the frontend to answer. Most RPCs are local bookkeeping
+/// or a small JSON round trip and land in a couple of poll ticks. The two that
+/// pull a whole recording down from the cloud are bounded by the audio blob's
+/// size and the user's connection instead — and timing those out is worse than
+/// slow, because the download keeps running in the app and the caller is told it
+/// failed.
+fn rpc_timeout(action: &str) -> std::time::Duration {
+    match action {
+        "download_cloud_recording" | "copy_org_recording_to_personal" => {
+            std::time::Duration::from_secs(180)
+        }
+        _ => std::time::Duration::from_secs(20),
+    }
+}
+
 /// Enqueue a command carrying an id and wait for the frontend to execute it and
 /// append `{ id, ok, data|error }` to the results file. The frontend polls the
 /// queue every ~1.5s, so a round trip is typically 2–3s; cloud operations (org
-/// listing/moves) add their own network time. Times out after 20s.
+/// listing/moves) add their own network time. See {@link rpc_timeout}.
 async fn call_frontend(state: &HttpState, action: &str, args: Value) -> anyhow::Result<Value> {
     use std::io::Write;
     let id = new_id();
@@ -1993,7 +2008,7 @@ async fn call_frontend(state: &HttpState, action: &str, args: Value) -> anyhow::
     // timers suspended, so without this kick the poll loop may never run.
     let _ = state.app.emit(SESSION_COMMANDS_EVENT, ());
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + rpc_timeout(action);
     loop {
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         if let Some(result) = find_result(&state.results_path, &id) {
@@ -2495,5 +2510,14 @@ mod tests {
         assert_eq!(tool_kind("add_dictionary_phrase"), "write");
         assert_eq!(tool_kind("update_dictionary_phrase"), "write");
         assert_eq!(tool_kind("delete_dictionary_phrase"), "write");
+    }
+
+    #[test]
+    fn recording_downloads_get_a_longer_deadline_than_bookkeeping() {
+        // A meeting's audio can take far longer than a folder rename; timing the
+        // download out would report failure while the app is still downloading.
+        let bookkeeping = rpc_timeout("rename_folder");
+        assert!(rpc_timeout("download_cloud_recording") > bookkeeping);
+        assert!(rpc_timeout("copy_org_recording_to_personal") > bookkeeping);
     }
 }

--- a/src/lib/sessionCommands.ts
+++ b/src/lib/sessionCommands.ts
@@ -51,6 +51,10 @@ function argStr(v: unknown): string {
   return typeof v === "string" ? v : (JSON.stringify(v) ?? "");
 }
 
+/** Why the personal-cloud tools can't run — the same fix for both. */
+const CLOUD_SYNC_OFF =
+  "cloud sync is off — sign in to Parley Cloud and enable sync in Settings";
+
 /** Coerce a loosely-shaped severity into a valid {@link TimelineEvent} severity. */
 function normalizeSeverity(v: unknown): TimelineEvent["severity"] {
   if (v === "critical") return "critical";
@@ -534,6 +538,65 @@ async function rpcImportTranscript(a: RpcArgs): Promise<unknown> {
   return { imported, failed, folderId, folder: folderName || null };
 }
 
+/**
+ * The account's cloud mirror, each entry tagged with where it stands on THIS
+ * device: "cloud" = recorded elsewhere and not here yet, "stale" = the cloud copy
+ * is newer than the local one, "synced" = this device is current. Local-only
+ * entries are dropped — those are already list_recordings' job.
+ *
+ * This is how an agent on a secondary device sees what the primary one recorded.
+ */
+async function rpcListCloudRecordings(a: RpcArgs): Promise<unknown> {
+  if (!syncEnabled()) throw new Error(CLOUD_SYNC_OFF);
+  const { listCloudRecordings, listMergedHistory } = await import("./cloud/sync");
+  // Fetch the cloud list first purely so a failed fetch THROWS here.
+  // listMergedHistory falls back to local-only when the cloud is unreachable,
+  // which would read as "nothing to download" — the one wrong answer for a
+  // caller whose whole purpose is finding what to download.
+  await listCloudRecordings();
+
+  const query = (typeof a.query === "string" ? a.query : "").trim().toLowerCase();
+  const since = typeof a.since === "number" ? a.since : 0;
+  const limit = typeof a.limit === "number" ? Math.max(0, a.limit) : 50;
+  const pending = a.pending === true;
+
+  const matches = (await listMergedHistory()).filter(
+    (e) =>
+      e.sync !== "local" &&
+      (!pending || e.sync === "cloud" || e.sync === "stale") &&
+      e.createdAt >= since &&
+      (!query ||
+        e.title.toLowerCase().includes(query) ||
+        (e.snippet ?? "").toLowerCase().includes(query)),
+  );
+  return {
+    recordings: matches.slice(0, limit),
+    total: matches.length,
+    returned: Math.min(matches.length, limit),
+  };
+}
+
+/**
+ * Pull one of the account's cloud recordings onto this device — the MCP trigger
+ * for what the library grid does when you click a "cloud" card.
+ */
+async function rpcDownloadCloudRecording(a: RpcArgs): Promise<unknown> {
+  const id = argStr(a.id);
+  if (!id) throw new Error("id is required");
+  if (!syncEnabled()) throw new Error(CLOUD_SYNC_OFF);
+  const { listCloudRecordings, downloadCloudEntry } = await import("./cloud/sync");
+  // The summary carries hasAudio + updatedAt, which the download needs to fetch
+  // the blob and clear the stale flag afterwards.
+  const rec = (await listCloudRecordings()).find((r) => r.id === id);
+  if (!rec) {
+    throw new Error(`no cloud recording with id ${id} — get ids from list_cloud_recordings`);
+  }
+  await downloadCloudEntry({ id: rec.id, hasAudio: rec.hasAudio, cloudUpdatedAt: rec.updatedAt });
+  const { emitHistoryUpdated } = await import("./history/history");
+  await emitHistoryUpdated(id);
+  return { id, title: rec.title, hasAudio: rec.hasAudio, downloaded: true };
+}
+
 async function rpcCopyOrgRecordingToPersonal(a: RpcArgs): Promise<unknown> {
   const id = argStr(a.id);
   const { saveOrgRecordingToPersonal } = await import("./cloud/sync");
@@ -594,6 +657,8 @@ const RPC_HANDLERS = new Map<string, (a: RpcArgs) => Promise<unknown>>([
   ["share_recording_to_org", rpcShareRecordingToOrg],
   ["move_recording_to_org", rpcMoveRecordingToOrg],
   ["import_transcript", rpcImportTranscript],
+  ["list_cloud_recordings", rpcListCloudRecordings],
+  ["download_cloud_recording", rpcDownloadCloudRecording],
   ["copy_org_recording_to_personal", rpcCopyOrgRecordingToPersonal],
   ["delete_org_recording", rpcDeleteOrgRecording],
   ["delete_recording", rpcDeleteRecording],


### PR DESCRIPTION
## What this changes

Two new MCP tools let an agent reach the recordings an account made on its **other** devices, not just the ones sitting on this one:

- **`list_cloud_recordings`** — the account's personal cloud mirror, each entry tagged with `sync`: `"cloud"` (recorded elsewhere, not on this device yet), `"stale"` (a local copy exists but the cloud one is newer), or `"synced"`. Pass `pending: true` for exactly the set this device is missing or behind on. Supports the same `query` / `since` / `limit` filters as `list_recordings`.
- **`download_cloud_recording`** — pulls one down: transcript, saved analysis, and the audio when the cloud copy has it. Afterwards it is an ordinary local recording — it appears in `list_recordings`, reads with `get_recording`, is searchable with `search_meetings`, and opens in replay. Re-downloading a `"stale"` entry refreshes the local copy.

Both are RPCs into the app rather than plain Rust, because the account's bearer token lives in the frontend.

## Why

Parley Cloud already mirrors an account's recordings across its devices — the library grid shows cloud-only entries and downloads them on click. MCP could not reach any of that: `list_recordings` reads local disk only, so an agent on a secondary device was blind to everything recorded elsewhere until a human clicked the card.

The motivating shape: many machines record, a few machines analyze. The analyzing machines need to pull work down on their own.

Until now the only agent-drivable path between devices was the org one (`share_recording_to_org` -> `copy_org_recording_to_personal`), which requires deliberately publishing each recording into a shared space. For one person's own devices that is the wrong mechanism.

### Also here: a timeout fix

`call_frontend` gave every RPC the same 20s deadline. That is generous for folder bookkeeping but short for pulling a meeting's audio down — the tool reports failure while the app is still downloading, and the caller retries work that was about to succeed. The deadline is now per-action: 180s for the two RPCs that fetch a whole recording, 20s for everything else.

This is a pre-existing bug that **`copy_org_recording_to_personal` already had**; it is fixed here too rather than left for the org path to keep hitting. Split into its own commit so it reads independently.

## How it was verified

- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run` passes (307 tests)
- [x] Added or updated tests — `cargo test --lib` passes (45 tests), 3 new: `download_cloud_recording` classifies as a write (it puts a file on disk, so the activity log must not treat it as a harmless read), download RPCs get a longer deadline than bookkeeping, and every tool name in `tools()` is unique
- [ ] Ran the app (`bun run tauri dev`) and exercised the change
- [ ] Added new user-facing strings to **both** `zh-TW` and `en` in `src/i18n/messages.ts`

**Not verified end-to-end on two real machines.** The type checking, unit tests and wiring are covered; an actual A -> cloud -> B pull has not been exercised on hardware. Worth doing before relying on it.

No new i18n keys: this is MCP surface only, no UI strings. No backend contract changes either — `/recordings`, `/recordings/:id/meta` and `/recordings/:id/audio` were already in use by the library grid.

## Notes for review

- `list_cloud_recordings` deliberately calls `listCloudRecordings()` before `listMergedHistory()`. The latter falls back to local-only when the cloud is unreachable, which would surface as "nothing to download" — the one wrong answer for a caller whose entire purpose is finding what to download. The extra call is there to make a failed fetch throw.
- `list_recordings`' description now says explicitly that it is *this device only* and points at the new tool, so an agent does not conclude a recording is missing when it is merely elsewhere.
