### PR TITLE
[feature] the app answers a right-click, and remembers where you have been

### DIFF
--- a/src/components/AnalysisErrorDialog.tsx
+++ b/src/components/AnalysisErrorDialog.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle, RefreshCw, Settings, X } from "lucide-react";
 import { useStore } from "../lib/store";
 import { hasProviderKey } from "../lib/ai/settings";
 import { PROVIDER_BY_ID } from "../lib/ai/providers";
-import { openSettings } from "../lib/nav";
+import { openSettings } from "../lib/nav/settings";
 import { runAnalysis } from "../lib/analysis/engine";
 import { useI18n } from "../i18n";
 import { log } from "../lib/log";

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -12,7 +12,7 @@ import { stopMockStream } from "../lib/mockStream";
 import { isMac } from "../lib/platform";
 import { isTauri } from "../lib/tauriEvents";
 import { beginMeeting } from "../lib/meeting/start";
-import { openSettings } from "../lib/nav";
+import { openSettings } from "../lib/nav/settings";
 import { useI18n } from "../i18n";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/components/library/LibraryCards.tsx
+++ b/src/components/library/LibraryCards.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import {
+  AudioLines,
   Check,
   Clock,
   CloudCheck,
@@ -24,6 +25,19 @@ import {
 } from "lucide-react";
 import { useI18n } from "../../i18n";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+  openMenuFromKeyboard,
+  preventFocusRestore,
+} from "@/components/ui/context-menu";
 import type { Folder as LocalFolder } from "../../lib/history/folders";
 import type { HistoryCardItem, HistorySyncState } from "../../lib/cloud/sync";
 import type { CloudOrg } from "../../lib/cloud/types";
@@ -91,6 +105,37 @@ export function SyncIcon({ sync, signedIn }: Readonly<{ sync: HistorySyncState; 
   );
 }
 
+/**
+ * Which of the four actions a given card can actually offer.
+ *
+ * Shared because a card now exposes them twice — the hover toolbar and the
+ * right-click menu — and a rule that lived in only one of them would let the
+ * menu offer a rename the toolbar already knows is impossible.
+ */
+function cardCapabilities(
+  o: Readonly<{ isOrgContext: boolean; isCloudOnly: boolean; folderCount: number }>
+): { canMove: boolean; canRename: boolean } {
+  return {
+    // An org card files into org folders (so it needs at least one); a personal
+    // one needs local meta to retag, which a cloud-only card does not have.
+    canMove: o.isOrgContext ? o.folderCount > 0 : !o.isCloudOnly,
+    canRename: !o.isCloudOnly && !o.isOrgContext,
+  };
+}
+
+/** Where a card can be filed: the scope's folders, plus taking it back out of
+ *  one. Shared so the toolbar popover and the right-click submenu can't drift
+ *  into naming the same destination two different things. */
+function moveTargets(
+  t: ReturnType<typeof useI18n>["t"],
+  folders: LocalFolder[]
+): { id: string | null; name: string }[] {
+  return [
+    { id: null, name: t("history.move.rootOption") },
+    ...folders.map((f) => ({ id: f.id, name: f.name })),
+  ];
+}
+
 /** Shared scrim + popover chrome for the two card menus. */
 function MenuShell({
   title,
@@ -148,10 +193,7 @@ function MoveMenu({
 }>) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
-  const options: { id: string | null; name: string }[] = [
-    { id: null, name: t("history.move.rootOption") },
-    ...folders.map((f) => ({ id: f.id, name: f.name })),
-  ];
+  const options = moveTargets(t, folders);
   return (
     <div className="relative">
       <button
@@ -378,10 +420,11 @@ export function CardActions({
   onMove: (folderId: string | null) => void;
 }>) {
   const { t } = useI18n();
-  // An org card files into org folders (so it needs at least one); a personal
-  // one needs local meta to retag, which a cloud-only card does not have.
-  const canMove = isOrgContext ? folders.length > 0 : !isCloudOnly;
-  const canRename = !isCloudOnly && !isOrgContext;
+  const { canMove, canRename } = cardCapabilities({
+    isOrgContext,
+    isCloudOnly,
+    folderCount: folders.length,
+  });
   const deleteLabel = isOrgContext ? t("history.org.remove") : t("history.delete");
   return (
     <div className={className}>
@@ -461,9 +504,20 @@ export function LibraryCard({
   const isLive = entry.source === "live";
   const isCloudOnly = !isOrgContext && entry.sync === "cloud";
   const canShare = !isOrgContext && signedIn && orgs.length > 0;
+  const { canMove, canRename } = cardCapabilities({
+    isOrgContext,
+    isCloudOnly,
+    folderCount: folders.length,
+  });
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(entry.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const openRef = useRef<HTMLButtonElement>(null);
+  // The menu's close handler runs from a listener Radix registered on an earlier
+  // render, so reading `editing` through the closure can report the stale value
+  // and steal focus back off the name input.
+  const editingRef = useRef(editing);
+  editingRef.current = editing;
 
   function startEdit() {
     setDraft(entry.title);
@@ -489,6 +543,9 @@ export function LibraryCard({
         <div className="flex items-center gap-1">
           <input
             ref={inputRef}
+            // Right-clicking a text field has to reach the webview's own edit
+            // menu; without this the card's menu swallows cut/copy/paste.
+            onContextMenu={(ev) => ev.stopPropagation()}
             value={draft}
             onChange={(ev) => setDraft(ev.target.value)}
             onKeyDown={(ev) => {
@@ -554,7 +611,7 @@ export function LibraryCard({
       </div>
     </>
   );
-  return (
+  const card = (
     <div
       className={`group relative flex flex-col gap-2 rounded-lg border bg-card p-3 text-left transition hover:border-foreground/25 hover:shadow-sm ${
         isCloudOnly ? "border-dashed" : ""
@@ -584,8 +641,12 @@ export function LibraryCard({
         </div>
       ) : (
         <button
+          ref={openRef}
           type="button"
           onClick={onOpen}
+          // The card's only focusable element, so it is where a keyboard user is
+          // standing when they ask for the menu; the event bubbles to the trigger.
+          onKeyDown={openMenuFromKeyboard}
           className={`flex flex-col gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring ${
             isCloudOnly ? "opacity-70" : ""
           }`}
@@ -603,5 +664,74 @@ export function LibraryCard({
         </div>
       )}
     </div>
+  );
+
+  // A second way to reach the toolbar's own actions, not a second set of them —
+  // one that does not depend on noticing icons that only appear on hover, and
+  // that a keyboard can summon at all. Share is the one omission: picking an org
+  // and then answering copy-or-move is a flow, not a menu item.
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{card}</ContextMenuTrigger>
+      <ContextMenuContent
+        onCloseAutoFocus={(event) => {
+          preventFocusRestore(event);
+          // Closing without renaming should leave the keyboard where it was, and
+          // Radix's own restore aims at the trigger — a plain <div>, which
+          // cannot take focus, so it would drop to the body instead.
+          if (!editingRef.current) openRef.current?.focus();
+        }}
+      >
+        <ContextMenuLabel>{entry.title}</ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onOpen}>
+          <AudioLines className="size-3.5" />
+          {t("library.menu.open")}
+        </ContextMenuItem>
+        {canRename && (
+          <ContextMenuItem onSelect={startEdit}>
+            <Pencil className="size-3.5" />
+            {t("library.menu.rename")}
+          </ContextMenuItem>
+        )}
+        {canMove && (
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <FolderInput className="size-3.5" />
+              {t("library.menu.move")}
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {moveTargets(t, folders).map((target) => {
+                const current = (entry.folderId ?? null) === target.id;
+                return (
+                  <ContextMenuItem
+                    key={target.id ?? "__root"}
+                    disabled={current}
+                    onSelect={() => onMove(target.id)}
+                  >
+                    {target.id === null ? (
+                      <FolderClosed className="size-3.5" />
+                    ) : (
+                      <Folder className="size-3.5" />
+                    )}
+                    <span className="truncate">{target.name}</span>
+                    {current && <Check className="ml-auto size-3.5" />}
+                  </ContextMenuItem>
+                );
+              })}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        )}
+        <ContextMenuSeparator />
+        {/* No confirmation, deliberately: deleting a recording never had one —
+            the toolbar's trash icon goes straight through — and inventing one
+            here would make the same action behave differently depending on
+            which way you reached it. */}
+        <ContextMenuItem variant="destructive" disabled={busy} onSelect={onDelete}>
+          <Trash2 className="size-3.5" />
+          {isOrgContext ? t("library.menu.removeFromOrg") : t("library.menu.delete")}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -11,6 +11,7 @@ import { HomeScreen } from "../home/HomeScreen";
 import { AppSidebar } from "./AppSidebar";
 import { CommandPalette } from "./CommandPalette";
 import { useLibraryTree } from "./useLibraryTree";
+import { useNavShortcuts } from "../../lib/nav/useNavShortcuts";
 import { useStore, isMeetingActive, type AppMode } from "../../lib/store";
 
 const LibraryScreen = lazy(() =>
@@ -23,12 +24,18 @@ const LibraryScreen = lazy(() =>
  * something else: a RUNNING meeting, where the live coach owns the window.
  * Everything else — live idle, a loaded recording, the library — keeps the tree
  * on screen, so nothing is a mode you have to exit. (Settings is not a route
- * here: it opens as its own OS window, see lib/nav.ts.)
+ * here: it opens as its own OS window, see lib/nav/settings.ts.)
  */
 export function AppShell() {
   const appMode = useStore((s) => s.appMode);
   const meetingActive = useStore((s) => isMeetingActive(s.meetingStatus));
   const tree = useLibraryTree();
+
+  // Above the focused branch on purpose: back/forward stays bound during a
+  // running meeting so the keys don't die and revive with the tree. Pressing
+  // them there is harmless — navigateTo refuses to move while the coach owns
+  // the window, and a refusal leaves the stack alone.
+  useNavShortcuts();
 
   const focused = meetingActive;
 

--- a/src/components/shell/AppSidebar.tsx
+++ b/src/components/shell/AppSidebar.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import {
   AudioLines,
   Check,
@@ -13,6 +20,14 @@ import {
   Trash2,
   UsersRound,
 } from "lucide-react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "../ui/context-menu";
 import { buildOwnershipIndex, countByNode, nodeKey, type LibraryNode } from "../../lib/library/scope";
 import { beginMeeting } from "../../lib/meeting/start";
 import { useStore, type LibrarySelection } from "../../lib/store";
@@ -65,7 +80,7 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
 
   const selectLibrary = (sel: LibrarySelection) => openLibrary(sel);
 
-  return (
+  const nav = (
     <nav className="flex h-full min-h-0 w-full flex-col overflow-y-auto border-r bg-background/60 px-2 py-2">
       <button
         type="button"
@@ -221,6 +236,51 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
 
     </nav>
   );
+
+  // The tree's own menu. Rows carry their own (see Row), and stop the event
+  // there, so this one only answers right-clicks on the section headers and the
+  // empty space below the tree — where "what can I even do here" has no answer
+  // other than the ＋ hiding in a header until you hover it.
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{nav}</ContextMenuTrigger>
+      <ContextMenuContent onCloseAutoFocus={preventFocusRestore}>
+        <ContextMenuItem onSelect={() => setNewFolderOpen(true)}>
+          <FolderPlus className="size-3.5" />
+          {t("sidebar.menu.newFolder")}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/**
+ * Radix restores focus to whatever was focused before the menu opened. Every
+ * item here hands focus straight to a freshly mounted text input, and that
+ * restore yanks it back out — the input's blur handler then commits the
+ * untouched name, so Rename and New folder both look like they did nothing.
+ */
+function preventFocusRestore(event: Event) {
+  event.preventDefault();
+}
+
+/**
+ * macOS keyboards have no context-menu key and WebKit does not synthesise a
+ * `contextmenu` event from Shift+F10, so a row menu reached only by right-click
+ * would be mouse-only. Radix opens on the DOM event and nothing else, so
+ * dispatching a real one at the row's own corner is all it takes.
+ */
+function openMenuFromKeyboard(event: KeyboardEvent<HTMLElement>) {
+  if (event.key !== "ContextMenu" && !(event.key === "F10" && event.shiftKey)) return;
+  event.preventDefault();
+  const box = event.currentTarget.getBoundingClientRect();
+  event.currentTarget.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      clientX: box.left + 12,
+      clientY: box.bottom - 4,
+    })
+  );
 }
 
 /**
@@ -325,6 +385,12 @@ function Row({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(label);
   const inputRef = useRef<HTMLInputElement>(null);
+  const selectRef = useRef<HTMLButtonElement>(null);
+  // The menu's close handler runs from a listener Radix registered on an
+  // earlier render, so reading `editing` through the closure can report the
+  // stale value and steal focus back off the name input.
+  const editingRef = useRef(editing);
+  editingRef.current = editing;
 
   function startEdit() {
     setDraft(label);
@@ -343,6 +409,9 @@ function Row({
       <div className="flex shrink-0 items-center gap-1 rounded-md py-1 pr-1" style={pad}>
         <input
           ref={inputRef}
+          // Right-clicking a text field has to reach the webview's own edit
+          // menu; without this the sidebar's menu swallows cut/copy/paste.
+          onContextMenu={(e) => e.stopPropagation()}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
@@ -361,7 +430,11 @@ function Row({
     );
   }
 
-  return (
+  // Same two actions the hover icons run — the menu is a second way to reach
+  // them, not a second implementation of them.
+  const actionable = !!(onRename ?? onDelete);
+
+  const row = (
     <div
       className={`group/row flex shrink-0 items-center rounded-md transition-colors ${
         active
@@ -388,9 +461,13 @@ function Row({
         </button>
       )}
       <button
+        ref={selectRef}
         type="button"
         onClick={onSelect}
         onDoubleClick={onRename ? startEdit : undefined}
+        // The row's only focusable element, so it is where a keyboard user is
+        // standing when they ask for the menu; the event bubbles to the trigger.
+        onKeyDown={actionable ? openMenuFromKeyboard : undefined}
         className="flex min-w-0 flex-1 items-center gap-1.5 py-1.5 pl-1 pr-1 text-left text-sm"
       >
         <span className="shrink-0">{icon}</span>
@@ -434,6 +511,52 @@ function Row({
       )}
     </div>
   );
+
+  if (!actionable) return row;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger
+        asChild
+        // The whole sidebar is a trigger too (for "New folder" on empty space).
+        // Without this the one right-click opens both menus stacked.
+        onContextMenu={(e) => e.stopPropagation()}
+      >
+        {row}
+      </ContextMenuTrigger>
+      <ContextMenuContent
+        onCloseAutoFocus={(event) => {
+          preventFocusRestore(event);
+          // Closing without renaming should leave the keyboard where it was,
+          // and Radix's own restore aims at the trigger — a plain <div>, which
+          // cannot take focus, so it would drop to the body instead.
+          if (!editingRef.current) selectRef.current?.focus();
+        }}
+      >
+        <ContextMenuLabel>{label}</ContextMenuLabel>
+        <ContextMenuSeparator />
+        {onRename && (
+          <ContextMenuItem onSelect={startEdit}>
+            <Pencil className="size-3.5" />
+            {t("sidebar.menu.rename")}
+          </ContextMenuItem>
+        )}
+        {onDelete && (
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() => {
+              // Delete confirms with a blocking confirm() (useLibraryTree), and
+              // blocking mid-close leaves the menu painted over the sheet.
+              requestAnimationFrame(() => onDelete());
+            }}
+          >
+            <Trash2 className="size-3.5" />
+            {t("sidebar.menu.delete")}
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
 }
 
 /** Inline name composer, opened on demand from a section header's ＋. */
@@ -461,6 +584,9 @@ function NewNameInput({
     >
       <input
         ref={ref}
+        // See the rename input: the sidebar's menu would otherwise take the
+        // place of the webview's cut/copy/paste menu.
+        onContextMenu={(e) => e.stopPropagation()}
         value={value}
         placeholder={placeholder}
         onChange={(e) => setValue(e.target.value)}

--- a/src/components/shell/AppSidebar.tsx
+++ b/src/components/shell/AppSidebar.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type ReactNode,
-} from "react";
+import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   AudioLines,
   Check,
@@ -27,6 +20,8 @@ import {
   ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuTrigger,
+  openMenuFromKeyboard,
+  preventFocusRestore,
 } from "../ui/context-menu";
 import { buildOwnershipIndex, countByNode, nodeKey, type LibraryNode } from "../../lib/library/scope";
 import { beginMeeting } from "../../lib/meeting/start";
@@ -251,35 +246,6 @@ export function AppSidebar({ tree }: Readonly<{ tree: LibraryTree }>) {
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
-  );
-}
-
-/**
- * Radix restores focus to whatever was focused before the menu opened. Every
- * item here hands focus straight to a freshly mounted text input, and that
- * restore yanks it back out — the input's blur handler then commits the
- * untouched name, so Rename and New folder both look like they did nothing.
- */
-function preventFocusRestore(event: Event) {
-  event.preventDefault();
-}
-
-/**
- * macOS keyboards have no context-menu key and WebKit does not synthesise a
- * `contextmenu` event from Shift+F10, so a row menu reached only by right-click
- * would be mouse-only. Radix opens on the DOM event and nothing else, so
- * dispatching a real one at the row's own corner is all it takes.
- */
-function openMenuFromKeyboard(event: KeyboardEvent<HTMLElement>) {
-  if (event.key !== "ContextMenu" && !(event.key === "F10" && event.shiftKey)) return;
-  event.preventDefault();
-  const box = event.currentTarget.getBoundingClientRect();
-  event.currentTarget.dispatchEvent(
-    new MouseEvent("contextmenu", {
-      bubbles: true,
-      clientX: box.left + 12,
-      clientY: box.bottom - 4,
-    })
   );
 }
 

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -11,10 +11,10 @@ import {
   type QuickSwitchLabels,
   type QuickTarget,
 } from "../../lib/library/quickSwitch";
-import { loadHistoryEntry } from "../../lib/history/history";
+import { navigateTo, type Location } from "../../lib/nav/navigate";
+import { useShortcut } from "../../lib/shortcuts";
 import { isMeetingActive, useStore } from "../../lib/store";
 import { useI18n, type TranslationKey } from "../../i18n";
-import { log } from "../../lib/log";
 import type { LibraryTree } from "./useLibraryTree";
 
 /**
@@ -48,18 +48,18 @@ export function CommandPalette({ tree }: Readonly<{ tree: LibraryTree }>) {
   const activeRef = useRef<HTMLButtonElement>(null);
 
   // ⌘K / Ctrl+K toggles. The guard reads the store directly rather than the
-  // subscribed value so the listener never has to be re-registered.
-  useEffect(() => {
-    const onKeyDown = (e: globalThis.KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        if (isMeetingActive(useStore.getState().meetingStatus)) return;
-        setOpen((o) => !o);
-      }
-    };
-    globalThis.addEventListener("keydown", onKeyDown);
-    return () => globalThis.removeEventListener("keydown", onKeyDown);
-  }, []);
+  // subscribed value, so the binding never has to be re-registered.
+  // `whileTyping`: the palette's own search field has focus whenever it is
+  // open, so a ⌘K that respected the typing guard could open this thing but
+  // never close it again.
+  useShortcut(
+    { mod: true, key: "k" },
+    () => {
+      if (isMeetingActive(useStore.getState().meetingStatus)) return;
+      setOpen((o) => !o);
+    },
+    { whileTyping: true }
+  );
 
   // A meeting starting while the palette is up takes the window back.
   useEffect(() => {
@@ -148,45 +148,20 @@ export function CommandPalette({ tree }: Readonly<{ tree: LibraryTree }>) {
     activeRef.current?.scrollIntoView({ block: "nearest" });
   }, [active, count]);
 
+  /** A row is a PLACE, so opening one is a plain navigation — the switch that
+   *  used to live here is now lib/nav/navigate.ts, shared with back/forward. */
   async function activate(target: QuickTarget) {
-    const { openHome, openLibrary } = useStore.getState();
     // Close first: the palette must never sit over the route it just opened.
     setOpen(false);
-    switch (target.kind) {
-      case "home":
-        openHome();
-        return;
-      case "all":
-        openLibrary({ kind: "personal", node: { kind: "all" } });
-        return;
-      case "folder":
-        openLibrary({ kind: "personal", node: { kind: "folder", folderId: target.id } });
-        return;
-      case "unassigned":
-        openLibrary({ kind: "personal", node: { kind: "unassigned" } });
-        return;
-      case "voice":
-        openLibrary({ kind: "voice" });
-        return;
-      case "org":
-        tree.ensureOrgFolders(target.orgId);
-        openLibrary({ kind: "org", id: target.orgId, name: target.orgName, folderId: null });
-        return;
-      case "orgFolder":
-        openLibrary({ kind: "org", id: target.orgId, name: target.orgName, folderId: target.id });
-        return;
-      case "recording":
-        try {
-          // Switches the app to the study route itself.
-          await loadHistoryEntry(target.id);
-        } catch (e) {
-          log.error("palette: open failed", { id: target.id, error: String(e) });
-          toast.error(
-            t("shell.palette.openFailed", {
-              error: e instanceof Error ? e.message : String(e),
-            })
-          );
-        }
+    // The org's folders are fetched lazily; opening the org is also the moment
+    // its children become worth having.
+    if (target.kind === "org") tree.ensureOrgFolders(target.orgId);
+    const outcome = await navigateTo(locationOf(target));
+    if (outcome.status === "unavailable") {
+      const e = outcome.error;
+      toast.error(
+        t("shell.palette.openFailed", { error: e instanceof Error ? e.message : String(e) })
+      );
     }
   }
 
@@ -279,6 +254,38 @@ export function CommandPalette({ tree }: Readonly<{ tree: LibraryTree }>) {
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>
   );
+}
+
+/** The place a row stands for. Every row is one — that is the palette's whole
+ *  contract (see the header), so this mapping is total and can't fail. */
+function locationOf(target: QuickTarget): Location {
+  switch (target.kind) {
+    case "home":
+      return { kind: "home" };
+    case "all":
+      return { kind: "library", selection: { kind: "personal", node: { kind: "all" } } };
+    case "folder":
+      return {
+        kind: "library",
+        selection: { kind: "personal", node: { kind: "folder", folderId: target.id } },
+      };
+    case "unassigned":
+      return { kind: "library", selection: { kind: "personal", node: { kind: "unassigned" } } };
+    case "voice":
+      return { kind: "library", selection: { kind: "voice" } };
+    case "org":
+      return {
+        kind: "library",
+        selection: { kind: "org", id: target.orgId, name: target.orgName, folderId: null },
+      };
+    case "orgFolder":
+      return {
+        kind: "library",
+        selection: { kind: "org", id: target.orgId, name: target.orgName, folderId: target.id },
+      };
+    case "recording":
+      return { kind: "entry", id: target.id };
+  }
 }
 
 /** The icons match the sidebar's, so a row means the same thing in both. */

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Right-click menus, built from dropdown-menu.tsx's styling vocabulary on
+ * purpose: two menu surfaces in one app that don't look like the same menu is
+ * the failure this file exists to avoid. Keep the two in step when either moves.
+ */
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        // No sideOffset twin of the dropdown's: this content anchors to the
+        // pointer, so Radix omits side/sideOffset/align from its props entirely.
+        className={cn(
+          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  /** `destructive` reads the same here as it does on AlertDialogAction. */
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      className={cn(
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors",
+        "focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+        variant === "destructive" &&
+          "text-destructive focus:bg-destructive/10 focus:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/** Names what the menu acts on — a menu summoned by right-click carries no
+ *  other clue about which row it came from. */
+function ContextMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label>) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      className={cn("truncate px-2 py-1.5 text-xs font-medium text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+};

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ChevronRight } from "lucide-react";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
@@ -93,6 +94,94 @@ function ContextMenuSeparator({
   );
 }
 
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger>) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      className={cn(
+        // Item's classes with `cursor-default` in place of `cursor-pointer`:
+        // this row opens a submenu and commits nothing, so a click cursor would
+        // promise an action that clicking never performs.
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors",
+        "focus:bg-accent focus:text-accent-foreground",
+        // Staying lit while the submenu is open is the only thing on screen
+        // tying the floating panel back to the row that opened it.
+        "data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto size-3.5" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.SubContent
+        data-slot="context-menu-sub-content"
+        className={cn(
+          // Scrolls where the parent content clips: a submenu lists as many rows
+          // as the user has folders, and thirty of them would otherwise run off
+          // the bottom of the screen with no way to reach the rest.
+          "z-50 max-h-64 min-w-[8rem] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+/**
+ * Radix restores focus to whatever was focused before the menu opened. An item
+ * that hands focus straight to a freshly mounted text input loses it to that
+ * restore, and the input's blur handler then commits the untouched draft — so
+ * Rename looks like it did nothing at all.
+ */
+function preventFocusRestore(event: Event) {
+  event.preventDefault();
+}
+
+/**
+ * macOS keyboards have no context-menu key and WebKit does not synthesise a
+ * `contextmenu` event from Shift+F10, so a menu reached only by right-click
+ * would be mouse-only. Radix opens on the DOM event and nothing else, so
+ * dispatching a real one at the element's own corner is all it takes.
+ *
+ * Hang it on whatever inside the trigger actually takes focus — that is where a
+ * keyboard user is standing, and the event bubbles from there to the trigger.
+ */
+function openMenuFromKeyboard(event: React.KeyboardEvent<HTMLElement>) {
+  if (event.key !== "ContextMenu" && !(event.key === "F10" && event.shiftKey)) return;
+  event.preventDefault();
+  const box = event.currentTarget.getBoundingClientRect();
+  event.currentTarget.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      clientX: box.left + 12,
+      clientY: box.bottom - 4,
+    })
+  );
+}
+
 export {
   ContextMenu,
   ContextMenuTrigger,
@@ -100,4 +189,9 @@ export {
   ContextMenuItem,
   ContextMenuLabel,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+  preventFocusRestore,
+  openMenuFromKeyboard,
 };

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -158,6 +158,12 @@ export const zhTW = {
   "shell.palette.hint.close": "關閉",
   "shell.palette.recordingIn": "在 {folder}",
   "shell.palette.openFailed": "開啟錄音失敗：{error}",
+
+  // ── 側邊欄的右鍵選單 ──
+  "sidebar.menu.rename": "重新命名",
+  "sidebar.menu.delete": "刪除",
+  "sidebar.menu.newFolder": "新增資料夾",
+
   "library.all": "所有錄音",
   "library.all.empty": "還沒有任何錄音",
   "library.all.emptyHint": "開一場會議或匯入一段錄音,之後每一場都會依日期排在這裡。",
@@ -1158,6 +1164,12 @@ export const en = {
   "shell.palette.hint.close": "Close",
   "shell.palette.recordingIn": "in {folder}",
   "shell.palette.openFailed": "Couldn’t open that recording: {error}",
+
+  // ── Sidebar right-click menu ──
+  "sidebar.menu.rename": "Rename",
+  "sidebar.menu.delete": "Delete",
+  "sidebar.menu.newFolder": "New folder",
+
   "library.all": "All recordings",
   "library.all.empty": "No recordings yet",
   "library.all.emptyHint":

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -167,6 +167,13 @@ export const zhTW = {
   "sidebar.menu.delete": "刪除",
   "sidebar.menu.newFolder": "新增資料夾",
 
+  // ── 錄音卡片的右鍵選單 ──
+  "library.menu.open": "開啟",
+  "library.menu.rename": "重新命名",
+  "library.menu.move": "移到資料夾",
+  "library.menu.delete": "刪除",
+  "library.menu.removeFromOrg": "從組織移除",
+
   "library.all": "所有錄音",
   "library.all.empty": "還沒有任何錄音",
   "library.all.emptyHint": "開一場會議或匯入一段錄音,之後每一場都會依日期排在這裡。",
@@ -1175,6 +1182,13 @@ export const en = {
   "sidebar.menu.rename": "Rename",
   "sidebar.menu.delete": "Delete",
   "sidebar.menu.newFolder": "New folder",
+
+  // ── Recording card right-click menu ──
+  "library.menu.open": "Open",
+  "library.menu.rename": "Rename",
+  "library.menu.move": "Move to folder",
+  "library.menu.delete": "Delete",
+  "library.menu.removeFromOrg": "Remove from org",
 
   "library.all": "All recordings",
   "library.all.empty": "No recordings yet",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -158,6 +158,9 @@ export const zhTW = {
   "shell.palette.hint.close": "關閉",
   "shell.palette.recordingIn": "在 {folder}",
   "shell.palette.openFailed": "開啟錄音失敗：{error}",
+
+  // ── 上一頁／下一頁 ──
+  "nav.skippedMissing": "有錄音已經被刪除，已跳過。",
   "library.all": "所有錄音",
   "library.all.empty": "還沒有任何錄音",
   "library.all.emptyHint": "開一場會議或匯入一段錄音,之後每一場都會依日期排在這裡。",
@@ -1158,6 +1161,9 @@ export const en = {
   "shell.palette.hint.close": "Close",
   "shell.palette.recordingIn": "in {folder}",
   "shell.palette.openFailed": "Couldn’t open that recording: {error}",
+
+  // ── Back / forward ──
+  "nav.skippedMissing": "Skipped a recording that no longer exists.",
   "library.all": "All recordings",
   "library.all.empty": "No recordings yet",
   "library.all.emptyHint":

--- a/src/lib/ai/failureToast.ts
+++ b/src/lib/ai/failureToast.ts
@@ -1,7 +1,7 @@
 import { toast } from "sonner";
 import { translate } from "../../i18n/messages";
 import { useStore } from "../store";
-import { openSettings } from "../nav";
+import { openSettings } from "../nav/settings";
 import { log } from "../log";
 import { AI_FAILURE_HINT_KEY, classifyAiFailure } from "./failure";
 import type { LlmWorkload } from "../types";

--- a/src/lib/nav/history.test.ts
+++ b/src/lib/nav/history.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { createNavHistory, type NavStatus } from "./history";
+import { locationKey, type Location } from "./location";
+
+/**
+ * The back/forward contract, proven against a fake applier — the real one needs
+ * a store, a window and a recording on disk, none of which the rules below
+ * depend on.
+ */
+
+const home: Location = { kind: "home" };
+const all: Location = { kind: "library", selection: { kind: "personal", node: { kind: "all" } } };
+const voice: Location = { kind: "library", selection: { kind: "voice" } };
+const folder = (id: string): Location => ({
+  kind: "library",
+  selection: { kind: "personal", node: { kind: "folder", folderId: id } },
+});
+const entry = (id: string): Location => ({ kind: "entry", id });
+
+/**
+ * A stand-in for the app: every location applies unless it is named in
+ * `gone` (deleted recording) or `refuse` is on (a meeting owns the window).
+ * Records what it was asked to do so a test can see the skipped ones.
+ */
+function fakeApp(opts: { gone?: string[]; refuse?: boolean } = {}) {
+  const gone = new Set(opts.gone ?? []);
+  const tried: string[] = [];
+  return {
+    tried,
+    gone,
+    refuse: !!opts.refuse,
+    apply: async function (location: Location): Promise<NavStatus> {
+      tried.push(locationKey(location));
+      if (this.refuse) return "refused";
+      if (location.kind === "entry" && gone.has(location.id)) return "unavailable";
+      return "applied";
+    },
+  };
+}
+
+/** The stack under test, wired to a fake app. */
+function setup(opts: { gone?: string[]; refuse?: boolean; limit?: number } = {}) {
+  const app = fakeApp(opts);
+  const history = createNavHistory({
+    apply: (l) => app.apply(l),
+    limit: opts.limit,
+  });
+  return { app, history };
+}
+
+describe("nav history", () => {
+  it("walks back and forward through the places it recorded", async () => {
+    const { history } = setup();
+    history.record(home);
+    history.record(all);
+    history.record(folder("f1"));
+
+    expect(history.canGoBack()).toBe(true);
+    expect(history.canGoForward()).toBe(false);
+
+    expect(await history.back()).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(all);
+    expect(await history.back()).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(home);
+
+    // The bottom of the stack is the bottom: back again is a no-op, not a wrap.
+    expect(await history.back()).toEqual({ moved: false, skipped: 0 });
+    expect(history.current()).toEqual(home);
+
+    expect(await history.forward()).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(all);
+    await history.forward();
+    expect(history.current()).toEqual(folder("f1"));
+    expect(await history.forward()).toEqual({ moved: false, skipped: 0 });
+  });
+
+  it("starts out with nowhere to go", async () => {
+    const { history } = setup();
+    expect(history.current()).toBeNull();
+    expect(history.canGoBack()).toBe(false);
+    expect(await history.back()).toEqual({ moved: false, skipped: 0 });
+
+    history.record(home);
+    // One entry is where you ARE, not somewhere you can go back to.
+    expect(history.canGoBack()).toBe(false);
+  });
+
+  it("truncates the forward branch when you go somewhere new", async () => {
+    const { history } = setup();
+    history.record(home);
+    history.record(all);
+    history.record(folder("f1"));
+    await history.back();
+    await history.back();
+    expect(history.canGoForward()).toBe(true);
+
+    history.record(voice);
+    expect(history.canGoForward()).toBe(false);
+    expect(history.entries().map(locationKey)).toEqual([home, voice].map(locationKey));
+  });
+
+  it("ignores a re-visit of the place it is already on", () => {
+    const { history } = setup();
+    history.record(home);
+    history.record(all);
+    history.record({ kind: "library", selection: { kind: "personal", node: { kind: "all" } } });
+    expect(history.entries()).toHaveLength(2);
+  });
+
+  it("drops the oldest entries past the cap", async () => {
+    const { history } = setup({ limit: 3 });
+    history.record(folder("a"));
+    history.record(folder("b"));
+    history.record(folder("c"));
+    history.record(folder("d"));
+
+    expect(history.entries().map(locationKey)).toEqual(
+      [folder("b"), folder("c"), folder("d")].map(locationKey)
+    );
+    expect(history.current()).toEqual(folder("d"));
+    await history.back();
+    await history.back();
+    expect(history.current()).toEqual(folder("b"));
+    expect(history.canGoBack()).toBe(false);
+  });
+
+  it("skips a recording that was deleted, and forgets it", async () => {
+    const { app, history } = setup({ gone: ["rec-2"] });
+    history.record(home);
+    history.record(entry("rec-2"));
+    history.record(folder("f1"));
+
+    // Back walks past the deleted recording to the next real place.
+    expect(await history.back()).toEqual({ moved: true, skipped: 1 });
+    expect(history.current()).toEqual(home);
+    expect(app.tried).toEqual([locationKey(entry("rec-2")), locationKey(home)]);
+
+    // And it is out of the stack, so going forward again doesn't retry it.
+    app.tried.length = 0;
+    expect(await history.forward()).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(folder("f1"));
+    expect(app.tried).toEqual([locationKey(folder("f1"))]);
+  });
+
+  it("does not wedge when everything behind it is gone", async () => {
+    const { history } = setup({ gone: ["a", "b"] });
+    history.record(entry("a"));
+    history.record(entry("b"));
+    history.record(home);
+
+    expect(await history.back()).toEqual({ moved: false, skipped: 2 });
+    // Still standing where it was, with a stack that no longer holds the dead.
+    expect(history.current()).toEqual(home);
+    expect(history.entries()).toEqual([home]);
+    expect(history.canGoBack()).toBe(false);
+  });
+
+  it("leaves the stack alone when the app refuses to move", async () => {
+    const { app, history } = setup();
+    history.record(home);
+    history.record(entry("rec-1"));
+    history.record(folder("f1"));
+
+    // A meeting starts: navigation is declined, not impossible.
+    app.refuse = true;
+    expect(await history.back()).toEqual({ moved: false, skipped: 0 });
+    expect(history.current()).toEqual(folder("f1"));
+    expect(history.entries()).toHaveLength(3);
+
+    // The meeting ends and the same press works, with nothing lost.
+    app.refuse = false;
+    expect(await history.back()).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(entry("rec-1"));
+  });
+
+  it("ignores a second traversal while one is still applying", async () => {
+    const { history } = setup();
+    history.record(home);
+    history.record(all);
+    history.record(folder("f1"));
+
+    // Holding ⌘[ down: two presses land before the first load resolves.
+    const first = history.back();
+    const second = history.back();
+    expect(await second).toEqual({ moved: false, skipped: 0 });
+    expect(await first).toEqual({ moved: true, skipped: 0 });
+    expect(history.current()).toEqual(all);
+  });
+});

--- a/src/lib/nav/history.ts
+++ b/src/lib/nav/history.ts
@@ -1,0 +1,120 @@
+import { sameLocation, type Location } from "./location";
+
+/**
+ * Browser-style back/forward over {@link Location}s.
+ *
+ * The stack records where the app actually WENT, never where it was asked to
+ * go — see {@link NavApply}. That distinction is the whole reason this module
+ * takes its applier as a parameter instead of calling navigateTo directly: it
+ * keeps the traversal rules (below) provable without a store, a window or a
+ * Tauri backend.
+ */
+
+/**
+ * What replaying a location did.
+ *
+ * `refused` and `unavailable` are NOT the same failure, and conflating them
+ * breaks the stack in one of two ways:
+ *   • `refused` — the app declined to move at all (a running meeting owns the
+ *     window). Nothing is wrong with the location; it will be reachable again
+ *     in a minute. A traversal stops and leaves the stack exactly as it was.
+ *   • `unavailable` — the place is gone (the recording was deleted). It can
+ *     never be reached again, so it is DROPPED from the stack and the traversal
+ *     keeps walking. Skipping without dropping would leave a dead entry that
+ *     every future ⌘[ has to trip over again.
+ */
+export type NavStatus = "applied" | "refused" | "unavailable";
+
+export type NavApply = (location: Location) => Promise<NavStatus>;
+
+/** Outcome of a back/forward press. `skipped` counts locations that turned out
+ *  to be gone — the caller may want to say so rather than let the app appear to
+ *  jump two steps. */
+export interface TraversalResult {
+  moved: boolean;
+  skipped: number;
+}
+
+export interface NavHistoryOptions {
+  apply: NavApply;
+  /** Oldest entries fall off past this. A session left open for a week must not
+   *  grow the stack without bound. */
+  limit?: number;
+}
+
+export interface NavHistory {
+  /** Record a location the app has ALREADY arrived at (a fresh navigation, not
+   *  a traversal). Truncates whatever was ahead, like a browser. */
+  record: (location: Location) => void;
+  back: () => Promise<TraversalResult>;
+  forward: () => Promise<TraversalResult>;
+  canGoBack: () => boolean;
+  canGoForward: () => boolean;
+  /** Introspection for tests and diagnostics. */
+  entries: () => readonly Location[];
+  current: () => Location | null;
+  reset: () => void;
+}
+
+const DEFAULT_LIMIT = 50;
+
+export function createNavHistory({ apply, limit = DEFAULT_LIMIT }: NavHistoryOptions): NavHistory {
+  let stack: Location[] = [];
+  /** Index of where we are now; -1 while the stack is empty. */
+  let index = -1;
+  /** A traversal is async (loading a recording hits disk). Two overlapping ones
+   *  would interleave their index updates and land somewhere neither asked for,
+   *  which is exactly what holding ⌘[ down produces. */
+  let traversing = false;
+
+  function record(location: Location): void {
+    // Re-selecting the place you are already on is not a step. Without this,
+    // clicking the same folder twice buries the real previous place under a
+    // duplicate that ⌘[ then "goes back" to with no visible effect.
+    if (index >= 0 && sameLocation(stack[index], location)) return;
+    stack = stack.slice(0, index + 1);
+    stack.push(location);
+    if (stack.length > limit) stack = stack.slice(stack.length - limit);
+    index = stack.length - 1;
+  }
+
+  async function traverse(direction: -1 | 1): Promise<TraversalResult> {
+    if (traversing) return { moved: false, skipped: 0 };
+    traversing = true;
+    let skipped = 0;
+    try {
+      for (;;) {
+        const next = index + direction;
+        if (next < 0 || next >= stack.length) return { moved: false, skipped };
+        const status = await apply(stack[next]);
+        if (status === "applied") {
+          index = next;
+          return { moved: true, skipped };
+        }
+        if (status === "refused") return { moved: false, skipped };
+        // Gone: drop it and keep walking the same direction. Going back, the
+        // hole is BEHIND the cursor, so the cursor slides down with it.
+        stack.splice(next, 1);
+        if (direction === -1) index = next;
+        skipped += 1;
+      }
+    } finally {
+      traversing = false;
+    }
+  }
+
+  return {
+    record,
+    back: () => traverse(-1),
+    forward: () => traverse(1),
+    canGoBack: () => index > 0,
+    canGoForward: () => index < stack.length - 1,
+    entries: () => stack,
+    current: () => (index >= 0 ? stack[index] : null),
+    reset: () => {
+      stack = [];
+      index = -1;
+      traversing = false;
+    },
+  };
+}

--- a/src/lib/nav/location.ts
+++ b/src/lib/nav/location.ts
@@ -1,0 +1,48 @@
+import { nodeKey } from "../library/scope";
+import type { LibrarySelection } from "../store";
+
+/**
+ * A PLACE in the main window, named the same way by everything that goes there
+ * or remembers having been there (the ⌘K palette, the back/forward stack).
+ *
+ * Deliberately data, not behaviour: a location has to survive being put in a
+ * list and replayed later, which rules out closing over a handler.
+ *
+ * Settings is absent on purpose — it is its own OS window (see ./settings.ts),
+ * so it is never a place this window has "gone to" and never belongs in the
+ * back stack.
+ */
+export type Location =
+  | { kind: "home" }
+  | { kind: "library"; selection: LibrarySelection }
+  | { kind: "entry"; id: string };
+
+/** Stable identity of a library selection. The org NAME is left out: renaming
+ *  an org doesn't make its folder a different place. */
+function selectionKey(selection: LibrarySelection): string {
+  switch (selection.kind) {
+    case "personal":
+      return `personal:${nodeKey(selection.node)}`;
+    case "org":
+      return `org:${selection.id}:${selection.folderId ?? ""}`;
+    case "voice":
+      return "voice";
+  }
+}
+
+/** Stable identity for comparison — two locations are the same place iff their
+ *  keys match. */
+export function locationKey(location: Location): string {
+  switch (location.kind) {
+    case "home":
+      return "home";
+    case "library":
+      return `library:${selectionKey(location.selection)}`;
+    case "entry":
+      return `entry:${location.id}`;
+  }
+}
+
+export function sameLocation(a: Location, b: Location): boolean {
+  return locationKey(a) === locationKey(b);
+}

--- a/src/lib/nav/navigate.ts
+++ b/src/lib/nav/navigate.ts
@@ -1,0 +1,117 @@
+import { loadHistoryEntry } from "../history/history";
+import { isMeetingActive, useStore } from "../store";
+import { log } from "../log";
+import { createNavHistory, type NavStatus } from "./history";
+import { sameLocation, type Location } from "./location";
+
+export type { Location } from "./location";
+export { locationKey, sameLocation } from "./location";
+
+/**
+ * The ONE implementation of "go there".
+ *
+ * This started as `CommandPalette.activate`. It had to leave: back/forward
+ * replays a location the same way the palette opened it, and two copies of that
+ * switch would have drifted the first time a new kind of place was added.
+ */
+
+export interface NavOutcome {
+  status: NavStatus;
+  /** Only for `unavailable`: what the load actually failed with, so a caller
+   *  that has somewhere to show it (the palette's toast) still can. */
+  error?: unknown;
+}
+
+export interface NavigateOptions {
+  /** Traversals pass false — replaying the back stack must not push onto it. */
+  record?: boolean;
+}
+
+/**
+ * Where the window is right now, as a {@link Location} — or null when it is
+ * somewhere that isn't a destination (a live meeting, or an uploaded recording
+ * that hasn't been saved and therefore has no id to come back to).
+ */
+export function currentLocation(): Location | null {
+  const s = useStore.getState();
+  switch (s.appMode) {
+    case "home":
+      return { kind: "home" };
+    case "library":
+      return { kind: "library", selection: s.librarySelection };
+    case "study":
+      return s.loadedHistoryId ? { kind: "entry", id: s.loadedHistoryId } : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The window's back/forward stack. Only locations reached through
+ * {@link navigateTo} are in it: a call site that sets `appMode` on the store
+ * directly is invisible here, by design — the stack should hold places the user
+ * chose to go, not every state the app passed through.
+ */
+export const navHistory = createNavHistory({
+  apply: async (location) => (await navigateTo(location, { record: false })).status,
+});
+
+/**
+ * Move the window to `location`, without touching the back stack.
+ *
+ * The two kinds are guarded differently, on purpose:
+ *
+ * `home` / `library` — `store.openHome` and `store.openLibrary` already refuse
+ * silently while a meeting is running, so the verdict is read back off the
+ * store AFTER the call instead of the rule being re-decided here. Restating the
+ * guard would leave two copies to keep in sync, and a stack that records places
+ * the app refused to go is worse than no stack at all.
+ *
+ * `entry` — the store's `loadHistory` has NO meeting guard: it would replace a
+ * running meeting's transcript with the recording. Navigation holds that line
+ * itself, before the load.
+ */
+async function applyLocation(location: Location): Promise<NavOutcome> {
+  const store = useStore.getState();
+
+  if (location.kind === "entry") {
+    if (isMeetingActive(store.meetingStatus)) return { status: "refused" };
+    try {
+      // Switches the app to the study route itself.
+      await loadHistoryEntry(location.id);
+    } catch (error) {
+      // Deleted, or unreadable — either way it is not somewhere we can be. The
+      // back stack treats this as "drop it", so a recording removed mid-session
+      // can't wedge ⌘[ on an entry that will never load again.
+      log.warn("nav: entry unavailable", { id: location.id, error: String(error) });
+      return { status: "unavailable", error };
+    }
+    return { status: "applied" };
+  }
+
+  if (location.kind === "home") store.openHome();
+  else store.openLibrary(location.selection);
+
+  const after = currentLocation();
+  // This reads "the app IS where you asked", not "the app moved" — asking for
+  // the place you are already standing counts as applied, which is what both
+  // the palette and the stack want.
+  return after && sameLocation(after, location) ? { status: "applied" } : { status: "refused" };
+}
+
+/** Go to `location`, record the trip, and report what happened. */
+export async function navigateTo(
+  location: Location,
+  opts: NavigateOptions = {}
+): Promise<NavOutcome> {
+  const before = currentLocation();
+  const outcome = await applyLocation(location);
+  if (outcome.status === "applied" && opts.record !== false) {
+    // Seed the stack with wherever we came from, once. Without it the first
+    // jump of a session has nothing behind it and ⌘[ does nothing — the place
+    // you started in is a place you were.
+    if (navHistory.entries().length === 0 && before) navHistory.record(before);
+    navHistory.record(location);
+  }
+  return outcome;
+}

--- a/src/lib/nav/settings.ts
+++ b/src/lib/nav/settings.ts
@@ -1,6 +1,6 @@
-import type { SettingsCategory } from "./store";
-import { openSettingsWindow } from "./settingsSync";
-import { log } from "./log";
+import type { SettingsCategory } from "../store";
+import { openSettingsWindow } from "../settingsSync";
+import { log } from "../log";
 
 /**
  * Where "go somewhere else in the app" is decided — one module, so a call site

--- a/src/lib/nav/useNavShortcuts.ts
+++ b/src/lib/nav/useNavShortcuts.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect } from "react";
+import { toast } from "sonner";
+import { useShortcut } from "../shortcuts";
+import { useI18n } from "../../i18n";
+import { navHistory } from "./navigate";
+
+/**
+ * Browser back/forward for the main window: ⌘[ / ⌘← and ⌘] / ⌘→, plus the
+ * mouse's two side buttons.
+ *
+ * Safe to keep live while a meeting is running: every replay goes through
+ * navigateTo, which refuses to move the window out from under the live coach,
+ * and a refusal leaves the stack untouched.
+ */
+
+/** The extra buttons a five-button mouse sends. `MouseEvent.button` numbers
+ *  them 3 and 4; there is no named constant for either. */
+const MOUSE_BACK = 3;
+const MOUSE_FORWARD = 4;
+
+export function useNavShortcuts(): void {
+  const { t } = useI18n();
+
+  const traverse = useCallback(
+    (direction: "back" | "forward") => {
+      const run = direction === "back" ? navHistory.back : navHistory.forward;
+      void run().then((result) => {
+        // The user asked for one step and got more than one, because what was
+        // one step away has since been deleted. Say so, rather than let the
+        // window appear to overshoot.
+        if (result.skipped > 0) toast.info(t("nav.skippedMissing"));
+      });
+    },
+    [t]
+  );
+
+  const goBack = useCallback(() => traverse("back"), [traverse]);
+  const goForward = useCallback(() => traverse("forward"), [traverse]);
+
+  useShortcut({ mod: true, key: "[" }, goBack);
+  useShortcut({ mod: true, key: "ArrowLeft" }, goBack);
+  useShortcut({ mod: true, key: "]" }, goForward);
+  useShortcut({ mod: true, key: "ArrowRight" }, goForward);
+
+  useEffect(() => {
+    const onMouseUp = (e: MouseEvent) => {
+      if (e.button !== MOUSE_BACK && e.button !== MOUSE_FORWARD) return;
+      e.preventDefault();
+      if (e.button === MOUSE_BACK) goBack();
+      else goForward();
+    };
+    // mouseup, not mousedown: the side buttons also fire `auxclick`, and acting
+    // on the press would navigate before the button is released under it.
+    document.addEventListener("mouseup", onMouseUp);
+    return () => document.removeEventListener("mouseup", onMouseUp);
+  }, [goBack, goForward]);
+}

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTypingTarget,
+  matchShortcut,
+  shortcutFires,
+  type KeyStroke,
+  type ShortcutSpec,
+} from "./shortcuts";
+
+/**
+ * The two properties every global shortcut in the app leans on: a chord means
+ * exactly one thing, and none of them fire while the user is typing.
+ */
+
+const MAC = true;
+const PC = false;
+
+/** A keystroke with nothing held down; override what the case is about. */
+function stroke(overrides: Partial<KeyStroke> & { key: string }): KeyStroke {
+  return { metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, ...overrides };
+}
+
+const cmdK: ShortcutSpec = { mod: true, key: "k" };
+
+describe("matchShortcut", () => {
+  it("maps mod to ⌘ on macOS and Ctrl elsewhere", () => {
+    const meta = stroke({ key: "k", metaKey: true });
+    const ctrl = stroke({ key: "k", ctrlKey: true });
+
+    expect(matchShortcut(meta, cmdK, MAC)).toBe(true);
+    expect(matchShortcut(ctrl, cmdK, MAC)).toBe(false);
+
+    expect(matchShortcut(ctrl, cmdK, PC)).toBe(true);
+    expect(matchShortcut(meta, cmdK, PC)).toBe(false);
+  });
+
+  it("treats mod as exclusive, so Ctrl+⌘ is a different chord", () => {
+    const both = stroke({ key: "k", metaKey: true, ctrlKey: true });
+    expect(matchShortcut(both, cmdK, MAC)).toBe(false);
+    expect(matchShortcut(both, cmdK, PC)).toBe(false);
+  });
+
+  it("does not match a bare key when a modifier is held", () => {
+    const spec: ShortcutSpec = { key: "k" };
+    expect(matchShortcut(stroke({ key: "k" }), spec, MAC)).toBe(true);
+    expect(matchShortcut(stroke({ key: "k", metaKey: true }), spec, MAC)).toBe(false);
+    expect(matchShortcut(stroke({ key: "k", ctrlKey: true }), spec, MAC)).toBe(false);
+  });
+
+  it("matches shift and alt exactly, in both directions", () => {
+    const shifted: ShortcutSpec = { mod: true, shift: true, key: "k" };
+    expect(matchShortcut(stroke({ key: "k", metaKey: true, shiftKey: true }), shifted, MAC)).toBe(
+      true
+    );
+    // ⌘K is not ⇧⌘K…
+    expect(matchShortcut(stroke({ key: "k", metaKey: true }), shifted, MAC)).toBe(false);
+    // …and ⇧⌘K is not ⌘K either.
+    expect(matchShortcut(stroke({ key: "k", metaKey: true, shiftKey: true }), cmdK, MAC)).toBe(
+      false
+    );
+    expect(matchShortcut(stroke({ key: "k", metaKey: true, altKey: true }), cmdK, MAC)).toBe(false);
+  });
+
+  it("compares the key case-insensitively and by name", () => {
+    expect(matchShortcut(stroke({ key: "K", metaKey: true }), cmdK, MAC)).toBe(true);
+    expect(matchShortcut(stroke({ key: "j", metaKey: true }), cmdK, MAC)).toBe(false);
+
+    const back: ShortcutSpec = { mod: true, key: "ArrowLeft" };
+    expect(matchShortcut(stroke({ key: "ArrowLeft", metaKey: true }), back, MAC)).toBe(true);
+    expect(matchShortcut(stroke({ key: "ArrowRight", metaKey: true }), back, MAC)).toBe(false);
+
+    const bracket: ShortcutSpec = { mod: true, key: "[" };
+    expect(matchShortcut(stroke({ key: "[", metaKey: true }), bracket, MAC)).toBe(true);
+    expect(matchShortcut(stroke({ key: "]", metaKey: true }), bracket, MAC)).toBe(false);
+  });
+});
+
+describe("isTypingTarget", () => {
+  it("claims the keyboard for text fields", () => {
+    expect(isTypingTarget({ tagName: "INPUT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "TEXTAREA" })).toBe(true);
+    expect(isTypingTarget({ tagName: "SELECT" })).toBe(true);
+    // Lowercase can't happen in HTML, but an SVG-ish or synthetic target can.
+    expect(isTypingTarget({ tagName: "input" })).toBe(true);
+  });
+
+  it("claims it for anything inside a contenteditable region", () => {
+    // isContentEditable is inherited, so a nested node answers true as well.
+    expect(isTypingTarget({ tagName: "B", isContentEditable: true })).toBe(true);
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: true })).toBe(true);
+  });
+
+  it("leaves ordinary elements — and no target at all — to the shortcuts", () => {
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: false })).toBe(false);
+    expect(isTypingTarget({ tagName: "BUTTON" })).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+    expect(isTypingTarget(undefined)).toBe(false);
+    expect(isTypingTarget(globalThis)).toBe(false);
+  });
+});
+
+describe("shortcutFires", () => {
+  const inField = { ...stroke({ key: "k", metaKey: true }), target: { tagName: "INPUT" } };
+  const onPage = { ...stroke({ key: "k", metaKey: true }), target: { tagName: "DIV" } };
+
+  it("swallows a matching chord while the caret is in a field", () => {
+    expect(shortcutFires(onPage, cmdK, {}, MAC)).toBe(true);
+    expect(shortcutFires(inField, cmdK, {}, MAC)).toBe(false);
+  });
+
+  it("honours the opt-out for shortcuts that own the field they fire in", () => {
+    // ⌘K is the palette's own toggle: it must still close a palette whose
+    // search input has focus.
+    expect(shortcutFires(inField, cmdK, { whileTyping: true }, MAC)).toBe(true);
+  });
+
+  it("still requires the chord to match, opt-out or not", () => {
+    const other = { ...stroke({ key: "j", metaKey: true }), target: { tagName: "INPUT" } };
+    expect(shortcutFires(other, cmdK, { whileTyping: true }, MAC)).toBe(false);
+  });
+
+  it("suppresses inside a contenteditable, where a bare key is text", () => {
+    const editing = {
+      ...stroke({ key: "ArrowLeft", metaKey: true }),
+      target: { tagName: "SPAN", isContentEditable: true },
+    };
+    // ⌘← is "jump to the start of the line" here, not "go back".
+    expect(shortcutFires(editing, { mod: true, key: "ArrowLeft" }, {}, MAC)).toBe(false);
+  });
+});

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from "react";
+import { isMac } from "./platform";
+
+/**
+ * Where a window-wide keyboard shortcut is declared — one matcher, one listener.
+ *
+ * Before this, every shortcut brought its own `addEventListener("keydown")` and
+ * its own idea of what "⌘" means, which is how you end up with a chord that
+ * fires while the user is typing a folder name into a text field. The matching
+ * rule and the typing guard live here so they can be stated once and tested.
+ *
+ * Two existing shortcuts deliberately stay where they are:
+ *   • ⌘+/⌘−/⌘0 (lib/zoom.ts) is installed from main.tsx BEFORE React mounts and
+ *     runs in every window, including the ones that never render an AppShell —
+ *     a React hook could not cover it.
+ *   • ⌘F (components/replay/ReplayTranscript.tsx) is scoped to one mounted
+ *     panel and has its own semantics (it focuses that panel's find field, and
+ *     must keep working while the field itself has focus).
+ */
+
+export interface ShortcutSpec {
+  /** ⌘ on macOS, Ctrl everywhere else. */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /** `KeyboardEvent.key`, compared case-insensitively: "k", "[", "ArrowLeft". */
+  key: string;
+}
+
+/**
+ * The parts of a KeyboardEvent a match depends on. Structural on purpose: a
+ * plain object satisfies it, so {@link matchShortcut} is testable without a DOM
+ * (the unit suite runs in plain Node — see vitest.config.ts).
+ */
+export interface KeyStroke {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}
+
+/**
+ * Does this keystroke BE the shortcut? Every modifier is exact: a spec that
+ * doesn't ask for shift is not matched by a stroke that holds it, so ⌘K and
+ * ⇧⌘K can mean two different things.
+ *
+ * `mac` is a parameter (defaulting to the real platform) so the split can be
+ * exercised both ways in a test without stubbing the OS.
+ */
+export function matchShortcut(e: KeyStroke, spec: ShortcutSpec, mac: boolean = isMac()): boolean {
+  const meta = !!e.metaKey;
+  const ctrl = !!e.ctrlKey;
+  // Exclusive, matching zoom.ts: on a Mac, Ctrl+⌘+K is a DIFFERENT chord from
+  // ⌘K and must fall through to whoever wants it, not fire this shortcut.
+  const mod = mac ? meta && !ctrl : ctrl && !meta;
+  if (spec.mod) {
+    if (!mod) return false;
+  } else if (meta || ctrl) {
+    // No `mod` asked for means none held — otherwise ⌘S would trigger a bare "s".
+    return false;
+  }
+  if (!!e.shiftKey !== !!spec.shift) return false;
+  if (!!e.altKey !== !!spec.alt) return false;
+  return e.key.toLowerCase() === spec.key.toLowerCase();
+}
+
+/** The parts of an event target the typing guard reads (see {@link KeyStroke}). */
+export interface FocusTarget {
+  tagName?: string;
+  isContentEditable?: boolean;
+}
+
+/**
+ * Is focus somewhere that owns the keyboard?
+ *
+ * This is the property the whole registry stands on. A global ⌘[ that fires
+ * while the caret sits in the rename field navigates the window out from under
+ * a half-typed name. `isContentEditable` is computed and inherited, so a node
+ * nested inside an editable region answers true as well.
+ */
+export function isTypingTarget(target: unknown): boolean {
+  if (!target || typeof target !== "object") return false;
+  const el = target as FocusTarget;
+  if (el.isContentEditable) return true;
+  const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+/**
+ * The whole decision the listener makes for one binding: the right chord, and
+ * not while the user is typing. Pure and exported so the guard can be proven in
+ * a test instead of only in a running window.
+ */
+export function shortcutFires(
+  e: KeyStroke & { target?: unknown },
+  spec: ShortcutSpec,
+  opts: Pick<ShortcutOptions, "whileTyping"> = {},
+  mac: boolean = isMac()
+): boolean {
+  if (!opts.whileTyping && isTypingTarget(e.target)) return false;
+  return matchShortcut(e, spec, mac);
+}
+
+export interface ShortcutOptions {
+  /** Unregister without unmounting — e.g. a route that suspends its bindings. */
+  enabled?: boolean;
+  /** Fire even when focus is in a field. Only for shortcuts that are ABOUT the
+   *  field, and never for anything that navigates or destroys. */
+  whileTyping?: boolean;
+  /** Defaults to true: a shortcut we claim must not also reach the webview. */
+  preventDefault?: boolean;
+}
+
+interface Binding {
+  spec: ShortcutSpec;
+  whileTyping: boolean;
+  preventDefault: boolean;
+  run: (e: KeyboardEvent) => void;
+}
+
+const bindings = new Set<Binding>();
+let listening = false;
+
+function onKeyDown(e: KeyboardEvent): void {
+  const mac = isMac();
+  // Copy: a handler is allowed to mount or unmount another shortcut's owner.
+  for (const b of [...bindings]) {
+    if (!bindings.has(b)) continue;
+    if (!shortcutFires(e, b.spec, b, mac)) continue;
+    if (b.preventDefault) e.preventDefault();
+    b.run(e);
+  }
+}
+
+/** Add a binding to the one shared listener. Returns its remover. */
+function register(binding: Binding): () => void {
+  bindings.add(binding);
+  if (!listening && typeof document !== "undefined") {
+    document.addEventListener("keydown", onKeyDown);
+    listening = true;
+  }
+  return () => {
+    bindings.delete(binding);
+    if (bindings.size === 0 && listening && typeof document !== "undefined") {
+      document.removeEventListener("keydown", onKeyDown);
+      listening = false;
+    }
+  };
+}
+
+/** Test seam: drop every binding so one case can't leak into the next. */
+export function resetShortcutsForTest(): void {
+  bindings.clear();
+  if (listening && typeof document !== "undefined") {
+    document.removeEventListener("keydown", onKeyDown);
+  }
+  listening = false;
+}
+
+/**
+ * Bind a shortcut for as long as the component is mounted.
+ *
+ * The handler is read through a ref, so a component that re-renders every
+ * keystroke doesn't re-register (and momentarily un-register) its shortcut.
+ */
+export function useShortcut(
+  spec: ShortcutSpec,
+  handler: (e: KeyboardEvent) => void,
+  opts: ShortcutOptions = {}
+): void {
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  const { enabled = true, whileTyping = false, preventDefault = true } = opts;
+  const { mod, shift, alt, key } = spec;
+  useEffect(() => {
+    if (!enabled) return;
+    // Rebuilt from primitives: an inline spec object is a new identity every
+    // render and would re-register forever.
+    return register({
+      spec: { mod, shift, alt, key },
+      whileTyping,
+      preventDefault,
+      run: (e) => handlerRef.current(e),
+    });
+  }, [enabled, mod, shift, alt, key, whileTyping, preventDefault]);
+}


### PR DESCRIPTION
Closes #338.

The app did not answer the two things a hand reaches for without thinking. A right-click anywhere in the tree or the library did nothing at all, and there was no way back to where you just were — every navigation overwrote the last one.

## What changed

**A right-click works.** `ui/context-menu.tsx` wraps Radix's `ContextMenu` using `dropdown-menu.tsx`'s styling class for class, so the app has one menu look rather than two. Radix's context menu ships in the `radix-ui` package already depended on, so this adds nothing to `package.json`.

- **Folder rows** offer Rename and Delete; the section headers and the empty space below the tree offer New folder.
- **Recording cards** offer Open, Rename, Move to folder (a submenu listing the same targets as the existing move popover, current folder disabled and check-marked) and Delete.

In both places the menu calls the paths that were already there — the same `useLibraryTree` operations behind the hover icons, the same `onRenameStart` / `onMove` / `onDelete` props on a card. It is a second way in, never a second implementation. Two rules that had been written twice, `cardCapabilities()` and `moveTargets()`, are now shared between the toolbar and the menu.

**Back and forward.** There is no router here; screens change by writing `appMode` in the store, so a navigation used to overwrite the previous position rather than stack on it. `nav/history.ts` keeps a capped stack of `Location` values — home, a library selection, or a recording — bound to ⌘[ / ⌘← and ⌘] / ⌘→ and to the mouse's side buttons.

`CommandPalette.activate()` was already a complete "go to this location" switch, so it was extracted as `navigateTo(location)` and both the palette and traversal now go through it. One implementation of "go there" is the point; two would drift.

**A shortcut registry.** `lib/shortcuts.ts` gives every window-wide shortcut one shared listener, one platform-correct `mod` modifier, and — the property the whole thing stands on — one implementation of "not while the user is typing". A global ⌘[ that fires while the caret sits in a rename field navigates the window out from under a half-typed name. ⌘K moved onto it.

Two shortcuts deliberately stayed where they are, and the code says why: zoom (`lib/zoom.ts`) is installed before React mounts and runs in windows that never render an `AppShell`; ⌘F (`ReplayTranscript`) is scoped to one panel and must keep working while its own find field has focus.

## Three things a reviewer should look at

**1. Deleting a recording still does not ask.** Tracing `remove()` in `LibraryScreen` through `deleteHistoryEntry` / `deleteCloudRecording` / `deleteOrgRecording` finds no confirmation anywhere; the only `globalThis.confirm()` calls in `src/` are the two folder deletes in `useLibraryTree`. The card's hover trash icon has always deleted on one click, and the menu matches it rather than growing a prompt only one of the two entry points has.

That consistency is correct and the behaviour is not. A context menu opens under the cursor with Delete a single click away, which makes an already-unguarded destructive action markedly easier to hit by accident. Adding a confirmation belongs on both entry points at once, in its own change — flagging it here because this PR is what makes it urgent.

**2. Keyboard invocation is reasoned, not executed.** macOS has no context-menu key and WebKit does not synthesise `contextmenu` from Shift+F10, so `openMenuFromKeyboard` dispatches a real bubbling `MouseEvent` — the only thing Radix listens for. The test suite runs in plain Node with no jsdom and no component-testing path, so this was verified by reading Radix's source rather than by running it. **It wants a manual check in the running app**, along with `onCloseAutoFocus={preventFocusRestore}`: without that line Radix restores focus off a freshly mounted rename input, the input's blur handler commits the untouched draft, and Rename silently does nothing.

**3. Not every navigation is in the stack yet.** Only `navigateTo` call sites are recorded, so sidebar clicks, `exitReplay` and the history-list open are still invisible to back/forward. `locationOf` in `CommandPalette.tsx` shows the mapping; routing the rest through `navigateTo` is the obvious follow-up.

Two constraints in the traversal are worth reading rather than trusting: a running meeting owns the window and the store *refuses* mode changes while one is active, so a refused navigation must not enter the stack, and a deleted recording must be dropped rather than throw. `refused` and `unavailable` are kept distinct for exactly that reason — collapsing them to a boolean would let one active meeting drain the whole stack.

## Not in this PR

The long tail the registry exists to make cheap: ⌘F promoted to app level, arrow-key movement through the tree, Enter to open, F2 to rename, ⌘N, Delete.

## Checks

`bunx tsc --noEmit` clean · `bunx vitest run` 33 files / 373 tests green, 21 of them new (`shortcuts.test.ts`, `nav/history.test.ts`) · `bun run build` succeeds.

The menus themselves are untested: there are no existing tests for `AppSidebar.tsx` or `LibraryCards.tsx` and no component-test harness to add them to. Standing up jsdom and a testing library is its own change.
